### PR TITLE
Fixed skipping while the player paused prevent the player from playing next song and can't resume the player

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -580,6 +580,7 @@ class MusicBot(discord.Client):
 
         else: # Don't serialize for autoplaylist events
             await self.serialize_queue(player.voice_client.channel.guild)
+            player.play(_continue = True)
 
     async def on_player_entry_added(self, player, playlist, entry, **_):
         log.debug('Running on_player_entry_added')

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -580,7 +580,9 @@ class MusicBot(discord.Client):
 
         else: # Don't serialize for autoplaylist events
             await self.serialize_queue(player.voice_client.channel.guild)
-            player.play(_continue = True)
+
+        if not player.is_stopped and not player.is_dead:
+            player.play(_continue=True)
 
     async def on_player_entry_added(self, player, playlist, entry, **_):
         log.debug('Running on_player_entry_added')

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2058,6 +2058,7 @@ class MusicBot(discord.Client):
 
         if skips_remaining <= 0:
             player.skip()  # check autopause stuff here
+            # @TheerapakG: Check for pausing state in the player.py make more sense
             return Response(
                 self.str.get('cmd-skip-reply-skipped-1', 'Your skip for `{0}` was acknowledged.\nThe vote to skip has been passed.{1}').format(
                     current_entry.title,

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -50,8 +50,8 @@ class BasePlaylistEntry(Serializable):
 
         else:
             # If we request a ready future, let's ensure that it'll actually resolve at one point.
-            asyncio.ensure_future(self._download())
             self._waiting_futures.append(future)
+            asyncio.ensure_future(self._download())
 
         log.debug('Created future for {0}'.format(self.filename))
         return future

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -191,9 +191,6 @@ class MusicPlayer(EventEmitter, Serializable):
             # unless ffmpeg is doing something highly questionable
             self.emit('error', player=self, entry=entry, ex=self._stderr_future.exception())
 
-        if not self.is_stopped and not self.is_dead:
-            self.play(_continue=True)
-
         if not self.bot.config.save_videos and entry:
             if not isinstance(entry, StreamPlaylistEntry):
                 if any([entry.filename == e.filename for e in self.playlist.entries]):
@@ -243,7 +240,7 @@ class MusicPlayer(EventEmitter, Serializable):
         """
             Plays the next entry from the playlist, or resumes playback of the current entry if paused.
         """
-        if self.is_paused:
+        if self.is_paused and self._current_player:
             return self.resume()
 
         if self.is_dead:


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
1. Fixed skipping while the player paused prevent the player from playing next song and can't resume the player
> Note:
> 1. This fix only ensures that the player doesn't fall into a non-interactive state in the event described above and might not produce a desirable behavior.
> 2. player paused mean the player state (`player.state`) is `MusicPlayerState.PAUSED`, not limited to pausing via cmd_pause coroutine (e.g. autopause)
> 3. skipping means the entry is skipped via invoking the `player.skip()`, not limited to pausing via cmd_skip coroutine (e.g. SkipWhenAbsent perms set to true)

### Related issues (if applicable)

