### PR TITLE
--enable-openssl is in the wrong spot

### DIFF
--- a/_docs/installing/raspbian.md
+++ b/_docs/installing/raspbian.md
@@ -43,7 +43,7 @@ sudo python3.5 get-pip.py
 cd /usr/src
 sudo git clone git://git.videolan.org/x264
 cd x264
-sudo ./configure --host=arm-unknown-linux-gnueabi --enable-static --disable-opencl
+sudo ./configure --host=arm-unknown-linux-gnueabi --enable-static --disable-opencl --enable-openssl
 sudo make
 sudo make install
 

--- a/_docs/installing/raspbian.md
+++ b/_docs/installing/raspbian.md
@@ -43,7 +43,7 @@ sudo python3.5 get-pip.py
 cd /usr/src
 sudo git clone git://git.videolan.org/x264
 cd x264
-sudo ./configure --host=arm-unknown-linux-gnueabi --enable-static --disable-opencl --enable-openssl
+sudo ./configure --host=arm-unknown-linux-gnueabi --enable-static --disable-opencl
 sudo make
 sudo make install
 
@@ -51,7 +51,7 @@ sudo make install
 cd /usr/src
 sudo git clone https://github.com/FFmpeg/FFmpeg.git
 cd FFmpeg
-sudo ./configure --arch=armel --target-os=linux --enable-gpl --enable-libx264 --enable-nonfree
+sudo ./configure --arch=armel --target-os=linux --enable-gpl --enable-libx264 --enable-nonfree --enable-openssl
 
 sudo make  # add -j4 to the end of this if you have a quad-core Raspberry Pi
 sudo make install


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description
i put the option to enable openssl for ffmpeg in the wrong spot
good job me

### Related issues (if applicable)
`Unknown option --enable-openssl`