### PR TITLE
Regularly check for bot updates

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -29,6 +29,7 @@ Token = bot_token
 ; I don't want any more "how do I get the OwnerID" questions.
 OwnerID = 000000000000000000
 
+
 [Updates]
 ; Whether the bot should check for updates automatically. If yes, the bot will 
 ; send a message to the Owner when an update is available. If no, updates will
@@ -41,7 +42,6 @@ UpdateInterval = 12
 ; How often (in hours) the bot should wait between notifications to the Owner
 UpdateNotificationInterval = 48
 
-; How often (in hours) the bot should wait before 
 
 [Chat]
 ; Change this if you don't want commands to trigger another bot
@@ -66,6 +66,7 @@ CommandPrefix = !
 ;
 ;AutojoinChannels =
 ;
+
 
 [MusicBot]
 ; The starting volume of the bot.  You can use any value from 0.01 to 1.0 but 0.15 is probably fine

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -29,6 +29,20 @@ Token = bot_token
 ; I don't want any more "how do I get the OwnerID" questions.
 OwnerID = 000000000000000000
 
+[Updates]
+; Whether the bot should check for updates automatically. If yes, the bot will 
+; send a message to the Owner when an update is available. If no, updates will
+; only be checked when using the !info command
+CheckForUpdates = no
+
+; How often (in hours) the bot should check for updates
+UpdateInterval = 12
+
+; How often (in hours) the bot should wait between notifications to the Owner
+UpdateNotificationInterval = 48
+
+; How often (in hours) the bot should wait before 
+
 [Chat]
 ; Change this if you don't want commands to trigger another bot
 ; Example:

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -32,7 +32,7 @@ OwnerID = 000000000000000000
 [Updates]
 ; Whether the bot should check for updates automatically. If yes, the bot will 
 ; send a message to the Owner when an update is available. If no, updates will
-; only be checked when using the !info command
+; only be checked when using the !version command
 CheckForUpdates = no
 
 ; How often (in hours) the bot should check for updates

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -105,6 +105,8 @@ class MusicBot(discord.Client):
         self.aiosession = aiohttp.ClientSession(loop=self.loop)
         self.http.user_agent += ' MusicBot/%s' % BOTVERSION
 
+        self.update_check_running = False
+
     def __del__(self):
         try:
             if not self.http.session.closed:
@@ -817,7 +819,8 @@ class MusicBot(discord.Client):
 
         print()
 
-        if self.config.check_updates:
+        if self.config.check_updates and not self.update_check_running:
+            self.update_check_running = True
             asyncio.ensure_future(self.check_and_notify_update())
 
         # t-t-th-th-that's all folks!
@@ -1984,6 +1987,7 @@ class MusicBot(discord.Client):
 
     async def notify_update(self):
         while True:
+            await self.wait_until_ready()
             await self.safe_send_message(self._get_owner(), "There is a MusicBot update available! https://github.com/SexualRhinoceros/MusicBot")
             await asyncio.sleep(60 * 60 * self.config.update_notification_interval)
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -139,7 +139,7 @@ class MusicBot(discord.Client):
 
         return wrapper
 
-    async def _update_available():
+    async def _update_available(self):
         try:
             with urllib.request.urlopen(UPDATE_FILE) as f:
                 m = re.search("(VERSION = )('|\")((\d|.|_)+)('|\")", f.read())

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -174,8 +174,6 @@ class MusicBot(discord.Client):
 
         return True
 
-
-
     # TODO: autosummon option to a specific channel
     async def _auto_summon(self):
         owner = self._get_owner(voice=True)

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -37,9 +37,9 @@ class Config:
         self.bound_channels = config.get('Chat', 'BindToChannels', fallback=ConfigDefaults.bound_channels)
         self.autojoin_channels =  config.get('Chat', 'AutojoinChannels', fallback=ConfigDefaults.autojoin_channels)
 
-        self.check_updates = config.get('Updates', 'CheckForUpdates', fallback=ConfigDefaults.check_updates)
-        self.update_interval = config.get('Updates', 'UpdateInterval', fallback=ConfigDefaults.update_interval)
-        self.update_notification_interval = config.get('Updates', 'UpdateNotificationInterval', fallback=ConfigDefaults.update_notification_interval)
+        self.check_updates = config.getboolean('Updates', 'CheckForUpdates', fallback=ConfigDefaults.check_updates)
+        self.update_interval = config.getfloat('Updates', 'UpdateInterval', fallback=ConfigDefaults.update_interval)
+        self.update_notification_interval = config.getfloat('Updates', 'UpdateNotificationInterval', fallback=ConfigDefaults.update_notification_interval)
 
         self.default_volume = config.getfloat('MusicBot', 'DefaultVolume', fallback=ConfigDefaults.default_volume)
         self.skips_required = config.getint('MusicBot', 'SkipsRequired', fallback=ConfigDefaults.skips_required)

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -15,7 +15,7 @@ class Config:
         config = configparser.ConfigParser(interpolation=None)
         config.read(config_file, encoding='utf-8')
 
-        confsections = {"Credentials", "Permissions", "Chat", "MusicBot"}.difference(config.sections())
+        confsections = {"Credentials", "Permissions", "Updates", "Chat", "MusicBot"}.difference(config.sections())
         if confsections:
             raise HelpfulError(
                 "One or more required config sections are missing.",
@@ -36,6 +36,10 @@ class Config:
         self.command_prefix = config.get('Chat', 'CommandPrefix', fallback=ConfigDefaults.command_prefix)
         self.bound_channels = config.get('Chat', 'BindToChannels', fallback=ConfigDefaults.bound_channels)
         self.autojoin_channels =  config.get('Chat', 'AutojoinChannels', fallback=ConfigDefaults.autojoin_channels)
+
+        self.check_updates = config.get('Updates', 'CheckForUpdates', fallback=ConfigDefaults.check_updates)
+        self.update_interval = config.get('Updates', 'UpdateInterval', fallback=ConfigDefaults.update_interval)
+        self.update_notification_interval = config.get('Updates', 'UpdateNotificationInterval', fallback=ConfigDefaults.update_notification_interval)
 
         self.default_volume = config.getfloat('MusicBot', 'DefaultVolume', fallback=ConfigDefaults.default_volume)
         self.skips_required = config.getint('MusicBot', 'SkipsRequired', fallback=ConfigDefaults.skips_required)
@@ -191,6 +195,10 @@ class ConfigDefaults:
     command_prefix = '!'
     bound_channels = set()
     autojoin_channels = set()
+
+    check_updates = False
+    update_interval = 12
+    update_notification_interval = 48
 
     default_volume = 0.15
     skips_required = 4

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -1,8 +1,6 @@
 import os.path
 
-MAIN_VERSION = '1.9.5_2'
-SUB_VERSION = ''
-VERSION = MAIN_VERSION + SUB_VERSION
+VERSION = '1.9.5_2'
 
 AUDIO_CACHE_PATH = os.path.join(os.getcwd(), 'audio_cache')
 DISCORD_MSG_CHAR_LIMIT = 2000

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -4,3 +4,4 @@ VERSION = '1.9.5_2'
 
 AUDIO_CACHE_PATH = os.path.join(os.getcwd(), 'audio_cache')
 DISCORD_MSG_CHAR_LIMIT = 2000
+UPDATE_FILE = "https://raw.githubusercontent.com/SexualRhinoceros/MusicBot/master/musicbot/constants.py"

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -101,3 +101,54 @@ def safe_print(content, *, end='\n', flush=True):
 
 def avg(i):
     return sum(i) / len(i)
+
+def version_is_newer(current, version):
+    """
+    Returns True if the given string in the format 'x.x.x[_x]' is newer
+    than the current version
+    """
+    if '_' in version:
+        main_ver, hotfix_ver = version.split('_', 1)
+    else:
+        main_ver = version
+        hotfix_ver = None
+
+    if '_' in current:
+        main_cur, hotfix_cur = current.split('_', 1)
+    else:
+        main_cur = current
+        hotfix_cur = None
+
+    major_ver, minor_ver, subminor_ver = main_ver.split('.', 2)
+    major_cur, minor_cur, subminor_cur = main_cur.split('.', 2)
+
+    if int(major_ver) > int(major_cur):
+        return True
+    elif int(minor_ver) > int(minor_cur):
+        return True
+    elif int(subminor_ver) > int(subminor_cur):
+        return True
+    
+    # At this point, all three parts of ver is <= cur. We only compare hotfixes
+    # if they are all equal
+    if int(major_ver) == int(major_cur) and int(minor_ver) == int(minor_cur) and \
+                    int(subminor_ver) == int(subminor_cur):
+        if hotfix_ver and not hotfix_cur:
+            return True
+        elif not hotfix_ver and not hotfix_cur:
+            return False
+        else: 
+            # Both have a hotfix number (it is not possible for there to be a 
+            # hotfix number for the current version but not the one fetched from
+            # online
+            return int(hotfix_ver) > int(hotfix_cur)
+    else:
+        return False
+
+
+    if hotfix_ver and not hotfix_cur:
+        return True
+    elif int(hotfix_ver) > int(hotfix_cur):
+        return True
+
+    return False


### PR DESCRIPTION
# What does this PR change?
- Changes the two version strings in constants.py to a single variable
- Adds a "version" command to check for updates
- Adds a few more options and a new section to options.ini
- Adds feature to send a private message to the bot owner when updates are available
# What does this PR reference?

Resolves part of #1
# Additional notes

In order to prevent the bot from spamming the owner, they have the option to disable private messages entirely (in which case you'd only be able to check for updates by using the "version" command, and when the bot does send a notification to the bot owner about an update, it will prevent sending additional reminders until a certain time has passed.
