### PR TITLE
Storagesize

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -81,6 +81,10 @@ WhiteListCheck = no
 SkipsRequired = 4
 SkipRatio = 0.5
 
+# Specify a value in bytes to set a limit on the size of your audio cache. Once exceeded, it will
+# delete the oldest songs that are cached. If left blank, there is no limit to the size of your cache.
+StorageLimit =
+
 # Determines if downloaded videos will be saved to the audio_cache folder. If this is yes,
 # they will not be redownloaded if found in the folder and queued again. Else, videos will
 # be downloaded to the folder temporarily to play, then deleted after to avoid filling space.

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -35,7 +35,7 @@ from .config import Config, ConfigDefaults
 from .permissions import Permissions, PermissionsDefaults
 from .aliases import Aliases, AliasesDefault
 from .constructs import SkipState, Response
-from .utils import load_file, write_file, fixg, ftimedelta, _func_, _get_variable
+from .utils import load_file, write_file, fixg, ftimedelta, _func_, _get_variable, folder_size
 from .spotify import Spotify
 from .json import Json
 
@@ -1097,6 +1097,19 @@ class MusicBot(discord.Client):
         """
         player.autoplaylist = list(set(self.autoplaylist))
         return Response(self.str.get('cmd-resetplaylist-response', '\N{OK HAND SIGN}'), delete_after=15)
+
+    async def cmd_space(self, message, channel, command=None):
+        """
+        Usage:
+            {command_prefix}space
+        Prints a message showing how much space is being used in the cache
+        and the storage limit if it is specified
+        """
+        if not self.config.storage_limit:
+            return Response("`{0}` bytes being used in the audio cache".format(str(folder_size('audio_cache'))))
+        else:
+            return Response("`{0}/{1}` bytes being used in the audio cache".format(str(folder_size('audio_cache')), int(self.config.storage_limit)), delete_after=45)
+
 
     async def cmd_help(self, message, channel, command=None):
         """

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -51,6 +51,7 @@ class Config:
         self.default_volume = config.getfloat('MusicBot', 'DefaultVolume', fallback=ConfigDefaults.default_volume)
         self.skips_required = config.getint('MusicBot', 'SkipsRequired', fallback=ConfigDefaults.skips_required)
         self.skip_ratio_required = config.getfloat('MusicBot', 'SkipRatio', fallback=ConfigDefaults.skip_ratio_required)
+        self.storage_limit = config.get('MusicBot', 'StorageLimit', fallback=ConfigDefaults.storage_limit)
         self.save_videos = config.getboolean('MusicBot', 'SaveVideos', fallback=ConfigDefaults.save_videos)
         self.now_playing_mentions = config.getboolean('MusicBot', 'NowPlayingMentions', fallback=ConfigDefaults.now_playing_mentions)
         self.auto_summon = config.getboolean('MusicBot', 'AutoSummon', fallback=ConfigDefaults.auto_summon)
@@ -319,6 +320,7 @@ class ConfigDefaults:
     default_volume = 0.15
     skips_required = 4
     skip_ratio_required = 0.5
+    storage_limit = None
     save_videos = True
     now_playing_mentions = False
     auto_summon = True

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -337,7 +337,7 @@ class URLPlaylistEntry(BasePlaylistEntry):
                             "Refer to StorageLimit in options.ini.")
                         break
                     log.info("Audio cache at over capacity. Deleting oldest song.")
-                    # remove the oldest file that isn't on the queue
+                    # remove the oldest file that isn't in the set of queued songs
                     removed_file = remove_oldest_file(self.download_folder, songs_on_queue)
                     if removed_file == None:
                         # if oldest song is still on the queue, the songs after are also on the queue

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import logging
 import aiohttp
@@ -147,6 +148,25 @@ def objdiff(obj1, obj2, *, access_attr=None, depth=0):
 
 def color_supported():
     return hasattr(sys.stderr, "isatty") and sys.stderr.isatty()
+
+def folder_size(dir):
+    total_size = 0
+    for dirpath, dirnames, filenames in os.walk(dir):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            total_size += os.path.getsize(fp)
+    return total_size
+
+def remove_oldest_file(dir, restricted_set):
+    list_of_files = os.listdir(dir)
+    full_path = [(dir + "/{0}").format(x) for x in list_of_files if x not in restricted_set]
+
+    if len(full_path) >= 1:
+        oldest_file = min(full_path, key=os.path.getctime)
+        os.remove(oldest_file)
+        return oldest_file
+    else:
+        return None
 
 def _func_():
     # emulate __func__ from C++


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
This pull request targets #1584 and #1588. 

1. StorageLimit is a new configurable option in options.ini and the bot tracks the size of the audio cache after every download. I added another variable to config.py to track this field and also added this field to example_options.ini. If the storage size is exceeded, it deletes the least recently downloaded songs with the exception of songs on the queue and the song currently being played. It also takes into consideration if a single media file exceeds the entire storage limit. The functions used to calculate folder size and find the oldest media file are implemented in utils.py.

2. !space is a new command that prints out a message stating the size of the audio_cache folder and the storage size limit if specified.

### Related issues (if applicable)
#1584
#1588
