### PR TITLE
Fixed Startup Log Bug

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1196,7 +1196,7 @@ class MusicBot(discord.Client):
             log.info("  Author insta-skip: " + ['Disabled', 'Enabled'][self.config.allow_author_skip])
             log.info("  Embeds: " + ['Disabled', 'Enabled'][self.config.embeds])
             log.info("  Spotify integration: " + ['Disabled', 'Enabled'][self.config._spotify])
-            log.info("  Legacy skip: " + ['Disabled']['Enabled'][self.config.legacy_skip])
+            log.info("  Legacy skip: " + ['Disabled', 'Enabled'][self.config.legacy_skip])
 
         print(flush=True)
 


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Fixed a small typo in bot.py creating a TypeError for the bots startup log relating to legacy skip


### Related issues (if applicable)
Old Traceback:
[ERROR:bot] Exception in on_ready
Traceback (most recent call last):
  File "C:\Users\Robert\AppData\Local\Programs\Python\Python36\lib\site-packages\discord\client.py", line 307, in _run_event
    yield from getattr(self, event)(*args, **kwargs)
  File "C:\MusicBot\reviewFix\musicbot\bot.py", line 1199, in on_ready
    log.info("  Legacy skip: " + ['Disabled']['Enabled'][self.config.legacy_skip])
TypeError: list indices must be integers or slices, not str
