### PR TITLE
Can use commands in server when no channels set with BindToChannels on

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -48,6 +48,12 @@ CommandPrefix = !
 # a space.
 BindToChannels =
 
+# Determines if the bot will respond to messages sent in servers that do not
+# have a channel set in BindToChannels when at least one is specified. Turning
+# this off will allow servers without any bound channels to use the bot. Does
+# nothing if BindToChannels is not set.
+AllowUnboundServers = no
+
 # Allows the bot to automatically join servers on startup. To use this, add the IDs
 # of the voice channels you would like the bot to join on startup, seperated by a
 # space. Each server can have one channel. If this option and AutoSummon are

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -48,10 +48,10 @@ CommandPrefix = !
 # a space.
 BindToChannels =
 
-# Determines if the bot will respond to messages sent in servers that do not
-# have a channel set in BindToChannels when at least one is specified. Turning
-# this on will allow servers without any bound channels to use the bot. Does
-# nothing if BindToChannels is not set.
+# Changes the behavior of BindToChannels. Normally any messages sent to a channel not in
+# BindToChannels will be ignored. This option allows servers that do not have any bound
+# channels while there are channels in BindToChannels to still use commands with the Music Bot.
+# Setting this to yes when there are no bound channels does nothing.
 AllowUnboundServers = no
 
 # Allows the bot to automatically join servers on startup. To use this, add the IDs

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -50,7 +50,7 @@ BindToChannels =
 
 # Determines if the bot will respond to messages sent in servers that do not
 # have a channel set in BindToChannels when at least one is specified. Turning
-# this off will allow servers without any bound channels to use the bot. Does
+# this on will allow servers without any bound channels to use the bot. Does
 # nothing if BindToChannels is not set.
 AllowUnboundServers = no
 

--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -2,6 +2,7 @@
     "cmd-resetplaylist-response": "The server's autoplaylist has been reset.",
     "cmd-help-invalid": "No such command",
     "cmd-help-response": "For information about a particular command, run `{}help [command]`\nFor further help, see https://just-some-bots.github.io/MusicBot/",
+    "cmd-help-all": "\nOnly showing commands you can use, for a list of all commands, run `{}help all`",
     "cmd-blacklist-invalid": "Invalid option '{0}' specified, use +, -, add, or remove",
     "cmd-blacklist-added": "{0} users have been added to the blacklist",
     "cmd-blacklist-none": "None of those users are in the blacklist.",

--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -1,6 +1,7 @@
 {
     "cmd-resetplaylist-response": "The server's autoplaylist has been reset.",
     "cmd-help-invalid": "No such command",
+    "cmd-help-no-perms": "You don't have permission to use any commands. Run `{}help all` list every command anyway",
     "cmd-help-response": "For information about a particular command, run `{}help [command]`\nFor further help, see https://just-some-bots.github.io/MusicBot/",
     "cmd-help-all": "\nOnly showing commands you can use, for a list of all commands, run `{}help all`",
     "cmd-blacklist-invalid": "Invalid option '{0}' specified, use +, -, add, or remove",

--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -1,7 +1,6 @@
 {
     "cmd-resetplaylist-response": "The server's autoplaylist has been reset.",
     "cmd-help-invalid": "No such command",
-    "cmd-help-no-perms": "You don't have permission to use any commands. Run `{}help all` list every command anyway",
     "cmd-help-response": "For information about a particular command, run `{}help [command]`\nFor further help, see https://just-some-bots.github.io/MusicBot/",
     "cmd-help-all": "\nOnly showing commands you can use, for a list of all commands, run `{}help all`",
     "cmd-blacklist-invalid": "Invalid option '{0}' specified, use +, -, add, or remove",

--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -2,7 +2,6 @@
     "cmd-resetplaylist-response": "The server's autoplaylist has been reset.",
     "cmd-help-invalid": "No such command",
     "cmd-help-response": "For information about a particular command, run `{}help [command]`\nFor further help, see https://just-some-bots.github.io/MusicBot/",
-    "cmd-help-all": "\nOnly showing commands you can use, for a list of all commands, run `{}help all`",
     "cmd-blacklist-invalid": "Invalid option '{0}' specified, use +, -, add, or remove",
     "cmd-blacklist-added": "{0} users have been added to the blacklist",
     "cmd-blacklist-none": "None of those users are in the blacklist.",

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1254,8 +1254,6 @@ class MusicBot(discord.Client):
             await gen_cmd_list(message, all=True)
 
         else:
-            if self.commands == []:
-                raise exceptions.CommandError(self.str.get('cmd-help-no-perms', 'You don\'t have permission to use any commands. Run `{}help all` list every command anyway'), expire_in=10)
             await gen_cmd_list(message)
             desc = '```\n' + ', '.join(self.commands) + '\n```\n' + self.str.get(
                 'cmd-help-response', 'For information about a particular command, run `{}help [command]`\n'

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1254,6 +1254,8 @@ class MusicBot(discord.Client):
             await gen_cmd_list(message, all=True)
 
         else:
+            if self.commands == []:
+                raise exceptions.CommandError(self.str.get('cmd-help-no-perms', 'You don\'t have permission to use any commands. Run `{}help all` list every command anyway'), expire_in=10)
             await gen_cmd_list(message)
             desc = '```\n' + ', '.join(self.commands) + '\n```\n' + self.str.get(
                 'cmd-help-response', 'For information about a particular command, run `{}help [command]`\n'

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2662,7 +2662,12 @@ class MusicBot(discord.Client):
             return
 
         if self.config.bound_channels and message.channel.id not in self.config.bound_channels and not message.channel.is_private:
-            return  # if I want to log this I just move it under the prefix check
+            if self.config.unbound_servers:
+                for channel in message.server.channels:
+                    if channel.id in self.config.bound_channels:
+                        return
+            else:
+                return  # if I want to log this I just move it under the prefix check
 
         command, *args = message_content.split(' ')  # Uh, doesn't this break prefixes with spaces in them (it doesn't, config parser already breaks them)
         command = command[len(self.config.command_prefix):].lower().strip()

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1214,7 +1214,7 @@ class MusicBot(discord.Client):
         player.autoplaylist = list(set(self.autoplaylist))
         return Response(self.str.get('cmd-resetplaylist-response', '\N{OK HAND SIGN}'), delete_after=15)
 
-    async def cmd_help(self, message, channel, command=None):
+    async def cmd_help(self, channel, command=None):
         """
         Usage:
             {command_prefix}help [command]
@@ -1223,47 +1223,30 @@ class MusicBot(discord.Client):
         If a command is specified, it prints a help message for that command.
         Otherwise, it lists the available commands.
         """
-        self.commands = []
-        prefix = self.config.command_prefix
 
-        async def gen_cmd_list(message, all=False):
+        if command:
+            cmd = getattr(self, 'cmd_' + command, None)
+            if cmd and not hasattr(cmd, 'dev_cmd'):
+                return Response(
+                    "```\n{}```".format(
+                        dedent(cmd.__doc__)
+                    ).format(command_prefix=self.config.command_prefix),
+                    delete_after=60
+                )
+            else:
+                raise exceptions.CommandError(self.str.get('cmd-help-invalid', "No such command"), expire_in=10)
+
+        else:
+            commands = []
 
             for att in dir(self):
                 if att.startswith('cmd_') and att != 'cmd_help' and not hasattr(getattr(self, att), 'dev_cmd'):
-                    user_permissions = self.permissions.for_user(message.author)
                     command_name = att.replace('cmd_', '').lower()
-                    if command_name in user_permissions.command_whitelist and not command_name in user_permissions.command_blacklist or all:
-                        self.commands.append("{}{}".format(self.config.command_prefix, command_name))
+                    commands.append("{}{}".format(self.config.command_prefix, command_name))
 
-        if command:
-            if command == 'all':
-                await gen_cmd_list(message, all=True)
-            else:
-                cmd = getattr(self, 'cmd_' + command, None)
-                if cmd and not hasattr(cmd, 'dev_cmd'):
-                    return Response(
-                        "```\n{}```".format(
-                            dedent(cmd.__doc__)
-                        ).format(command_prefix=self.config.command_prefix),
-                        delete_after=60
-                    )
-                else:
-                    raise exceptions.CommandError(self.str.get('cmd-help-invalid', "No such command"), expire_in=10)
-
-        elif message.author.id == self.config.owner_id:
-            await gen_cmd_list(message, all=True)
-
-        else:
-            await gen_cmd_list(message)
-            desc = '```\n' + ', '.join(self.commands) + '\n```\n' + self.str.get(
-                'cmd-help-response', 'For information about a particular command, run `{}help [command]`\n'
-                                     'For further help, see https://just-some-bots.github.io/MusicBot/').format(prefix) + self.str.get(
-                'cmd-help-all', '\nOnly showing commands you can use, for a list of all commands, run `{}help all`')
-            return Response(desc, reply=True, delete_after=60)
-
-        desc = '```\n' + ', '.join(self.commands) + '\n```\n' + self.str.get(
+        desc = '```\n' + ', '.join(commands) + '\n```\n' + self.str.get(
             'cmd-help-response', 'For information about a particular command, run `{}help [command]`\n'
-                                 'For further help, see https://just-some-bots.github.io/MusicBot/').format(prefix)
+                                 'For further help, see https://just-some-bots.github.io/MusicBot/').format(self.config.command_prefix)
 
         return Response(desc, reply=True, delete_after=60)
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -45,6 +45,7 @@ class Config:
 
         self.command_prefix = config.get('Chat', 'CommandPrefix', fallback=ConfigDefaults.command_prefix)
         self.bound_channels = config.get('Chat', 'BindToChannels', fallback=ConfigDefaults.bound_channels)
+        self.unbound_servers = config.getboolean('Chat', 'AllowUnboundServers', fallback=ConfigDefaults.unbound_servers)
         self.autojoin_channels =  config.get('Chat', 'AutojoinChannels', fallback=ConfigDefaults.autojoin_channels)
 
         self.default_volume = config.getfloat('MusicBot', 'DefaultVolume', fallback=ConfigDefaults.default_volume)
@@ -284,6 +285,7 @@ class ConfigDefaults:
 
     command_prefix = '!'
     bound_channels = set()
+    unbound_servers = False
     autojoin_channels = set()
 
     default_volume = 0.15


### PR DESCRIPTION
Please make sure these boxes are checked (put an 'x' inside them) **before** creating the pull request.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Allows for when there are channels in the `BindToChannels` list, a server that has no bound channels can be used (toggled in options.ini). A little messy since I accidentally merged the test branch from another PR into this branch so those commits are reverted.


### Related issues (if applicable)
Feature request #272
