### PR TITLE
Added cmd_remove (removes a song from the queue based on index)

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1239,6 +1239,40 @@ class MusicBot(discord.Client):
         except:
             raise exceptions.CommandError('Invalid URL provided:\n{}\n'.format(server_link), expire_in=30)
 
+    async def cmd_remove(self, player, leftover_args, index):
+        """
+        Usage:
+            {command_prefix}remove [index]
+
+        Remove a song at the given index from the queue. 
+        Use {command_prefix}queue to see the list of queued songs and their indices.
+        """
+        try:
+            index = int(' '.join([index, *leftover_args]))
+            playlist_size = len(player.playlist.entries)
+            if index > playlist_size:
+                if(playlist_size > 1):
+                    reply_text = "There are only %s songs in the queue, dumbass!"
+                    reply_text %= (playlist_size)
+                    return Response(reply_text, expire_in=30)
+                elif(playlist_size == 1):
+                    reply_text = "There is only %s song in the queue, dumbass!"
+                    reply_text %= (playlist_size)
+                    return Response(reply_text, expire_in=30)
+                else:
+                    reply_text = "There aren't any songs in the queue, dumbass!"
+                    return Response(reply_text, expire_in=30)
+
+            entry = await player.playlist.remove_entry(index)
+            reply_text = "Removed **%s** from the playlist"
+            reply_text %= (entry.title)
+
+            return Response(reply_text, expire_in=30)
+        except ValueError:
+            reply_text = "Must specify an index to remove (AKA a number)"
+
+            return Response(reply_text, expire_in=30)
+
     async def cmd_play(self, player, channel, author, permissions, leftover_args, song_url):
         """
         Usage:

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -42,6 +42,27 @@ class Playlist(EventEmitter, Serializable):
     def clear(self):
         self.entries.clear()
 
+    async def remove_entry(self, index):
+        """
+            Removes a song from the playlist.
+
+            :param index: The index of the song to remove from the queue.
+        """
+
+        removed_entries = deque()
+
+        if index == 1:
+            return self.entries.popleft()
+
+        for i in range(1, index):
+            removed_entries.appendleft(self.entries.popleft())
+        removed_entry = self.entries.popleft()
+
+        for entry in removed_entries:
+            self.entries.appendleft(entry)
+
+        return removed_entry
+
     async def add_entry(self, song_url, **meta):
         """
             Validates and adds a song_url to be played. This does not start the download of the song.


### PR DESCRIPTION
Remove command allows a user to remove a song from the "to-be-played" queue based on the song's index. Plan to add "remove song by name" feature in the future.