### PR TITLE
Python3.6 update to Arch Guide

### DIFF
--- a/_docs/installing/arch.md
+++ b/_docs/installing/arch.md
@@ -4,15 +4,24 @@ category: Installing the bot
 order: 7
 ---
 
-<img class="doc-img" src="{{ site.baseurl }}/images/arch.png" alt="centos" style="width: 75px; float: right;"/>
-Installation on Arch is **majorly untested and is not officially supported** due to issues. Please keep this in mind when seeking support.
+<img class="doc-img" src="{{ site.baseurl }}/images/arch.png" alt="arch" style="width: 75px; float: right;"/>
+Installation on Arch is **majorly untested and is not officially supported.** Please keep this in mind when seeking support.
 
 ~~~ bash
-# Update system packages
-sudo pacman -Syu
+# Update system repositories
+sudo pacman -Sy
 
 # Install dependencies
-sudo pacman -S git python python-pip opus libffi libsodium ncurses gdbm glibc zlib sqlite tk openssl ffmpeg
+sudo pacman -S base-devel git opus libffi libsodium ncurses gdbm glibc zlib sqlite tk openssl ffmpeg
+
+# Install Python 3.6 from the AUR
+git clone https://aur.archlinux.org/python36.git
+cd python36
+makepkg -sic
+
+# Install pip to Python 3.6
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+sudo python3.6 get-pip.py
 
 # Clone the MusicBot to your home directory
 cd ~
@@ -20,8 +29,8 @@ git clone https://github.com/Just-Some-Bots/MusicBot.git MusicBot -b master
 cd MusicBot
 
 # Install dependencies
-sudo pip install --upgrade pip
-sudo pip install --upgrade -r requirements.txt
+sudo python3.6 -m pip install --upgrade pip
+sudo python3.6 -m pip install --upgrade -r requirements.txt
 ~~~
 
 Once everything has been completed, you can go ahead and [configure]({{ site.baseurl }}/using/configuration) the bot and then run with `sh ./run.sh`.


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description
The Arch repositories have updated the [python](https://www.archlinux.org/packages/extra/x86_64/python/) package to 3.7, and as such, this builds [python36](https://aur.archlinux.org/packages/python36/) from the AUR and then installs pip to Python 3.6.