### PR TITLE
owner permission falling back and other minor owner bug

### DIFF
--- a/config/example_permissions.ini
+++ b/config/example_permissions.ini
@@ -10,6 +10,7 @@
 ; - Add whatever permissions you want, but always have at least one.
 ; - Never have an options without a value, i.e. "CommandBlacklist = "
 ; - [Default] is a special section.  Any user that doesn't get assigned to a group via role or UserList gets assigned to this group.
+; - [Owner (auto)] is a section that owner of the bot gets assigned to.
 ;
 ;
 ; Option info:
@@ -81,6 +82,8 @@
 ;  into writing for this exact purpose.  It tells you how to use every option.  Your question is probably answered there.
 ;
 ;;;;;;;;;;;;;;;;;;;
+
+
 
 ; This group is for owner.  Any options not specified will fallback to permissive default value.  Don't remove/rename this group.
 ; You cannot assign users or roles to this group.  Those options are ignored.

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -70,7 +70,6 @@ class MusicBot(discord.Client):
 
         self.config = Config(config_file)
         
-        # I noticed just now that permissions file copying log not shown up because it's way too below
         self._setup_logging()
         
         self.permissions = Permissions(perms_file, grant_all=[self.config.owner_id])

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -69,6 +69,10 @@ class MusicBot(discord.Client):
         self.last_status = None
 
         self.config = Config(config_file)
+        
+        # I noticed just now that permissions file copying log not shown up because it's way too below
+        self._setup_logging()
+        
         self.permissions = Permissions(perms_file, grant_all=[self.config.owner_id])
         self.str = Json(self.config.i18n_file)
 
@@ -77,8 +81,6 @@ class MusicBot(discord.Client):
 
         self.aiolocks = defaultdict(asyncio.Lock)
         self.downloader = downloader.Downloader(download_folder='audio_cache')
-
-        self._setup_logging()
 
         log.info('Starting MusicBot {}'.format(BOTVERSION))
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -149,6 +149,7 @@ class Config:
                         "instructions in the options or ask in the help server.",
                         preface=self._confpreface
                     )
+                self.owner_id = int(self.owner_id)
 
             elif self.owner_id == 'auto':
                 pass # defer to async check
@@ -227,8 +228,6 @@ class Config:
 
             self.owner_id = bot.cached_app_info.owner.id
             log.debug("Acquired owner id via API")
-        else:
-            self.owner_id = int(self.owner_id)
 
         if self.owner_id == bot.user.id:
             raise HelpfulError(

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -73,10 +73,20 @@ class Permissions:
         for section in self.config.sections():
             if section != 'Owner (auto)':
                 self.groups.add(PermissionGroup(section, self.config[section]))
-
-        # Create a fake section to fallback onto the permissive default values to grant to the owner
-        # noinspection PyTypeChecker
-        owner_group = PermissionGroup('Owner (auto)', self.config['Owner (auto)'], fallback=Permissive)
+                
+        if self.config.has_section('Owner (auto)'):
+            owner_group = PermissionGroup('Owner (auto)', self.config['Owner (auto)'], fallback=Permissive)
+            
+        else:
+            log.info("")
+            log.warning("[Owner (auto)] section not found in permissions.ini\n1.9.8_2-rc1 introduced a band-aid fixes to permission system which require [Owner (auto)] section in permissions.ini\nPlease consider copying over the [Owner (auto)] section from example_permissions.ini into your permissions.ini")
+            log.info("")
+            log.warning("Now the bot is falling back to using bugged owner permission")
+            log.info("")
+            # Create a fake section to fallback onto the default non-permissive values to grant to the owner emulating the old behavior
+            # noinspection PyTypeChecker
+            owner_group = PermissionGroup("Owner (auto)", configparser.SectionProxy(self.config, None))
+            
         if hasattr(grant_all, '__iter__'):
             owner_group.user_list = set(grant_all)
 

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -78,14 +78,10 @@ class Permissions:
             owner_group = PermissionGroup('Owner (auto)', self.config['Owner (auto)'], fallback=Permissive)
             
         else:
-            log.info("")
-            log.warning("[Owner (auto)] section not found in permissions.ini\n1.9.8_2-rc1 introduced a band-aid fixes to permission system which require [Owner (auto)] section in permissions.ini\nPlease consider copying over the [Owner (auto)] section from example_permissions.ini into your permissions.ini")
-            log.info("")
-            log.warning("Now the bot is falling back to using bugged owner permission")
-            log.info("")
+            log.info("[Owner (auto)] section not found, falling back to permissive default")
             # Create a fake section to fallback onto the default non-permissive values to grant to the owner emulating the old behavior
             # noinspection PyTypeChecker
-            owner_group = PermissionGroup("Owner (auto)", configparser.SectionProxy(self.config, None))
+            owner_group = PermissionGroup("Owner (auto)", configparser.SectionProxy(self.config, Permissive))
             
         if hasattr(grant_all, '__iter__'):
             owner_group.user_list = set(grant_all)
@@ -133,11 +129,7 @@ class Permissions:
 
 
 class PermissionGroup:
-    def __init__(self, name, section_data, fallback=None):
-        self.name = name
-        if fallback == None:
-            fallback = PermissionsDefaults
-            
+    def __init__(self, name, section_data, fallback=PermissionsDefaults):            
         self.command_whitelist = section_data.get('CommandWhiteList', fallback=fallback.CommandWhiteList)
         self.command_blacklist = section_data.get('CommandBlackList', fallback=fallback.CommandBlackList)
         self.ignore_non_voice = section_data.get('IgnoreNonVoice', fallback=fallback.IgnoreNonVoice)

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -129,7 +129,9 @@ class Permissions:
 
 
 class PermissionGroup:
-    def __init__(self, name, section_data, fallback=PermissionsDefaults):            
+    def __init__(self, name, section_data, fallback=PermissionsDefaults):
+        self.name = name
+        
         self.command_whitelist = section_data.get('CommandWhiteList', fallback=fallback.CommandWhiteList)
         self.command_blacklist = section_data.get('CommandBlackList', fallback=fallback.CommandBlackList)
         self.ignore_non_voice = section_data.get('IgnoreNonVoice', fallback=fallback.IgnoreNonVoice)


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
Added a warning and error handling about #1740. Falling back to old behavior when there are no owner perms in the file.

Also fixed some permission bug that escaped from sight because we turn owner_id into integer too late.

### Related issues (if applicable)
close #1766, close #1771, close #952
