### PR TITLE
Add Dependency Autoupdate to Docker Installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /musicBot
 #Install PIP dependencies
 RUN sudo pip install -r requirements.txt
 
-RUN echo "root python3.5 -m pip install --upgrade -r /musicBot/requirements.txt; pkill python3.5" > /etc/cron.d/auto-update-dependencies
+RUN echo "* 0 * * * root python3.5 -m pip install --upgrade -r /musicBot/requirements.txt; pkill python3.5" > /etc/cron.d/auto-update-dependencies
 
 #Add volume for configuration
 VOLUME /musicBot/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-MAINTAINER Sidesplitter, https://github.com/SexualRhinoceros/MusicBot
+MAINTAINER Sidesplitter, https://github.com/Just-Some-Bots/MusicBot
 
 #Install dependencies
 RUN sudo apt-get update \
@@ -25,6 +25,8 @@ WORKDIR /musicBot
 
 #Install PIP dependencies
 RUN sudo pip install -r requirements.txt
+
+RUN echo "root python3.5 -m pip install --upgrade -r /musicBot/requirements.txt; pkill python3.5" > /etc/cron.d/auto-update-dependencies
 
 #Add volume for configuration
 VOLUME /musicBot/config


### PR DESCRIPTION
This would prevent errors caused by Dependencies like youtube-dl.
The container should be run with --restart=unless-stopped !
Otherwise we need a capsulation script for the execution, because this would effectively kill the root process (PID 1 '/bin/sh -c python3.5 run.py').
Also fixes the MAINTAINER Tag.