### PR TITLE
Add PyNaCl to python requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ discord.py[voice] ~= 0.16.0
 pip
 youtube_dl
 colorlog
+PyNaCl
 cffi --only-binary all; sys_platform == 'win32'


### PR DESCRIPTION
This is to fix an upstream change in the discord library which now
prints:

```
File "/usr/lib/python3.6/site-packages/discord/voice_client.py", line 217, in __init__
  raise RuntimeError("PyNaCl library needed in order to use voice")
```

After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description



### Related issues (if applicable)

