### PR TITLE
Use Python 3.6 with python3 in ubuntu guides

### DIFF
--- a/_docs/installing/ubuntu.md
+++ b/_docs/installing/ubuntu.md
@@ -35,6 +35,10 @@ cd ~/MusicBot
 # Install Python dependencies
 sudo python3.6 -m pip install -U pip
 sudo python3.6 -m pip install -U -r requirements.txt 
+
+# Set python3 to Python 3.6
+sudo rm /usr/bin/python3
+sudo cp /usr/bin/python3.6 /usr/bin/python3
 ~~~
 
 ## Ubuntu 16.04
@@ -63,6 +67,10 @@ cd ~/MusicBot
 # Install Python dependencies
 sudo python3.6 -m pip install -U pip
 sudo python3.6 -m pip install -U -r requirements.txt 
+
+# Set python3 to Python 3.6
+sudo rm /usr/bin/python3
+sudo cp /usr/bin/python3.6 /usr/bin/python3
 ~~~
 
 After doing those commands, you can [configure]({{ site.baseurl }}/using/configuration) the bot and then run it using `sudo ./run.sh`.


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5/3.6

----

### Description

Title is self-explanatory, `python3` shouldn't be Python 3.5.2 if there's a newer version being installed, fixes dependency issues relating to `run.sh` on first run.

`update.sh` will still output an aiohttp version issue as it uses `python3.5` instead of `python3` for some reason.

### Related issues (if applicable)

All Python 3.5.2 dependency related issues.