### PR TITLE
Added LastFM Scrobbling. ONLY works if LastFM can resolve entry.title

### DIFF
--- a/config/options.txt
+++ b/config/options.txt
@@ -36,3 +36,12 @@ AutoSummon = yes
 
 ; Play random songs when nothing is queued
 UseAutoPlaylist = yes
+
+; Scrooble songs to LastFM
+; Create a LastFM API account here: http://last.fm/api/account/create
+Scrobble = no
+; LastFM credentials
+LastFmUsername = name
+LastFmPassword = password
+LastFmApiKey = key
+LastFmApiSecret= secret

--- a/config/options.txt
+++ b/config/options.txt
@@ -38,9 +38,9 @@ AutoSummon = yes
 UseAutoPlaylist = yes
 
 ; Scrooble songs to LastFM
-; Create a LastFM API account here: http://last.fm/api/account/create
 Scrobble = no
 ; LastFM credentials
+; Create a LastFM API account here: http://last.fm/api/account/create
 LastFmUsername = name
 LastFmPassword = password
 LastFmApiKey = key

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -20,6 +20,11 @@ class Config(object):
         self.now_playing_mentions = config.getboolean('MusicBot', 'NowPlayingMentions', fallback=True)
         self.auto_summon = config.getboolean('MusicBot', 'AutoSummon', fallback=True)
         self.auto_playlist = config.getboolean('MusicBot', 'UseAutoPlaylist', fallback=True)
+        self.scrobble = config.getboolean('MusicBot', 'Scrobble', fallback=False)
+        self.lastFmUsername = config.get('MusicBot', 'LastFmUsername', fallback='')
+        self.lastFmPassword = config.get('MusicBot', 'LastFmPassword', fallback='')
+        self.lastFmApiKey = config.get('MusicBot', 'LastFmApiKey', fallback='')
+        self.lastFmApiSecret = config.get('MusicBot', 'LastFmApiSecret', fallback='')
 
         self.blacklist_file = config.get('Files', 'BlacklistFile', fallback='config/blacklist.txt')
         self.whitelist_file = config.get('Files', 'WhitelistFile', fallback='config/whitelist.txt')

--- a/musicbot/scrobble.py
+++ b/musicbot/scrobble.py
@@ -1,0 +1,78 @@
+import urllib
+import json
+import hashlib
+import time
+import sys
+
+sk = ''
+api_key = ''
+api_secret = ''
+
+class Scrobble(object):
+	def __init__(self, user, passwd, key, secret):
+		global sk
+		global api_key
+		global api_secret
+		api_key = key
+		api_secret = secret
+		api_sig = hashlib.md5(("api_key" + api_key + "methodauth.getMobileSessionpassword" + passwd + "username" + user + api_secret).encode('utf-8')).hexdigest()
+		params = {
+			'method': 'auth.getMobileSession',
+			'format': 'json',
+			'username': user,
+			'password': passwd,
+			'api_key': api_key,
+			'api_sig': api_sig
+		}
+		try:
+			sk = self.request(params)['session']['key']
+		except:
+			print('There was an error getting a session key with the LastFM credentials provided.')
+			sys.exit()
+			
+	def send(self, entry):
+		global sk
+		global api_key
+		global api_secret
+		params = {
+			'method': 'track.search',
+			'format': 'json',
+			'track': entry.title,
+			'api_key': api_key,
+			'limit': '1'
+		}
+		try:
+			t = self.request(params)['results']['trackmatches']['track']
+		except:
+			print("There was an error searching LastFM for '" + entry.title + "'")
+			return
+			
+		if len(t)==0:
+			print(entry.title + ' was not found on LastFM')
+			return
+		artist = t[0]['artist']
+		track = t[0]['name']
+		ts = str(time.time()).split(".")[0]
+		api_sig = hashlib.md5(("api_key" + api_key + "artist" + artist + "methodtrack.scrobblesk" + sk + "timestamp" + ts + "track" + track + api_secret).encode('utf-8')).hexdigest()
+		params = {
+			'method': 'track.scrobble',
+			'format': 'json',
+			'artist': artist,
+			'track': track,
+			'timestamp': ts,
+			'api_key': api_key,
+			'api_sig': api_sig,
+			'sk': sk
+		}
+		try:
+			self.request(params)
+		except:
+			print('There was an error scobbling the track ' + entry.title + "'")
+			return
+		
+	def request(self, params):
+		url = "https://ws.audioscrobbler.com/2.0/"
+		params = urllib.parse.urlencode(params).encode()
+		r = urllib.request.Request(url, data=params, headers={"Content-Type": "application/x-www-form-urlencoded"})
+		u = urllib.request.urlopen(r)
+		return json.loads(u.read().decode('utf-8'))


### PR DESCRIPTION
Using the entry.title string to query LastFM to get an artist and track to sent back to the scobbling API.
This avoids counting on a similar format since the track data might be <artist> - <track> or <track> ~ <artist>
If there is a more reliable way to get artist and track from say, the youtube_dl lib. That would be the way to go because LastFM doesn't resolve them reliably with a lot of special or non English letters. Though I've been surprised by some tracks that it has done correctly.

It sends a scrobble immediately on track play. Some other apps have scrobbling delayed for up to 10-30 seconds of continuous play for track skips. But I wasn't quite sure how to implement that. 
