### PR TITLE
Added ExclusiveTextChannel feature

### DIFF
--- a/config/options.txt
+++ b/config/options.txt
@@ -11,6 +11,12 @@ OwnerID = 000000000000000000
 ; Change this if you don't want commands to trigger another bot
 CommandPrefix = !
 
+; This tells the bot to read this text channel only
+; If not set, it will read commands from all channel the bot has access
+; example:
+; ExclusiveTextChannel = music
+ExclusiveTextChannel =
+
 [MusicBot]
 ; This option is not implemented yet
 DaysActive = 0

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -258,7 +258,6 @@ class MusicBot(discord.Client):
     def _fixg(self, x, dp=2):
         return ('{:.%sf}' % dp).format(x).rstrip('0').rstrip('.')
 
-
     async def handle_help(self):
         """
         Usage: {command_prefix}help
@@ -673,9 +672,8 @@ class MusicBot(discord.Client):
         """
         pass
 
-
-
     async def on_message(self, message):
+
         if message.author == self.user:
             if message.content.startswith(self.config.command_prefix):
                 print("Ignoring command from myself (%s)" % message.content)
@@ -688,6 +686,12 @@ class MusicBot(discord.Client):
         message_content = message.content.strip()
         if not message_content.startswith(self.config.command_prefix):
             return
+
+        if self.config.exclusive_text_channel:
+            if not message.channel.name == self.config.exclusive_text_channel:
+                print("Ignoring command from channel #{0}, because I am using exclusive channel #{1}"
+                        .format(message.channel.name, self.config.exclusive_text_channel))
+                return
 
         command, *args = message_content.split()
         command = command[len(self.config.command_prefix):].lower().strip()

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -10,7 +10,9 @@ class Config(object):
         self.password = config.get('Credentials', 'Password', fallback=None)
 
         self.owner_id = config.get('Permissions', 'OwnerID', fallback=None)
+
         self.command_prefix = config.get('Chat', 'CommandPrefix', fallback='!')
+        self.exclusive_text_channel = config.get('Chat', 'ExclusiveTextChannel', fallback=None)
 
         self.days_active = config.getint('MusicBot', 'DaysActive', fallback=0)
         self.white_list_check = config.getboolean('MusicBot', 'WhiteListCheck', fallback=False)


### PR DESCRIPTION
This add a new feature, if user sets the config variable: ExclusiveTextChannel, the bot will only read commands from that channel, useful for server that have a #music channel to request music to the bot
