### PR TITLE
quick fix for leftover non-rewrite permissions

### DIFF
--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -80,7 +80,7 @@ class Permissions:
         """
 
         for group in self.groups:
-            if user.id in group.user_list:
+            if str(user.id) in group.user_list:
                 return group
 
         # The only way I could search for roles is if I add a `server=None` param and pass that too
@@ -90,7 +90,7 @@ class Permissions:
         # We loop again so that we don't return a role based group before we find an assigned one
         for group in self.groups:
             for role in user.roles:
-                if role.id in group.granted_to_roles:
+                if str(role.id) in group.granted_to_roles:
                     return group
 
         return self.default_group


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Fixes
```client.py - line 221, in run_event 
    await coro(*args**kwargs)
boy.py - line 2600 in on_message
    user_permissions = self.permissions.for_user(mesage.author)
permissions - line 83, in for_user
    if user.id in group.user_list:
TypeError: `in <string>` requires string as a left operand, not int.
```
by turning `user.id` into a str, does the same for `role.id` in a later line.
