### PR TITLE
Remove broken link from backuplist.

### DIFF
--- a/config/backuplist.txt
+++ b/config/backuplist.txt
@@ -1382,7 +1382,6 @@ https://www.youtube.com/watch?v=VgFM6r_7O3A
 https://www.youtube.com/watch?v=Dasz1JZ0emU
 https://www.youtube.com/watch?v=kWD5gdpt4Dw
 https://www.youtube.com/watch?v=wPSvDoqUl8Q
-https://www.youtube.com/watch?v=KSFAzSyrd5I
 https://www.youtube.com/watch?v=ruBtVEplFEY
 https://www.youtube.com/watch?v=RkEpkUhYT_g
 https://www.youtube.com/watch?v=x3m0GVimn8k


### PR DESCRIPTION
The following link doesn't work. It crashes the bot.
https://www.youtube.com/watch?v=KSFAzSyrd5I
