### PR TITLE
Move docker image to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,17 @@
-FROM ubuntu:14.04
+FROM alpine:3.4
 
-MAINTAINER Sidesplitter, https://github.com/SexualRhinoceros/MusicBot
+# Install Dependencies
+RUN apk update \
+ && apk add python3-dev ca-certificates gcc make linux-headers musl-dev ffmpeg libffi-dev 
 
-#Install dependencies
-RUN sudo apt-get update \
-    && sudo apt-get install software-properties-common -y \
-    && sudo add-apt-repository ppa:fkrull/deadsnakes -y \
-    && sudo add-apt-repository ppa:mc3man/trusty-media -y \
-    && sudo apt-get update -y \
-    && sudo apt-get install build-essential unzip -y \
-    && sudo apt-get install python3.5 python3.5-dev -y \
-    && sudo apt-get install ffmpeg -y \
-    && sudo apt-get install libopus-dev -y \
-    && sudo apt-get install libffi-dev -y
+# Add project source
+ADD . /usr/src/MusicBot
+WORKDIR /usr/src/MusicBot
 
-#Install Pip
-RUN sudo apt-get install wget \
-    && wget https://bootstrap.pypa.io/get-pip.py \
-    && sudo python3.5 get-pip.py
+# Create volume for mapping the config
+VOLUME /usr/src/MusicBot/config
 
-#Add musicBot
-ADD . /musicBot
-WORKDIR /musicBot
+# Install pip dependencies
+RUN  pip3 install -r requirements.txt
 
-#Install PIP dependencies
-RUN sudo pip install -r requirements.txt
-
-#Add volume for configuration
-VOLUME /musicBot/config
-
-CMD python3.5 run.py
+CMD python3.5 run.py 


### PR DESCRIPTION
Now that docker users must build the image themselves (see #399), it is a good time to look into optimizing the image.  Building off of Alpine Linux instead of Ubuntu yielded significant improvements in both build time, and image size

Build time:
Alpine - 2:30
Ubuntu - 7:30

Image Size:
Alpine - 280 MB
Ubuntu - 735.7 MB

This change would see no change in the build process on the users side, other than a different mount point for the config.  
If you would like to test this build, follow the same process as describe in the wiki, except use config:/usr/src/MusicBot/config as the argument to the -v option when running the image.
