### PR TITLE
Improvement guild nick and user id's in perm command

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2404,24 +2404,39 @@ class MusicBot(discord.Client):
         return Response("Sent a message with a list of IDs.", delete_after=20)
 
 
-    async def cmd_perms(self, author, user_mentions, channel, guild, permissions):
+    async def cmd_perms(self, author, user_mentions, channel, guild, message, permissions):
         """
         Usage:
             {command_prefix}perms [@user]
-
         Sends the user a list of their permissions, or the permissions of the user specified.
         """
 
-        lines = ['Command permissions in %s\n' % guild.name, '```', '```']
+        no_mentions = len(self.config.command_prefix) + 5 # there's probably a better way to do this but /shrug
+        mentions = len(self.config.command_prefix) + 6
 
         if user_mentions:
             user = user_mentions[0]
             permissions = self.permissions.for_user(user)
+            
+        if not user_mentions and (len(message.content) == no_mentions):
+            user = author
+            
+        if not user_mentions and (len(message.content) > mentions):
+            user = guild.get_member_named(message.content[mentions:])
+            if user == None:
+                try:
+                    user = await self.fetch_user(message.content[mentions:])
+                except discord.NotFound:
+                    return Response("Invalid user ID or server nickname, please double check all typing and try again.", reply=False, delete_after=30)
+                    
+        if user == author:
+            lines = ['Command permissions in %s\n' % guild.name, '```', '```']
+        else:
+            lines = ['Command permissions for {} in {}\n'.format(user, guild.name), '```', '```']
 
         for perm in permissions.__dict__:
             if perm in ['user_list'] or permissions.__dict__[perm] == set():
                 continue
-
             lines.insert(len(lines) - 1, "%s: %s" % (perm, permissions.__dict__[perm]))
 
         await self.safe_send_message(author, '\n'.join(lines))

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2404,35 +2404,33 @@ class MusicBot(discord.Client):
         return Response("Sent a message with a list of IDs.", delete_after=20)
 
 
-    async def cmd_perms(self, author, user_mentions, channel, guild, message, permissions):
+    async def cmd_perms(self, author, user_mentions, channel, guild, message, permissions, target=None):
         """
         Usage:
             {command_prefix}perms [@user]
         Sends the user a list of their permissions, or the permissions of the user specified.
         """
 
-        no_mentions = len(self.config.command_prefix) + 5 # there's probably a better way to do this but /shrug
-        mentions = len(self.config.command_prefix) + 6
-
         if user_mentions:
             user = user_mentions[0]
-            permissions = self.permissions.for_user(user)
             
-        if not user_mentions and (len(message.content) == no_mentions):
+        if not user_mentions and not target:
             user = author
             
-        if not user_mentions and (len(message.content) > mentions):
-            user = guild.get_member_named(message.content[mentions:])
+        if not user_mentions and target:
+            user = guild.get_member_named(target)
             if user == None:
                 try:
-                    user = await self.fetch_user(message.content[mentions:])
+                    user = await self.fetch_user(target)
                 except discord.NotFound:
                     return Response("Invalid user ID or server nickname, please double check all typing and try again.", reply=False, delete_after=30)
+
+        permissions = self.permissions.for_user(user)    
                     
         if user == author:
             lines = ['Command permissions in %s\n' % guild.name, '```', '```']
         else:
-            lines = ['Command permissions for {} in {}\n'.format(user, guild.name), '```', '```']
+            lines = ['Command permissions for {} in {}\n'.format(user.name, guild.name), '```', '```']
 
         for perm in permissions.__dict__:
             if perm in ['user_list'] or permissions.__dict__[perm] == set():


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Adds the ability to type `{command_prefix}perms 335677038830682112` or `{command_prefix}perms AutumnClove` eg user id's and server nicknames


### Related issues (if applicable)
#1888 
