### PR TITLE
Help command only returns commands you can use

### DIFF
--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -2,6 +2,7 @@
     "cmd-resetplaylist-response": "The server's autoplaylist has been reset.",
     "cmd-help-invalid": "No such command",
     "cmd-help-response": "For information about a particular command, run `{}help [command]`\nFor further help, see https://just-some-bots.github.io/MusicBot/",
+    "cmd-help-all": "\nOnly showing commands you can use, for a list of all commands, run `{}help all`",
     "cmd-blacklist-invalid": "Invalid option '{0}' specified, use +, -, add, or remove",
     "cmd-blacklist-added": "{0} users have been added to the blacklist",
     "cmd-blacklist-none": "None of those users are in the blacklist.",

--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -1,6 +1,7 @@
 {
     "cmd-resetplaylist-response": "The server's autoplaylist has been reset.",
     "cmd-help-invalid": "No such command",
+    "cmd-help-no-perms": "You don't have permission to use any commands. Run `{}help all` list every command anyway",
     "cmd-help-response": "For information about a particular command, run `{}help [command]`\nFor further help, see https://just-some-bots.github.io/MusicBot/",
     "cmd-help-all": "\nOnly showing commands you can use, for a list of all commands, run `{}help all`",
     "cmd-blacklist-invalid": "Invalid option '{0}' specified, use +, -, add, or remove",

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1254,6 +1254,8 @@ class MusicBot(discord.Client):
             await gen_cmd_list(message, all=True)
 
         else:
+            if self.commands == []:
+                raise exceptions.CommandError(self.str.get('cmd-help-no-perms', 'You don\'t have permission to use any commands. Run `{}help all` list every command anyway'), expire_in=10)
             await gen_cmd_list(message)
             desc = '```\n' + ', '.join(self.commands) + '\n```\n' + self.str.get(
                 'cmd-help-response', 'For information about a particular command, run `{}help [command]`\n'


### PR DESCRIPTION
Please make sure these boxes are checked (put an 'x' inside them) **before** creating the pull request.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Changes the behavior for the help command. `{}help` now only returns commands you can run with your permissions. You can bypass this by running `{}help all` or if you are owner.

### Related issues (if applicable)
Feature request #129
