### PR TITLE
Added comment line checking in utils.load_file()

### DIFF
--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -9,7 +9,8 @@ def load_file(filename):
             for line in f:
                 line = line.strip()
                 if line:
-                    results.append(line)
+                    if not line.startswith('#'):
+                        results.append(line)
 
             return results
 


### PR DESCRIPTION
This is especially handy for the `autoplaylist.txt` file, as server owners can add comments into their files and not worry about breaking the bot.

Using a nested `if not` statement to make sure that we don't run `line.startswith('#')` on an empty line. Not sure if this would be an issue or not, but it's safer? :joy:
