### PR TITLE
Fix issue with excess whitespace messing with commands Resolves #1628

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2560,6 +2560,8 @@ class MusicBot(discord.Client):
         command, *args = message_content.split(' ')  # Uh, doesn't this break prefixes with spaces in them (it doesn't, config parser already breaks them)
         command = command[len(self.config.command_prefix):].lower().strip()
 
+        args = ' '.join(args).lstrip(' ').split(' ')
+
         handler = getattr(self, 'cmd_' + command, None)
         if not handler:
             return


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Trims leading whitespace from next significant command component.

It allows these commands to be similar in execution

```
!play https://www.youtube.com/watch?v=84lJON6MK4c
```

```
!play  https://www.youtube.com/watch?v=84lJON6MK4c
```

The original issue is having an extra space, while it serves no purpose is recognized as search query which shouldn't be the intended behavior. I can't think of a command where leading whitespace is significant. This PR only alters leading whitespace and does not affect whitespace after the first significant component.

### Related issues (if applicable)
Issue #1628
