### PR TITLE
Fixed a crash when loading translation files with non standard chars

### DIFF
--- a/musicbot/json.py
+++ b/musicbot/json.py
@@ -11,7 +11,7 @@ class Json:
 
     def parse(self):
         """Parse the file as JSON"""
-        with open(self.file) as data:
+        with open(self.file, encoding='utf-8') as data:
             try:
                 parsed = json.load(data)
             except Exception:


### PR DESCRIPTION
Please make sure these boxes are checked (put an 'x' inside them) **before** creating the pull request.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Translation files were being loaded with default encoding, which caused crashes during json parsing when using non standard characters.
