### PR TITLE
Another perms-related PR

### DIFF
--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -7,6 +7,8 @@ import discord
 
 log = logging.getLogger(__name__)
 
+# PermissionDefaults class define the strictest value of each permissions
+# Permissive class define the permissive value of each permissions
 
 class PermissionsDefaults:
     perms_file = 'config/permissions.ini'
@@ -79,9 +81,9 @@ class Permissions:
             
         else:
             log.info("[Owner (auto)] section not found, falling back to permissive default")
-            # Create a fake section to fallback onto the default non-permissive values to grant to the owner emulating the old behavior
+            # Create a fake section to fallback onto the default permissive values to grant to the owner
             # noinspection PyTypeChecker
-            owner_group = PermissionGroup("Owner (auto)", configparser.SectionProxy(self.config, Permissive))
+            owner_group = PermissionGroup("Owner (auto)", configparser.SectionProxy(self.config, "Owner (auto)"), fallback=Permissive)
             
         if hasattr(grant_all, '__iter__'):
             owner_group.user_list = set(grant_all)

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -143,11 +143,11 @@ class PermissionGroup:
         self.max_playlist_length = section_data.get('MaxPlaylistLength', fallback=fallback.MaxPlaylistLength)
         self.max_search_items = section_data.get('MaxSearchItems', fallback=fallback.MaxSearchItems)
 
-        self.allow_playlists = section_data.get('AllowPlaylists', fallback=fallback.AllowPlaylists)
-        self.instaskip = section_data.get('InstaSkip', fallback=fallback.InstaSkip)
-        self.remove = section_data.get('Remove', fallback=fallback.Remove)
-        self.skip_when_absent = section_data.get('SkipWhenAbsent', fallback=fallback.SkipWhenAbsent)
-        self.bypass_karaoke_mode = section_data.get('BypassKaraokeMode', fallback=fallback.BypassKaraokeMode)
+        self.allow_playlists = section_data.getboolean('AllowPlaylists', fallback=fallback.AllowPlaylists)
+        self.instaskip = section_data.getboolean('InstaSkip', fallback=fallback.InstaSkip)
+        self.remove = section_data.getboolean('Remove', fallback=fallback.Remove)
+        self.skip_when_absent = section_data.getboolean('SkipWhenAbsent', fallback=fallback.SkipWhenAbsent)
+        self.bypass_karaoke_mode = section_data.getboolean('BypassKaraokeMode', fallback=fallback.BypassKaraokeMode)
 
         self.extractors = section_data.get('Extractors', fallback=fallback.Extractors)
 
@@ -195,26 +195,6 @@ class PermissionGroup:
         if int(self.max_search_items) > 100:
             log.warning('Max search items can\'t be larger than 100. Setting to 100.')
             self.max_search_items = 100
-
-        self.allow_playlists = configparser.RawConfigParser.BOOLEAN_STATES.get(
-            self.allow_playlists, PermissionsDefaults.AllowPlaylists
-        )
-
-        self.instaskip = configparser.RawConfigParser.BOOLEAN_STATES.get(
-            self.instaskip, PermissionsDefaults.InstaSkip
-        )
-
-        self.remove = configparser.RawConfigParser.BOOLEAN_STATES.get(
-            self.remove, PermissionsDefaults.Remove
-        )
-
-        self.skip_when_absent = configparser.RawConfigParser.BOOLEAN_STATES.get(
-            self.skip_when_absent, PermissionsDefaults.SkipWhenAbsent
-        )
-
-        self.bypass_karaoke_mode = configparser.RawConfigParser.BOOLEAN_STATES.get(
-            self.bypass_karaoke_mode, PermissionsDefaults.BypassKaraokeMode
-        )
 
     @staticmethod
     def _process_list(seq, *, split=' ', lower=True, strip=', ', coerce=str, rcoerce=list):


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
1. Change boolean conversion in permissions.py to make it similar to how we do it in options.py
> Reduce LOC (bytes are precious) and it's similar to how the config.py does this.
>
> This apparently also fixed owner boolean problem
2. The owner now get real permissive value if there's no section in the permission file
> In the previous version, according to perms command output, the owner is given default, considerably restrictive perms. So in on of my PR that is in 1.9.8_2 do just that and people seems to confuse so this should make people less confused.

### Related issues (if applicable)

