### PR TITLE
Disconnect, Shutdown, and Restart Message Replies.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1793,9 +1793,7 @@ class MusicBot(discord.Client):
     async def cmd_restart(self, message):
         await self.safe_send_message(
             message.channel,
-            'Restarting...',
-            expire_in=30,
-            also_delete=message if self.config.delete_invoking else None
+            'Restarting...'
             )
         await self.disconnect_all_voice_clients()
         raise exceptions.RestartSignal
@@ -1803,9 +1801,7 @@ class MusicBot(discord.Client):
     async def cmd_shutdown(self, message):
         await self.safe_send_message(
             message.channel,
-            'Shutting Down...',
-            expire_in=30,
-            also_delete=message if self.config.delete_invoking else None
+            'Shutting Down...'
             )
         await self.disconnect_all_voice_clients()
         raise exceptions.TerminateSignal

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1781,14 +1781,32 @@ class MusicBot(discord.Client):
 
 
     async def cmd_disconnect(self, server, message):
+        await self.safe_send_message(
+            message.channel,
+            'Disconnecting from %s...' % server,
+            expire_in=30,
+            also_delete=message if self.config.delete_invoking else None
+            )
         await self.disconnect_voice_client(server)
         await self._manual_delete_check(message)
 
     async def cmd_restart(self):
+        await self.safe_send_message(
+            message.channel,
+            'Restarting...',
+            expire_in=30,
+            also_delete=message if self.config.delete_invoking else None
+            )
         await self.disconnect_all_voice_clients()
         raise exceptions.RestartSignal
 
     async def cmd_shutdown(self):
+        await self.safe_send_message(
+            message.channel,
+            'Shutting Down...',
+            expire_in=30,
+            also_delete=message if self.config.delete_invoking else None
+            )
         await self.disconnect_all_voice_clients()
         raise exceptions.TerminateSignal
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1784,7 +1784,7 @@ class MusicBot(discord.Client):
         await self.safe_send_message(
             message.channel,
             'Disconnecting from %s...' % message.server.me.voice_channel,
-            expire_in=30,
+            expire_in=30 if self.config.delete_messages else None,
             also_delete=message if self.config.delete_invoking else None
             )
         await self.disconnect_voice_client(server)

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1274,7 +1274,7 @@ class MusicBot(discord.Client):
                 delete_after=30
             )
 
-    async def cmd_summon(self, channel, author, voice_channel, message):
+    async def cmd_summon(self, channel, author, voice_channel):
         """
         Usage:
             {command_prefix}summon
@@ -1288,7 +1288,7 @@ class MusicBot(discord.Client):
         voice_client = self.the_voice_clients.get(channel.server.id, None)
         if voice_client and voice_client.channel.server == author.voice_channel.server:
             await self.move_voice_client(author.voice_channel)
-            return Response('Joined $s' % voice_channel,delete_after=30)
+            return
 
         # move to _verify_vc_perms?
         chperms = author.voice_channel.permissions_for(author.voice_channel.server.me)

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1780,17 +1780,17 @@ class MusicBot(discord.Client):
         return Response(":ok_hand:", delete_after=20)
 
 
-    async def cmd_disconnect(self, server, message):
+    async def cmd_disconnect(self, server, message, channel):
         await self.safe_send_message(
             message.channel,
-            'Disconnecting from %s...' % server,
+            'Disconnecting from %s...' % message.server.me.voice_channel,
             expire_in=30,
             also_delete=message if self.config.delete_invoking else None
             )
         await self.disconnect_voice_client(server)
         await self._manual_delete_check(message)
 
-    async def cmd_restart(self):
+    async def cmd_restart(self, message):
         await self.safe_send_message(
             message.channel,
             'Restarting...',
@@ -1800,7 +1800,7 @@ class MusicBot(discord.Client):
         await self.disconnect_all_voice_clients()
         raise exceptions.RestartSignal
 
-    async def cmd_shutdown(self):
+    async def cmd_shutdown(self, message):
         await self.safe_send_message(
             message.channel,
             'Shutting Down...',

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1274,7 +1274,7 @@ class MusicBot(discord.Client):
                 delete_after=30
             )
 
-    async def cmd_summon(self, channel, author, voice_channel):
+    async def cmd_summon(self, channel, author, voice_channel, message):
         """
         Usage:
             {command_prefix}summon
@@ -1288,7 +1288,7 @@ class MusicBot(discord.Client):
         voice_client = self.the_voice_clients.get(channel.server.id, None)
         if voice_client and voice_client.channel.server == author.voice_channel.server:
             await self.move_voice_client(author.voice_channel)
-            return
+            return Response('Joined $s' % voice_channel,delete_after=30)
 
         # move to _verify_vc_perms?
         chperms = author.voice_channel.permissions_for(author.voice_channel.server.me)


### PR DESCRIPTION
Bot posts back to the server when the {}Disconnect, {}Shutdown, or {}Restart message is fired successfully.  This shows the operator that the bot did in fact recognize the command, something that isn't always apparent when not looking at console, especially if the bot needs to restart.
