### PR TITLE
Add more options for how the bot send now playing messages

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -66,25 +66,25 @@ AllowUnboundServers = no
 # enabled, this option will take priority.
 AutojoinChannels =
 
-# Direct message now playing messages instead of sending them into the guild. Now playing messages
-# for automatic entries are unaffected and follows NowPlayingChannels config. The bot will not
-# delete direct messages
+# Send direct messages for now playing messages instead of sending them into the guild. They are
+# sent to the user who added the media being played. Now playing messages for automatic entries
+# are unaffected and follows NowPlayingChannels config. The bot will not delete direct messages.
 DMNowPlaying = no
 
-# Disable now playing messages for entries automatically added by the bot.
+# Disable now playing messages for entries automatically added by the bot, via the autoplaylist.
 DisableNowPlayingAutomatic = no
 
 # For now playing messages that are unaffected by DMNowPlaying and DisableNowPlayingAutomatic,
 # determine which channels the bot is going to output now playing messages to. If this is not
-# specified for a server, now playing message for manually added entry will be send in the same
-# channel that users used the command to add that entry and now playing messages for automatically 
-# added entries will be send to the same channel that the last now playing message was sent to if
+# specified for a server, now playing message for manually added entries will be sent in the same
+# channel that users used the command to add that entry, and now playing messages for automatically 
+# added entries will be sent to the same channel that the last now playing message was sent to if
 # this is not specified for a server if possible. Specifying more than one channel for a server
 # forces the bot to pick only one channel from the list to send messages to.
 NowPlayingChannels =
 
 # The bot would try to delete (or edit) previously sent now playing messages by default. If you
-# don't want the bot to delete them (for keeping log of what have been played), turn this 
+# don't want the bot to delete them (for keeping a log of what has been played), turn this 
 # option off.
 DeleteNowPlaying = yes
 

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -66,16 +66,24 @@ AllowUnboundServers = no
 # enabled, this option will take priority.
 AutojoinChannels =
 
-# Determine which channels the bot is going to output now playing messages to. If this is
-# not specified for a server, the bot will output now playing message for manually added
-# entry in the channel that users used the command to add that entry. The bot will also
-# try to guess where the now playing messages for automatically added entries should go
-# if this is not specified for a server, which might not possible in some cases. Specifying
-# more than one channel for a server forces the bot to pick only one channel from the list
-# to send messages to
+# Direct message now playing messages instead of them into the guild. Now playing messages
+# for automatic entries are unaffected and follows NowPlayingChannels config. The bot will not
+# delete direct messages
+DMNowPlaying = no
+
+# Disable now playing messages for entries automatically added by the bot.
+DisableNowPlayingAutomatic = no
+
+# For now playing messages that are unaffected by DMNowPlaying and DisableNowPlayingAutomatic,
+# determine which channels the bot is going to output now playing messages to. If this is not
+# specified for a server, now playing message for manually added entry will be send in the same
+# channel that users used the command to add that entry and now playing messages for automatically 
+# added entries will be send to the same channel that the last now playing message was sent to if
+# this is not specified for a server if possible. Specifying more than one channel for a server
+# forces the bot to pick only one channel from the list to send messages to.
 NowPlayingChannels =
 
-# The bot try to delete (or edit) previously sent now playing messages by default. If you
+# The bot would try to delete (or edit) previously sent now playing messages by default. If you
 # don't want the bot to delete them (for keeping log of what have been played), turn this 
 # option off.
 DeleteNowPlaying = yes

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -66,7 +66,7 @@ AllowUnboundServers = no
 # enabled, this option will take priority.
 AutojoinChannels =
 
-# Direct message now playing messages instead of them into the guild. Now playing messages
+# Direct message now playing messages instead of sending them into the guild. Now playing messages
 # for automatic entries are unaffected and follows NowPlayingChannels config. The bot will not
 # delete direct messages
 DMNowPlaying = no

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -487,6 +487,16 @@ class MusicBot(discord.Client):
                 entry.title, player.voice_client.channel.name)
 
         if newmsg:
+            if self.config.dm_nowplaying and author:
+                if not author.dm_channel:
+                    await author.create_dm()
+                channel = author.dm_channel
+                await self.safe_send_message(channel, newmsg)
+                return
+
+            if self.config.no_nowplaying_auto and not author:
+                return
+
             guild = player.voice_client.guild
             last_np_msg = self.server_specific_data[guild]['last_np_msg']
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -488,10 +488,7 @@ class MusicBot(discord.Client):
 
         if newmsg:
             if self.config.dm_nowplaying and author:
-                if not author.dm_channel:
-                    await author.create_dm()
-                channel = author.dm_channel
-                await self.safe_send_message(channel, newmsg)
+                await self.safe_send_message(author, newmsg)
                 return
 
             if self.config.no_nowplaying_auto and not author:

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -47,6 +47,8 @@ class Config:
         self.bound_channels = config.get('Chat', 'BindToChannels', fallback=ConfigDefaults.bound_channels)
         self.unbound_servers = config.getboolean('Chat', 'AllowUnboundServers', fallback=ConfigDefaults.unbound_servers)
         self.autojoin_channels =  config.get('Chat', 'AutojoinChannels', fallback=ConfigDefaults.autojoin_channels)
+        self.dm_nowplaying = config.getboolean('Chat', 'DMNowPlaying', fallback=ConfigDefaults.dm_nowplaying)
+        self.no_nowplaying_auto = config.getboolean('Chat', 'DisableNowPlayingAutomatic', fallback=ConfigDefaults.no_nowplaying_auto)
         self.nowplaying_channels =  config.get('Chat', 'NowPlayingChannels', fallback=ConfigDefaults.nowplaying_channels)
         self.delete_nowplaying = config.getboolean('Chat', 'DeleteNowPlaying', fallback=ConfigDefaults.delete_nowplaying)
 
@@ -324,6 +326,8 @@ class ConfigDefaults:
     bound_channels = set()
     unbound_servers = False
     autojoin_channels = set()
+    dm_nowplaying = False
+    no_nowplaying_auto = False
     nowplaying_channels = set()
     delete_nowplaying = True
 


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Add more options for how the bot send now playing messages. These options are:
DMNowPlaying - Direct message now playing messages instead of sending them into the guild
DisableNowPlayingAutomatic - Disable now playing messages for entries automatically added by the bot


### Related issues (if applicable)

