### PR TITLE
Added maximum volume parameter that lets users set up to 1000% volume.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -154,3 +154,9 @@ PersistentQueue = yes
 ; verbose than DEBUG, and should probably only be used for debugging:
 ; 	VOICEDEBUG, FFMPEG, NOISY, EVERYTHING
 DebugLevel = INFO
+
+; The maximum volume percentage of the bot that someone can set.
+; This option only applies to users with the "AllowHigherVolume = yes" permission, otherwise the max volume is 100%.
+; This is for experimental purposes, leave this alone if you don't want any distortion.
+; Range: 1 - 1000, whole numbers only.
+MaxVolume = 100

--- a/config/example_permissions.ini
+++ b/config/example_permissions.ini
@@ -51,6 +51,10 @@
 ;    InstaSkip = no
 ;    Allows the user to skip a song without having to vote, like the owner.
 ;
+;    AllowHigherVolume = no
+;    Allows the user to go past 100% volume up to the MaxVolume set in options.
+;    Enabling this will allow users to distort the volume if the MaxVolume is set higher than 100.
+;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 
@@ -75,6 +79,7 @@ MaxSongs = 0
 AllowPlaylists = yes
 ; MaxPlaylistLength = 20
 InstaSkip = no
+AllowHigherVolume = no
 
 ; This group has full permissions.
 [MusicMaster]
@@ -85,6 +90,7 @@ MaxSongs = 0
 MaxPlaylistLength = 0
 AllowPlaylists = yes
 InstaSkip = yes
+AllowHigherVolume = yes
 
 ; This group can't use the blacklist and listids commands, but otherwise has full permissions.
 [DJ]

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1098,6 +1098,7 @@ class MusicBot(discord.Client):
 
         log.info("  Command prefix: " + self.config.command_prefix)
         log.info("  Default volume: {}%".format(int(self.config.default_volume * 100)))
+        log.info("  Maximum volume: {}%".format(self.config.max_volume))
         log.info("  Skip threshold: {} votes or {}%".format(
             self.config.skips_required, fixg(self.config.skip_ratio_required * 100)))
         log.info("  Now Playing @mentions: " + ['Disabled', 'Enabled'][self.config.now_playing_mentions])
@@ -1907,14 +1908,20 @@ class MusicBot(discord.Client):
                 delete_after=20
             )
 
-    async def cmd_volume(self, message, player, new_volume=None):
+    async def cmd_volume(self, author, message, player, permissions, new_volume=None):
         """
         Usage:
             {command_prefix}volume (+/-)[volume]
 
-        Sets the playback volume. Accepted values are from 1 to 100.
+        Sets the playback volume. Accepted values are from 1 to 100, or 1 to {max_volume} if you have the 'allow_higher_volume: True' permission.
         Putting + or - before the volume will make the volume change relative to the current volume.
         """
+
+        # Permissions for volume over 100
+        if author.id == self.config.owner_id or permissions.allow_higher_volume:
+            max_volume = self.config.max_volume
+        else:
+            max_volume = 100
 
         if not new_volume:
             return Response('Current volume: `%s%%`' % int(player.volume * 100), reply=True, delete_after=20)
@@ -1936,7 +1943,7 @@ class MusicBot(discord.Client):
 
         old_volume = int(player.volume * 100)
 
-        if 0 < new_volume <= 100:
+        if 0 < new_volume <= max_volume:
             player.volume = new_volume / 100.0
 
             return Response('updated volume from %d to %d' % (old_volume, new_volume), reply=True, delete_after=20)
@@ -1945,10 +1952,10 @@ class MusicBot(discord.Client):
             if relative:
                 raise exceptions.CommandError(
                     'Unreasonable volume change provided: {}{:+} -> {}%.  Provide a change between {} and {:+}.'.format(
-                        old_volume, vol_change, old_volume + vol_change, 1 - old_volume, 100 - old_volume), expire_in=20)
+                        old_volume, vol_change, old_volume + vol_change, 1 - old_volume, max_volume - old_volume), expire_in=20)
             else:
                 raise exceptions.CommandError(
-                    'Unreasonable volume provided: {}%. Provide a value between 1 and 100.'.format(new_volume), expire_in=20)
+                    'Unreasonable volume provided: {}%. Provide a value between 1 and {}.'.format(new_volume, max_volume), expire_in=20)
 
     async def cmd_queue(self, channel, player):
         """

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -61,6 +61,7 @@ class Config:
         self.debug_level = config.get('MusicBot', 'DebugLevel', fallback=ConfigDefaults.debug_level)
         self.debug_level_str = self.debug_level
         self.debug_mode = False
+        self.max_volume = config.getint('MusicBot', 'MaxVolume', fallback=ConfigDefaults.max_volume)
 
         self.blacklist_file = config.get('Files', 'BlacklistFile', fallback=ConfigDefaults.blacklist_file)
         self.auto_playlist_file = config.get('Files', 'AutoPlaylistFile', fallback=ConfigDefaults.auto_playlist_file)
@@ -147,6 +148,13 @@ class Config:
             except:
                 log.warning("AutojoinChannels data is invalid, will not autojoin any channels")
                 self.autojoin_channels = set()
+
+        if self.max_volume < 1 or self.max_volume > 1000:
+            if self.max_volume < 1:
+                print("[Warning] Max Volume is {}%, which is less than 1%, defaulting to 100%.".format(self.max_volume))
+            elif self.max_volume > 1000:
+                print("[Warning] Max Volume is {}%, which is greater than 1000%, defaulting to 100%.".format(self.max_volume))
+            self.max_volume = 100
 
         self.delete_invoking = self.delete_invoking and self.delete_messages
 
@@ -280,6 +288,7 @@ class ConfigDefaults:
     delete_invoking = False
     persistent_queue = True
     debug_level = 'INFO'
+    max_volume = 100
 
     options_file = 'config/options.ini'
     blacklist_file = 'config/blacklist.txt'

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -24,6 +24,8 @@ class PermissionsDefaults:
     AllowPlaylists = True
     InstaSkip = False
 
+    AllowHigherVolume = False
+
 
 class Permissions:
     def __init__(self, config_file, grant_all=None):
@@ -112,6 +114,8 @@ class PermissionGroup:
         self.allow_playlists = section_data.get('AllowPlaylists', fallback=PermissionsDefaults.AllowPlaylists)
         self.instaskip = section_data.get('InstaSkip', fallback=PermissionsDefaults.InstaSkip)
 
+        self.allow_higher_volume = section_data.get('AllowHigherVolume', fallback=PermissionsDefaults.AllowHigherVolume)
+
         self.validate()
 
     def validate(self):
@@ -151,6 +155,10 @@ class PermissionGroup:
 
         self.instaskip = configparser.RawConfigParser.BOOLEAN_STATES.get(
             self.instaskip, PermissionsDefaults.InstaSkip
+        )
+
+        self.allow_higher_volume = configparser.RawConfigParser.BOOLEAN_STATES.get(
+            self.allow_higher_volume, PermissionsDefaults.AllowHigherVolume
         )
 
     @staticmethod

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -48,7 +48,7 @@ class PatchedBuff:
         frame = self.buff.read(frame_size)
 
         if self.volume != 1:
-            frame = self._frame_vol(frame, self.volume, maxv=2)
+            frame = self._frame_vol(frame, self.volume, maxv=10)
 
         if self.draw and not self.frame_count % self.frame_skip:
             # these should be processed for every frame, but "overhead"
@@ -61,7 +61,7 @@ class PatchedBuff:
 
         return frame
 
-    def _frame_vol(self, frame, mult, *, maxv=2, use_audioop=True):
+    def _frame_vol(self, frame, mult, *, maxv=10, use_audioop=True):
         if use_audioop:
             return audioop.mul(frame, 2, min(mult, maxv))
         else:


### PR DESCRIPTION
They need a permission however otherwise it defaults to 100%.

I made this because I just wanted to have the freedom to go over 100%. I originally modified it just for myself but I decided to add permissions for it and a config option and everything, then fork and make a pull request it so it could be in the main repo.

Basically, if a user/group has "AllowHigherVolume = yes", then when they adjust the volume the maximum limit is what the user sets in the config (default: 100%). So if someone set the MaxVolume option to 500, they could type for example "!volume 500" if they have the permission. However, if someone has "AllowHigherVolume = no", then they're limited to 100% no matter what. 

Log:
Set player max volume

setting up permissions, config option

Working, adding permissions

Permissions working, adding config check

Config error handling handled correctly

Merged code to review branch