### PR TITLE
Fix unintended autoplaylist shuffle.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -525,7 +525,7 @@ class MusicBot(discord.Client):
                     self.config.auto_playlist = False
                 else:
                     log.debug("No content in current autoplaylist. Filling with new music...")
-                    player.autoplaylist = list(set(self.autoplaylist))
+                    player.autoplaylist = list(self.autoplaylist)
 
             while player.autoplaylist:
                 if self.config.auto_playlist_random:


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Autoplaylist seems to be converting to set, therefore messing up the initial order even if random autoplaylist is turned off.

