### PR TITLE
Fix skip ratio

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -9,6 +9,7 @@ import logging
 import asyncio
 import pathlib
 import traceback
+import math
 
 import aiohttp
 import discord
@@ -34,7 +35,7 @@ from .opus_loader import load_opus_lib
 from .config import Config, ConfigDefaults
 from .permissions import Permissions, PermissionsDefaults
 from .constructs import SkipState, Response, VoiceStateUpdate
-from .utils import load_file, write_file, sane_round_int, fixg, ftimedelta
+from .utils import load_file, write_file, fixg, ftimedelta
 
 from .constants import VERSION as BOTVERSION
 from .constants import DISCORD_MSG_CHAR_LIMIT, AUDIO_CACHE_PATH
@@ -1879,7 +1880,7 @@ class MusicBot(discord.Client):
 
         skips_remaining = min(
             self.config.skips_required,
-            sane_round_int(num_voice * self.config.skip_ratio_required)
+            math.ceil(self.config.skip_ratio_required / (1 / num_voice)) # Number of skips from config ratio
         ) - num_skips
 
         if skips_remaining <= 0:

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -1,5 +1,4 @@
 import sys
-import decimal
 import logging
 import aiohttp
 
@@ -31,11 +30,6 @@ def write_file(filename, contents):
         for item in contents:
             f.write(str(item))
             f.write('\n')
-
-
-def sane_round_int(x):
-    return int(decimal.Decimal(x).quantize(1, rounding=decimal.ROUND_HALF_UP))
-
 
 def paginate(content, *, length=DISCORD_MSG_CHAR_LIMIT, reserve=0):
     """


### PR DESCRIPTION
There seems to be a bug in the code that handles rounding for the number of skips. I noticed it when helping a fellow over #979.
What should happen when you set the number of skips ratio in the config to be 0.2, and that there are 6 "default" members (not muted, not owner, etc), I expected to have two skips required. That is because if you divide 1 / 6 = 0.1666. It means that each users have 16% of a share in the ratio. And in order to hit the 0.2 (20%) ratio, you need to have 2 skips (0.16666 x 2 = 0.33333 >= 0.2).
But what has happened is not accurate. The `sane_round_int` method in utils.py doesn't correctly compute the number of skips. Here is my demonstration:

```py
>>> import math
>>> num_voice = 1     # set number of voice users to 1
>>> ratio = 0.2     # set ratio to 0.2
>>> math.ceil(ratio / (1 / num_voice))      # Take the ratio and divided by the ratio share per user. Round that up to nearest integer.
1       # 1 skip required for 1 user in voice channel w/ ratio 20%
>>> num_voice = 2
>>> math.ceil(ratio / (1 / num_voice))
1
>>> num_voice = 3
>>> math.ceil(ratio / (1 / num_voice))
1
>>> num_voice = 4
>>> math.ceil(ratio / (1 / num_voice))
1
>>> num_voice = 5
>>> math.ceil(ratio / (1 / num_voice))
1          # 1 skip required still b/c each users have the power of 0.2 (20%) ratio to skip. Which is equivalent to the ratio set originally above (aka config)
>>> num_voice = 6      # set the number of voice users to 6
>>> math.ceil(ratio / (1 / num_voice))
2         # 2 skips required as demonstrated by example above
>>> num_voice = 7
>>> math.ceil(ratio / (1 / num_voice))
2
>>> num_voice = 8
>>> math.ceil(ratio / (1 / num_voice))
2
>>> num_voice = 9
>>> math.ceil(ratio / (1 / num_voice))
2
>>> num_voice = 10
>>> math.ceil(ratio / (1 / num_voice))
2
>>> num_voice = 11      # 3 skips at 11 users because each users now has 0.09 (9%) ratio. 0.09 * 3 0.27 >= 0.20.
>>> math.ceil(ratio / (1 / num_voice))
3
```

As demonstrated above, this is the code that I have proposed to implement. Here is the demonstration for the one that uses `sane_round_int` method as the bot does currently. I kept the ratio the same (0.2) and incremented the users one by one again.
```py
>>> import decimal
>>> def sane_round_int(x):
...     return int(decimal.Decimal(x).quantize(1, rounding=decimal.ROUND_HALF_UP))
... 
>>> ratio = 0.2
>>> num_voice = 1
>>> sane_round_int(num_voice * ratio)
0
>>> num_voice = 2
>>> sane_round_int(num_voice * ratio)
0
>>> num_voice = 3
>>> sane_round_int(num_voice * ratio)
1
>>> num_voice = 4
>>> sane_round_int(num_voice * ratio)
1
>>> num_voice = 5                                     # Each user would have 0.2 ratio, 1 skip is required
>>> sane_round_int(num_voice * ratio)
1
>>> num_voice = 6                                     # Each user SHOULD have 0.16 ratio, 2 SKIPS is required
>>> sane_round_int(num_voice * ratio)
1
>>> num_voice = 7
>>> sane_round_int(num_voice * ratio)
1
>>> num_voice = 8
>>> sane_round_int(num_voice * ratio)
2
```
As you can see that giving one users somehow gave a skips of zero. And that at 3 users, it increments to 1 skips. What is unacceptible is when there are 6 users. Each of them should have a ratio of 0.16. Therefore, it would need 2 people to skip. However, the method still returns 1 skip. 

I am proposing this change to fix the rounding issue with calculating the amount of skips to accurately reflect the amount of users in the channel along with the ratio given in the config.