### PR TITLE
Added file for Mac Users for update_deps

### DIFF
--- a/update_macdeps.command
+++ b/update_macdeps.command
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd "$(dirname "$BASH_SOURCE")" || {
+	echo "Python 3.5 doesn't seem to be installed" >&2
+exit 1
+}
+
+python3.5 -m pip install --upgrade -r requirements.txt


### PR DESCRIPTION
This will allow mac users to just run the file to update their dependencies rather than doing the extra shenanigans of cd'ing to the file and running the `python3.5 -m pip` etc.
