### PR TITLE
Added support for SoundCloud sets (and potentially other playlists supported by youtube_dl) and changed the auto_playlist a little

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -363,7 +363,7 @@ class MusicBot(discord.Client):
 
             reply_text = "Enqueued **%s** to be played. Position in queue: %s"
 
-            if 'playlist?list' in song_url:
+            if 'playlist?list' in song_url or '/sets/' in song_url:
                 t0 = time.time()
 
                 # My test was 1.2 seconds per song, but we maybe should fudge it a bit, unless we can

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -362,8 +362,9 @@ class MusicBot(discord.Client):
             await self.send_typing(channel)
 
             reply_text = "Enqueued **%s** to be played. Position in queue: %s"
+            info = await extract_info(player.playlist.loop, song_url, download=False, process=False)
 
-            if 'playlist?list' in song_url or '/sets/' in song_url:
+            if 'entries' in info:
                 t0 = time.time()
 
                 # My test was 1.2 seconds per song, but we maybe should fudge it a bit, unless we can
@@ -373,7 +374,6 @@ class MusicBot(discord.Client):
                 # Different playlists might download at different speeds though
                 wait_per_song = 1.2
 
-                info = await extract_info(player.playlist.loop, song_url, download=False, process=False)
                 num_songs = sum(1 for _ in info['entries'])
 
                 procmesg = await self.send_message(channel,

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -233,9 +233,6 @@ class MusicBot(discord.Client):
         if self.config.auto_summon:
             await self._auto_summon()
 
-            if self.config.auto_playlist:
-                await self.on_finished_playing(await self.get_player(self._get_owner_voice_channel()))
-
 
     async def _auto_summon(self):
         channel = self._get_owner_voice_channel()
@@ -450,6 +447,9 @@ class MusicBot(discord.Client):
         #     return Response('ok?')
 
         player = await self.get_player(channel, create=True)
+
+        if self.config.auto_playlist:
+            await self.on_finished_playing(await self.get_player(self._get_owner_voice_channel()))
 
         if player.is_stopped:
             player.play()


### PR DESCRIPTION
The auto_playlist used to generate exception if it wasn't auto-summoned from the beginning. What's more, if summoned later, it doesn't work. I moved it to summon so we create the await there and it works in the previous scenarios as well as in the auto-summon one.

I added the ability to process SoundCloud sets and potentially other supported playlists that used to crash the server because the server tried to process the whole list as 1 song and when it started you were not able to add more songs, you had to reboot the server.
