### PR TITLE
Write current song to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ audio_cache/
 dectalk/
 
 discord.log
+now-playing.txt
 logs/
 config/options.ini
 config/permissions.ini

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -642,11 +642,15 @@ class MusicBot(discord.Client):
                 player = discord.utils.get(self.players.values(), is_playing=True)
                 entry = player.current_entry
 
+        name = ''
+
         if entry:
             prefix = u'\u275A\u275A ' if is_paused else ''
 
-            name = u'{}{}'.format(prefix, entry.title)[:128]
-            game = discord.Game(name=name)
+            name = u'{}{}'.format(prefix, entry.title)
+            game = discord.Game(name=name[:128])
+
+        write_file('now-playing.txt', name)
 
         await self.change_status(game)
 

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -28,9 +28,12 @@ def load_file(filename, skip_commented_lines=True, comment_char='#'):
 
 def write_file(filename, contents):
     with open(filename, 'w', encoding='utf8') as f:
-        for item in contents:
-            f.write(str(item))
-            f.write('\n')
+        if type(contents) == list:
+            for item in contents:
+                f.write(str(item))
+                f.write('\n')
+        else:
+            f.write(contents)
 
 
 def sane_round_int(x):


### PR DESCRIPTION
The MusicBot will write the current playing song into `now-playing.txt`. Useful for streamers that use the bot for song requests.

Considered making a config option for it, didn't seem like it was worth having a toggle though. If you don't want to use it, you don't need to touch the file. Quality of life kinda thing.

Closes #76 
