### PR TITLE
Maxvolume permissions

### DIFF
--- a/config/example_permissions.ini
+++ b/config/example_permissions.ini
@@ -75,6 +75,7 @@ MaxSongs = 0
 AllowPlaylists = yes
 ; MaxPlaylistLength = 20
 InstaSkip = no
+;MaxVolume = 0
 
 ; This group has full permissions.
 [MusicMaster]
@@ -85,6 +86,7 @@ MaxSongs = 0
 MaxPlaylistLength = 0
 AllowPlaylists = yes
 InstaSkip = yes
+MaxVolume = 100
 
 ; This group can't use the blacklist and listids commands, but otherwise has full permissions.
 [DJ]
@@ -96,6 +98,7 @@ MaxSongs = 0
 MaxPlaylistLength = 0
 AllowPlaylists = yes
 InstaSkip = yes
+MaxVolume = 50
 
 ; This group can only use the listed commands, can only use play/skip when in the bot's voice channel,
 ; can't request songs longer than 3 and a half minutes, and can only request a maximum of 8 songs at a time.
@@ -108,3 +111,4 @@ MaxSongLength = 210
 MaxSongs = 8
 AllowPlaylists = yes
 InstaSkip = no
+MaxVolume = 25

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1907,7 +1907,7 @@ class MusicBot(discord.Client):
                 delete_after=20
             )
 
-    async def cmd_volume(self, message, player, new_volume=None):
+    async def cmd_volume(self, message, player, permissions, new_volume=None):
         """
         Usage:
             {command_prefix}volume (+/-)[volume]
@@ -1928,6 +1928,11 @@ class MusicBot(discord.Client):
 
         except ValueError:
             raise exceptions.CommandError('{} is not a valid number'.format(new_volume), expire_in=20)
+
+        if permissions.max_volume and new_volume > permissions.max_volume:
+            raise exceptions.PermissionsError(
+                "You are not able to set the volume above (%s)" % permissions.max_volume
+                )
 
         vol_change = None
         if relative:

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -20,6 +20,7 @@ class PermissionsDefaults:
     MaxSongs = 0
     MaxSongLength = 0
     MaxPlaylistLength = 0
+    MaxVolume = 0
 
     AllowPlaylists = True
     InstaSkip = False
@@ -108,6 +109,7 @@ class PermissionGroup:
         self.max_songs = section_data.get('MaxSongs', fallback=PermissionsDefaults.MaxSongs)
         self.max_song_length = section_data.get('MaxSongLength', fallback=PermissionsDefaults.MaxSongLength)
         self.max_playlist_length = section_data.get('MaxPlaylistLength', fallback=PermissionsDefaults.MaxPlaylistLength)
+        self.max_volume = section_data.get ('MaxVolume', fallback=PermissionsDefaults.MaxVolume)
 
         self.allow_playlists = section_data.get('AllowPlaylists', fallback=PermissionsDefaults.AllowPlaylists)
         self.instaskip = section_data.get('InstaSkip', fallback=PermissionsDefaults.InstaSkip)
@@ -144,6 +146,11 @@ class PermissionGroup:
             self.max_playlist_length = max(0, int(self.max_playlist_length))
         except:
             self.max_playlist_length = PermissionsDefaults.MaxPlaylistLength
+
+        try:
+            self.max_volume = max(0, int(self.max_volume))
+        except:
+            self.max_volume = PermissionsDefaults.MaxVolume
 
         self.allow_playlists = configparser.RawConfigParser.BOOLEAN_STATES.get(
             self.allow_playlists, PermissionsDefaults.AllowPlaylists


### PR DESCRIPTION
Redone the simple addition from scratch starting with the review branch (rather the the old one being from the master branch)

Added - MaxVolume in permissions (Limit how loud people can set the bots
volume, the number set in the permissions.ini is the limit)