### PR TITLE
Fix setavatar for uploaded images and dev only commands

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2423,14 +2423,15 @@ class MusicBot(discord.Client):
         """
 
         if message.attachments:
-            thing = message.attachments[0]['url']
+            thing = message.attachments[0].url
         elif url:
             thing = url.strip('<>')
         else:
             raise exceptions.CommandError("You must provide a URL or attach a file.", expire_in=20)
 
         try:
-            with aiohttp.Timeout(10):
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout):
                 async with self.aiosession.get(thing) as res:
                     await self.user.edit(avatar=await res.read())
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -145,7 +145,7 @@ class MusicBot(discord.Client):
         async def wrapper(self, *args, **kwargs):
             orig_msg = _get_variable('message')
 
-            if orig_msg.author.id in self.config.dev_ids:
+            if str(orig_msg.author.id) in self.config.dev_ids:
                 # noinspection PyCallingNonCallable
                 return await func(self, *args, **kwargs)
             else:
@@ -2431,9 +2431,8 @@ class MusicBot(discord.Client):
 
         try:
             timeout = aiohttp.ClientTimeout(total=10)
-            async with aiohttp.ClientSession(timeout=timeout):
-                async with self.aiosession.get(thing) as res:
-                    await self.user.edit(avatar=await res.read())
+            async with self.aiosession.get(thing, timeout=timeout) as res:
+                await self.user.edit(avatar=await res.read())
 
         except Exception as e:
             raise exceptions.CommandError("Unable to change avatar: {}".format(e), expire_in=20)


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description

[Fixes aiohttp error in setavatar](http://docs.aiohttp.org/en/latest/client_quickstart.html#timeouts) and updates attachments to work with rewrite

Edit: Also fixes a type error when running dev only commands

`TypeError: 'in <string>' requires string as left operand, not int`

### Related issues (if applicable)

#1678 