### PR TITLE
Change default behaviour to youtube-search.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -717,7 +717,13 @@ class MusicBot(discord.Client):
                     continue
 
                 if args:
-                    arg_value = args.pop(0)
+                    arg_value = None
+
+                    if len(args) > 1:
+                        arg_value = ' '.join(args)
+                    else:
+                        arg_value = args.pop(0)
+                        
                     handler_kwargs[key] = arg_value
                     params.pop(key)
 

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -12,7 +12,8 @@ ytdl_format_options = {
     'nocheckcertificate': True,
     'ignoreerrors': True,
     'quiet': True,
-    'no_warnings': True
+    'no_warnings': True,
+    'default_search': "auto"
 }
 
 thread_pool = ThreadPoolExecutor(max_workers=2)

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -43,6 +43,10 @@ class Playlist(EventEmitter):
         if not info:
             raise ExtractionError('Could not extract information from %s' % song_url)
 
+        if info['extractor'] == 'youtube:search':
+            info = info['entries'][0]
+            song_url = info['webpage_url']
+
         entry = PlaylistEntry(
             self,
             song_url,


### PR DESCRIPTION
This change is so if arguments are passed to !play without a url, it will default to searching and playing the first video on YouTube that gets returned from those terms. Currently, if no url is passed to !play nothing is played.

Also, using `ytsearch:<songname>` doesn't work properly as the arguments get split off via spaces, i.e. `ytsearch:Lego House` just searches **Lego** instead of **Lego House** even if surrounded by quotes or apostrophes. The change to bot.py to combine multiple arguments solves this, but I'm not sure if it would cause other issues.
