### PR TITLE
Add pip when installing python

### DIFF
--- a/_docs/installing/debian.md
+++ b/_docs/installing/debian.md
@@ -18,7 +18,7 @@ sudo apt-get install git libopus-dev libffi-dev libsodium-dev ffmpeg -y
 sudo apt-get install build-essential libncursesw5-dev libgdbm-dev libc6-dev zlib1g-dev libsqlite3-dev tk-dev libssl-dev openssl -y
 
 # If using Debian Stretch or lower, you need to install Python too using...
-sudo apt-get install python3.5 -y
+sudo apt-get install python3.5 python3-pip -y
 
 # Clone the MusicBot to your home directory
 cd ~


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description

Debian seems to tend to lack pip after installing, for whatever reason. This ensures that if the user is installing python that they also install pip.


### Related issues (if applicable)

`/usr/bin/python3.5: No module named pip`