### PR TITLE
Change run.sh to use python3.5 instead of python3 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-(command -v python3 >/dev/null 2>&1 &&
+(command -v python3.5 >/dev/null 2>&1 &&
 python3.5 -c 'import sys; sys.exit(sys.hexversion < 0x03050000)') || {
 	echo >&2 "Python 3.5 or later not found."
 	echo >&2 "If you have python, use it to run run.py."

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 (command -v python3 >/dev/null 2>&1 &&
-python3 -c 'import sys; sys.exit(sys.hexversion < 0x03050000)') || {
+python3.5 -c 'import sys; sys.exit(sys.hexversion < 0x03050000)') || {
 	echo >&2 "Python 3.5 or later not found."
 	echo >&2 "If you have python, use it to run run.py."
 	exit 1; }
 
 cd "$(dirname "$BASH_SOURCE")"
-python3 run.py
+python3.5 run.py


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [ x ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ x ] I have tested my changes on Python 3.5/3.6

----

### Description
Keeps things uniform between run.sh and update.sh, as they should be the same, otherwise issues could arise such as dependencies being installed to a version of python associated with `python3` that isn't associated with `python3.5`

### Related issues (if applicable)

