### PR TITLE
Fix audio np counter bug

### DIFF
--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -7,7 +7,7 @@ import audioop
 import subprocess
 import re
 
-from discord import FFmpegPCMAudio, PCMVolumeTransformer
+from discord import FFmpegPCMAudio, PCMVolumeTransformer, AudioSource
 
 from enum import Enum
 from array import array
@@ -96,6 +96,18 @@ class MusicPlayerState(Enum):
     def __str__(self):
         return self.name
 
+class SourcePlaybackCounter(AudioSource):
+    def __init__(self, source, progress = 0):
+        self._source = source
+        self.progress = progress
+
+    def read(self):
+        self.progress += 1
+        return self._source.read()
+
+    def get_progress(self):
+        return self.progress * 0.02
+
 
 class MusicPlayer(EventEmitter, Serializable):
     def __init__(self, bot, voice_client, playlist):
@@ -114,6 +126,8 @@ class MusicPlayer(EventEmitter, Serializable):
         self._current_player = None
         self._current_entry = None
         self._stderr_future = None
+
+        self._source = None
 
         self.playlist.on('entry-added', self.on_entry_added)
 
@@ -185,6 +199,7 @@ class MusicPlayer(EventEmitter, Serializable):
             self._kill_current_player()
 
         self._current_entry = None
+        self._source = None
 
         if self._stderr_future.done() and self._stderr_future.exception():
             # I'm not sure that this would ever not be done if it gets to this point
@@ -272,17 +287,19 @@ class MusicPlayer(EventEmitter, Serializable):
 
                 log.ffmpeg("Creating player with options: {} {} {}".format(boptions, aoptions, entry.filename))
 
-                source = PCMVolumeTransformer(
-                    FFmpegPCMAudio(
-                        entry.filename,
-                        before_options=boptions,
-                        options=aoptions,
-                        stderr=subprocess.PIPE
-                    ),
-                    self.volume
+                self._source = SourcePlaybackCounter(
+                    PCMVolumeTransformer(
+                        FFmpegPCMAudio(
+                            entry.filename,
+                            before_options=boptions,
+                            options=aoptions,
+                            stderr=subprocess.PIPE
+                        ),
+                        self.volume
+                    )
                 )
-                log.debug('Playing {0} using {1}'.format(source, self.voice_client))
-                self.voice_client.play(source, after=self._playback_finished)
+                log.debug('Playing {0} using {1}'.format(self._source, self.voice_client))
+                self.voice_client.play(self._source, after=self._playback_finished)
 
                 self._current_player = self.voice_client
 
@@ -294,7 +311,7 @@ class MusicPlayer(EventEmitter, Serializable):
 
                 stderr_thread = Thread(
                     target=filter_stderr,
-                    args=(self._current_player._player.source.original._process, self._stderr_future),
+                    args=(self._source._source.original._process, self._stderr_future),
                     name="stderr reader"
                 )
 
@@ -364,8 +381,8 @@ class MusicPlayer(EventEmitter, Serializable):
 
     @property
     def progress(self):
-        if self._current_player:
-            return round(self._current_player._player.loops * 0.02)
+        if self._source:
+            return self._source.get_progress()
             # TODO: Properly implement this
             #       Correct calculation should be bytes_read/192k
             #       192k AKA sampleRate * (bitDepth / 8) * channelCount

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -102,8 +102,10 @@ class SourcePlaybackCounter(AudioSource):
         self.progress = progress
 
     def read(self):
-        self.progress += 1
-        return self._source.read()
+        res = self._source.read()
+        if res:
+            self.progress += 1
+        return res
 
     def get_progress(self):
         return self.progress * 0.02


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Fix #1738, where pausing the music and then resuming it resets the np counter. This fix is a replica of how progress is got in [TheerapakG/ModuBot:alpha](https://github.com/TheerapakG/ModuBot/tree/alpha). However, this is not a proper implementation (based on the TODO) as it relies on the fact that read() reads 20ms worth of audio but there's really nothing we can do if the underlying source does not spit out 20ms worth of audio as it would then be wrong to the documentation anyway.


### Related issues (if applicable)

