### PR TITLE
Patch auto pause in various cases.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -655,6 +655,14 @@ class MusicBot(discord.Client):
         await self.update_now_playing_status()
 
     async def on_player_finished_playing(self, player, **_):
+        def _autopause(player):
+            if self._check_if_empty(player.voice_client.channel):
+                log.info("Player finished playing, autopaused in empty channel")
+
+                player.pause()
+                self.server_specific_data[player.voice_client.channel.server]['auto_paused'] = True
+        
+        
         if not player.playlist.entries and not player.current_entry and self.config.auto_playlist:
             if not player.autoplaylist:
                 if not self.autoplaylist:
@@ -702,6 +710,9 @@ class MusicBot(discord.Client):
 
                 # Do I check the initial conditions again?
                 # not (not player.playlist.entries and not player.current_entry and self.config.auto_playlist)
+                
+                if self.config.auto_pause:
+                    player.once('play', lambda player, **_: _autopause(player))
 
                 try:
                     await player.playlist.add_entry(song_url, channel=None, author=None)

--- a/musicbot/constructs.py
+++ b/musicbot/constructs.py
@@ -169,7 +169,10 @@ class VoiceStateUpdate:
     def is_about_my_voice_channel(self):
         return all((
             self.my_voice_channel,
-            self.voice_channel == self.my_voice_channel
+            any((
+                self.new_voice_channel == self.my_voice_channel,
+                self.old_voice_channel == self.my_voice_channel
+            ))
         ))
 
     @property


### PR DESCRIPTION
- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
The Auto-Pause feature has a few conditions that prevent automatically pausing the playing track when a channel becomes empty or has been empty when the bot starts.  This patch attempts to address several of those cases. 

Auto Pause on Click-&-Drag now works.
Auto Pause on member moving channels now works.
Auto Pause on Initial join now more reliable.
Auto Pause on playing a new track via autoplaylist now works.
 
This patch also resumes any paused players to prevent hanging ffmpeg threads on shutdown and restart calls.

### Related issues (if applicable)
#1482 and #1477
