### PR TITLE
General bugfixes

### DIFF
--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -166,14 +166,14 @@ class Config:
 
         if self.bound_channels:
             try:
-                self.bound_channels = set(x for x in self.bound_channels.split() if x)
+                self.bound_channels = set(x for x in self.bound_channels.replace(',', ' ').split() if x)
             except:
                 log.warning("BindToChannels data is invalid, will not bind to any channels")
                 self.bound_channels = set()
 
         if self.autojoin_channels:
             try:
-                self.autojoin_channels = set(x for x in self.autojoin_channels.split() if x)
+                self.autojoin_channels = set(x for x in self.autojoin_channels.replace(',', ' ').split() if x)
             except:
                 log.warning("AutojoinChannels data is invalid, will not autojoin any channels")
                 self.autojoin_channels = set()
@@ -184,9 +184,9 @@ class Config:
 
         self.delete_invoking = self.delete_invoking and self.delete_messages
 
-        self.bound_channels = set(int(item.replace(',', ' ').strip()) for item in self.bound_channels)
+        self.bound_channels = set(int(item) for item in self.bound_channels)
 
-        self.autojoin_channels = set(int(item.replace(',', ' ').strip()) for item in self.autojoin_channels)
+        self.autojoin_channels = set(int(item) for item in self.autojoin_channels)
 
         ap_path, ap_name = os.path.split(self.auto_playlist_file)
         apn_name, apn_ext = os.path.splitext(ap_name)

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -130,10 +130,12 @@ class URLPlaylistEntry(BasePlaylistEntry):
 
             # TODO: Better [name] fallbacks
             if 'channel' in data['meta']:
-                meta['channel'] = playlist.bot.get_channel(data['meta']['channel']['id'])
+                # int() it because persistent queue from pre-rewrite days saved ids as strings
+                meta['channel'] = playlist.bot.get_channel(int(data['meta']['channel']['id']))
 
             if 'author' in data['meta']:
-                meta['author'] = meta['channel'].guild.get_member(data['meta']['author']['id'])
+                # int() it because persistent queue from pre-rewrite days saved ids as strings
+                meta['author'] = meta['channel'].guild.get_member(int(data['meta']['author']['id']))
 
             entry = cls(playlist, url, title, duration, expected_filename, **meta)
             entry.filename = filename

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -132,10 +132,15 @@ class URLPlaylistEntry(BasePlaylistEntry):
             if 'channel' in data['meta']:
                 # int() it because persistent queue from pre-rewrite days saved ids as strings
                 meta['channel'] = playlist.bot.get_channel(int(data['meta']['channel']['id']))
-
-            if 'author' in data['meta']:
-                # int() it because persistent queue from pre-rewrite days saved ids as strings
-                meta['author'] = meta['channel'].guild.get_member(int(data['meta']['author']['id']))
+                if not meta['channel']:
+                    log.warning('Cannot find channel in an entry loaded from persistent queue. Chennel id: {}'.format(data['meta']['channel']['id']))
+                    meta.pop('channel')
+                elif 'author' in data['meta']:
+                    # int() it because persistent queue from pre-rewrite days saved ids as strings
+                    meta['author'] = meta['channel'].guild.get_member(int(data['meta']['author']['id']))
+                    if not meta['author']:
+                        log.warning('Cannot find author in an entry loaded from persistent queue. Author id: {}'.format(data['meta']['author']['id']))
+                        meta.pop('author')
 
             entry = cls(playlist, url, title, duration, expected_filename, **meta)
             entry.filename = filename

--- a/update.py
+++ b/update.py
@@ -14,9 +14,9 @@ def update_deps():
     print("Attempting to update dependencies...")
 
     try:
-        subprocess.check_call('{} -m pip install -U -r requirements.txt'.format(sys.executable), shell=True)
+        subprocess.check_call('"{}" -m pip install -U -r requirements.txt'.format(sys.executable), shell=True)
     except subprocess.CalledProcessError:
-        raise OSError("Could not update dependencies. You will need to run '{0} -m pip install -U -r requirements.txt' yourself.".format(sys.executable))
+        raise OSError("Could not update dependencies. You will need to run '\"{0}\" -m pip install -U -r requirements.txt' yourself.".format(sys.executable))
 
 def finalize():
     try:


### PR DESCRIPTION
It is a miracle that these bugs survived for some time.

After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
* Fix parts of Python path which contain spaces turns into args in the update script
> Parts of Python program path turns into args when the path to python executable contain spaces (such as `C:\Program Files (x86)\Python37-32\python.exe` on Windows).
* Fix loading persistent queues that are saved prior the rewrite
> In persistent queue generated from the old version of the bot, Ids of channels and authors are saved as strings. We passed data deserialized from json to discord.py without doing anything and that broke things (broke things beyond what I'd have imagined).
* BindtoChannels and AutojoinChannels ids can now be separated with only a single comma.
> Before this, `id,id` would break and might confuse people. The options said that it must be separated with spaces but looking from the code intent (which change commas to spaces and then remove) the above format *should have* work too. Let's be real here, even if it's clearly stated that you must separate it by spaces, there will be some people who use commas `id, id` to separate it because they don't know how to read and assume that you separate it like you normally separate it in the writing and then they made a typo (forgetting a space) and then they filed a bug report and we will have to waste time.

### Related issues (if applicable)

