### PR TITLE
Allow servers without bound channels

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -54,6 +54,12 @@ CommandPrefix = !
 # a space.
 BindToChannels =
 
+# Changes the behavior of BindToChannels. Normally any messages sent to a channel not in
+# BindToChannels will be ignored. This option allows servers that do not have any bound
+# channels while other server have some defined to still use commands in any channel with
+# the Music Bot. Setting this to yes when there are no bound channels does nothing.
+AllowUnboundServers = no
+
 # Allows the bot to automatically join servers on startup. To use this, add the IDs
 # of the voice channels you would like the bot to join on startup, seperated by a
 # space. Each server can have one channel. If this option and AutoSummon are

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2572,7 +2572,13 @@ class MusicBot(discord.Client):
             return
 
         if self.config.bound_channels and message.channel.id not in self.config.bound_channels:
-            return  # if I want to log this I just move it under the prefix check
+            if self.config.unbound_servers:
+                for channel in message.guild.channels:
+                    if channel.id in self.config.bound_channels:
+                        return
+            else:
+                return  # if I want to log this I just move it under the prefix check
+
         if not isinstance(message.channel, discord.abc.GuildChannel):
             return
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -45,6 +45,7 @@ class Config:
 
         self.command_prefix = config.get('Chat', 'CommandPrefix', fallback=ConfigDefaults.command_prefix)
         self.bound_channels = config.get('Chat', 'BindToChannels', fallback=ConfigDefaults.bound_channels)
+        self.unbound_servers = config.getboolean('Chat', 'AllowUnboundServers', fallback=ConfigDefaults.unbound_servers)
         self.autojoin_channels =  config.get('Chat', 'AutojoinChannels', fallback=ConfigDefaults.autojoin_channels)
 
         self.default_volume = config.getfloat('MusicBot', 'DefaultVolume', fallback=ConfigDefaults.default_volume)
@@ -311,6 +312,7 @@ class ConfigDefaults:
 
     command_prefix = '!'
     bound_channels = set()
+    unbound_servers = False
     autojoin_channels = set()
 
     default_volume = 0.15


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Allows servers without any defined bound channels to function normally with commands if other servers have bound channels (if setting enabled, off by default)


### Related issues (if applicable)
#272
