### PR TITLE
Fix broken permissions because IDs were still strings

### DIFF
--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -137,10 +137,10 @@ class PermissionGroup:
             self.ignore_non_voice = set(self.ignore_non_voice.lower().split())
 
         if self.granted_to_roles:
-            self.granted_to_roles = set(self.granted_to_roles.split())
+            self.granted_to_roles = set([int(x) for x in self.granted_to_roles.split()])
 
         if self.user_list:
-            self.user_list = set(self.user_list.split())
+            self.user_list = set([int(x) for x in self.user_list.split()])
 
         if self.extractors:
             self.extractors = set(self.extractors.split())


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
IDs in rewrite are now int, the owner id and channel ids were converted, however the permission ids were not.


### Related issues (if applicable)

