### PR TITLE
Fix "module 'aiohttp' has no attribute 'Timeout'" raised when queueing unrecognized source using the play command

### DIFF
--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -60,12 +60,12 @@ def paginate(content, *, length=DISCORD_MSG_CHAR_LIMIT, reserve=0):
 
 
 async def get_header(session, url, headerfield=None, *, timeout=5):
-    with aiohttp.Timeout(timeout):
-        async with session.head(url) as response:
-            if headerfield:
-                return response.headers.get(headerfield)
-            else:
-                return response.headers
+    req_timeout = aiohttp.ClientTimeout(total = timeout)
+    async with session.head(url, timeout = req_timeout) as response:
+        if headerfield:
+            return response.headers.get(headerfield)
+        else:
+            return response.headers
 
 
 def md5sum(filename, limit=0):


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5/3.6

----

### Description
This fix means that get_header is now performing correctly and as such, anything that uses it (most of the time it's when the streams are incorrectly queued using play command or queueing some audio from an unknown source or dropbox) should now do things as intended.

### Related issues (if applicable)

