### PR TITLE
Blank string fixes

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2607,7 +2607,11 @@ class MusicBot(discord.Client):
         command, *args = message_content.split(' ')  # Uh, doesn't this break prefixes with spaces in them (it doesn't, config parser already breaks them)
         command = command[len(self.config.command_prefix):].lower().strip()
 
-        args = ' '.join(args).lstrip(' ').split(' ')
+        # [] produce [''] which is not what we want (it break things)
+        if args:
+            args = ' '.join(args).lstrip(' ').split(' ')
+        else:
+            args = []
 
         handler = getattr(self, 'cmd_' + command, None)
         if not handler:


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
This is a `bugfix` PR.

1. This fix command that has only 1 argument and the argument has a default value behaving in an unintended way (does not use the default value) when no command argument passed

commands that fall into this criterion (afaik, tested):
> listids
> objgraph
> clean

This does not seem to be a bug that needs immediate notice and can be postponed for merging until the next big release because this bug does not have any serious effect at all except needs of few more keystroke. (that's why it take me so long to get to this item on my bucket list despite there was [report on the server](https://discordapp.com/channels/129489631539494912/134938212916396032/507640286277664796) since November)

### Related issues (if applicable)
