### PR TITLE
Console now prints song name.

### DIFF
--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -207,14 +207,14 @@ class URLPlaylistEntry(BasePlaylistEntry):
 
     # noinspection PyShadowingBuiltins
     async def _really_download(self, *, hash=False):
-        print("[Download] Started:", self.url)
+        print("[Download] Started: '%s' [s%]" % (self.title, self.url)
 
         try:
             result = await self.playlist.downloader.extract_info(self.playlist.loop, self.url, download=True)
         except Exception as e:
             raise ExtractionError(e)
 
-        print("[Download] Complete:", self.url)
+        print("[Download] Complete: '%s' [%s]" % (self.title, self.url))
 
         if result is None:
             raise ExtractionError("ytdl broke and hell if I know why")


### PR DESCRIPTION
Console now prints the name of the song that is being downloaded, in addition to the url.
Song name is printed inside single quotes; song url is printed inside square brackets.