### PR TITLE
Fix for showing negative estimated time for entries w/o duration information from ytdl

### DIFF
--- a/config/i18n/en.json
+++ b/config/i18n/en.json
@@ -38,6 +38,7 @@
     "cmd-play-song-reply": "Enqueued `%s` to be played. Position in queue: %s",
     "cmd-play-next": "Up next!",
     "cmd-play-eta": " - estimated time until playing: %s",
+    "cmd-play-eta-error": " - cannot estimate time until playing",
     "cmd-play-badextractor": "You do not have permission to play media from this service.",
     "cmd-stream-limit": "You have reached your enqueued song limit ({0})",
     "cmd-stream-success": "Streaming.",

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1841,7 +1841,7 @@ class MusicBot(discord.Client):
 
             # TODO: Fix timedelta garbage with util function
             song_progress = ftimedelta(timedelta(seconds=player.progress))
-            song_total = ftimedelta(timedelta(seconds=player.current_entry.duration))
+            song_total = ftimedelta(timedelta(seconds=player.current_entry.duration)) if player.current_entry.duration != None else '(no duration data)'
 
             streaming = isinstance(player.current_entry, StreamPlaylistEntry)
             prog_str = ('`[{progress}]`' if streaming else '`[{progress}/{total}]`').format(
@@ -1851,7 +1851,7 @@ class MusicBot(discord.Client):
 
             # percentage shows how much of the current song has already been played
             percentage = 0.0
-            if player.current_entry.duration > 0:
+            if player.current_entry.duration and player.current_entry.duration > 0:
                 percentage = player.progress / player.current_entry.duration
 
             # create the actual bar
@@ -2242,7 +2242,7 @@ class MusicBot(discord.Client):
         if player.is_playing:
             # TODO: Fix timedelta garbage with util function
             song_progress = ftimedelta(timedelta(seconds=player.progress))
-            song_total = ftimedelta(timedelta(seconds=player.current_entry.duration))
+            song_total = ftimedelta(timedelta(seconds=player.current_entry.duration)) if player.current_entry.duration != None else '(no duration data)'
             prog_str = '`[%s/%s]`' % (song_progress, song_total)
 
             if player.current_entry.meta.get('channel', False) and player.current_entry.meta.get('author', False):

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1568,6 +1568,7 @@ class MusicBot(discord.Client):
                 reply_text %= (btext, position)
 
             else:
+                reply_text %= (btext, position)
                 try:
                     time_until = await player.playlist.estimate_time_until(position, player)
                     reply_text += (self.str.get('cmd-play-eta', ' - estimated time until playing: %s') % ftimedelta(time_until))

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1570,12 +1570,11 @@ class MusicBot(discord.Client):
             else:
                 try:
                     time_until = await player.playlist.estimate_time_until(position, player)
-                    reply_text += self.str.get('cmd-play-eta', ' - estimated time until playing: %s')
+                    reply_text += (self.str.get('cmd-play-eta', ' - estimated time until playing: %s') % ftimedelta(time_until))
+                except exceptions.InvalidDataError:
+                    reply_text += self.str.get('cmd-play-eta-error', ' - cannot estimate time until playing')
                 except:
                     traceback.print_exc()
-                    time_until = ''
-
-                reply_text %= (btext, position, ftimedelta(time_until))
 
         return Response(reply_text, delete_after=30)
 

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -323,29 +323,30 @@ class URLPlaylistEntry(BasePlaylistEntry):
             else:
                 # Move the temporary file to it's final location.
                 os.rename(unhashed_fname, self.filename)
+        
+        if self.duration == None:
+            # Get duration from the file after downloaded
+            args = [
+                'ffprobe', 
+                '-i', self.filename, 
+                '-show_entries', 'format=duration', 
+                '-v', 'quiet', 
+                '-of', 'csv="p=0"'
+            ]
 
-        # Get duration from the file after downloaded
-        args = [
-            'ffprobe', 
-            '-i', self.filename, 
-            '-show_entries', 'format=duration', 
-            '-v', 'quiet', 
-            '-of', 'csv="p=0"'
-        ]
+            output = await self.run_command(args)
+            output = output.decode("utf-8")
 
-        output = await self.run_command(args)
-        output = output.decode("utf-8")
-
-        try:
-            self.duration = float(output)
-        except ValueError:
-            # @TheerapakG: If somehow it is not string of float
-            if not self.duration:
-                log.error('Cannot extract duration of downloaded entry, invalid output from ffprobe.'
-                          'This does not affect the ability of the bot. However, estimated time for this entry'
-                          'will not be unavailable and estimated time of the queue will also not be available'
-                          'until this entry got removed.'
-                          'entry file: {}'.format(self.filename))
+            try:
+                self.duration = float(output)
+            except ValueError:
+                # @TheerapakG: If somehow it is not string of float
+                if not self.duration:
+                    log.error('Cannot extract duration of downloaded entry, invalid output from ffprobe.'
+                            'This does not affect the ability of the bot. However, estimated time for this entry'
+                            'will not be unavailable and estimated time of the queue will also not be available'
+                            'until this entry got removed.'
+                            'entry file: {}'.format(self.filename))
 
 
 class StreamPlaylistEntry(BasePlaylistEntry):

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -88,10 +88,11 @@ class URLPlaylistEntry(BasePlaylistEntry):
         self.url = url
         self.title = title
         self.duration = duration
-        log.info('Cannot extract duration of the entry. This does not affect the ability of the bot.'
-                 'However, estimated time for this entry will not be unavailable and estimated time'
-                 'of the queue will also not be available until this entry got downloaded.'
-                 'entry name: {}'.format(self.title))
+        if duration == None: # duration could be 0
+            log.info('Cannot extract duration of the entry. This does not affect the ability of the bot.'
+                     'However, estimated time for this entry will not be unavailable and estimated time'
+                     'of the queue will also not be available until this entry got downloaded.'
+                     'entry name: {}'.format(self.title))
         self.expected_filename = expected_filename
         self.meta = meta
         self.aoptions = '-vn'

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -10,6 +10,12 @@ from .constructs import Serializable
 from .exceptions import ExtractionError
 from .utils import get_header, md5sum
 
+# optionally using pymediainfo instead of ffprobe if presents
+try:
+    import pymediainfo
+except:
+    pymediainfo = None
+
 log = logging.getLogger(__name__)
 
 
@@ -89,9 +95,9 @@ class URLPlaylistEntry(BasePlaylistEntry):
         self.title = title
         self.duration = duration
         if duration == None: # duration could be 0
-            log.info('Cannot extract duration of the entry. This does not affect the ability of the bot.'
-                     'However, estimated time for this entry will not be unavailable and estimated time'
-                     'of the queue will also not be available until this entry got downloaded.'
+            log.info('Cannot extract duration of the entry. This does not affect the ability of the bot. '
+                     'However, estimated time for this entry will not be unavailable and estimated time '
+                     'of the queue will also not be available until this entry got downloaded.\n'
                      'entry name: {}'.format(self.title))
         self.expected_filename = expected_filename
         self.meta = meta
@@ -221,6 +227,41 @@ class URLPlaylistEntry(BasePlaylistEntry):
                 else:
                     await self._really_download()
 
+            if self.duration == None:
+                if pymediainfo:
+                    try:
+                        mediainfo = pymediainfo.MediaInfo.parse(self.filename)
+                        self.duration = (mediainfo.tracks[0].duration)/1000
+                    except:
+                        self.duration = None
+
+                else:
+                    args = [
+                        'ffprobe', 
+                        '-i', self.filename, 
+                        '-show_entries', 'format=duration', 
+                        '-v', 'quiet', 
+                        '-of', 'csv="p=0"'
+                    ]
+
+                    output = await self.run_command(' '.join(args))
+                    output = output.decode("utf-8")
+
+                    try:
+                        self.duration = float(output)
+                    except ValueError:
+                        # @TheerapakG: If somehow it is not string of float
+                        self.duration = None
+
+                if not self.duration:
+                    log.error('Cannot extract duration of downloaded entry, invalid output from ffprobe or pymediainfo. '
+                              'This does not affect the ability of the bot. However, estimated time for this entry '
+                              'will not be unavailable and estimated time of the queue will also not be available '
+                              'until this entry got removed.\n'
+                              'entry file: {}'.format(self.filename))
+                else:
+                    log.debug('Get duration of {} as {} seconds by inspecting it directly'.format(self.filename, self.duration))
+
             if self.playlist.bot.config.use_experimental_equalization:
                 try:
                     mean, maximum = await self.get_mean_volume(self.filename)
@@ -323,30 +364,6 @@ class URLPlaylistEntry(BasePlaylistEntry):
             else:
                 # Move the temporary file to it's final location.
                 os.rename(unhashed_fname, self.filename)
-        
-        if self.duration == None:
-            # Get duration from the file after downloaded
-            args = [
-                'ffprobe', 
-                '-i', self.filename, 
-                '-show_entries', 'format=duration', 
-                '-v', 'quiet', 
-                '-of', 'csv="p=0"'
-            ]
-
-            output = await self.run_command(args)
-            output = output.decode("utf-8")
-
-            try:
-                self.duration = float(output)
-            except ValueError:
-                # @TheerapakG: If somehow it is not string of float
-                if not self.duration:
-                    log.error('Cannot extract duration of downloaded entry, invalid output from ffprobe.'
-                            'This does not affect the ability of the bot. However, estimated time for this entry'
-                            'will not be unavailable and estimated time of the queue will also not be available'
-                            'until this entry got removed.'
-                            'entry file: {}'.format(self.filename))
 
 
 class StreamPlaylistEntry(BasePlaylistEntry):

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -358,9 +358,6 @@ class StreamPlaylistEntry(BasePlaylistEntry):
         self.title = title
         self.destination = destination
         self.duration = None
-        log.info('Cannot estimate duration for stream, estimated time of the queue will not be available'
-                 'until this stream got removed from the queue.'
-                 'stream name: {}'.format(self.title))
         self.meta = meta
 
         if self.destination:

--- a/musicbot/exceptions.py
+++ b/musicbot/exceptions.py
@@ -24,6 +24,10 @@ class CommandError(MusicbotException):
 class ExtractionError(MusicbotException):
     pass
 
+# Something is wrong about data
+class InvalidDataError(MusicbotException):
+    pass
+
 # The no processing entry type failed and an entry was a playlist/vice versa
 # TODO: Add typing options instead of is_playlist
 class WrongEntryTypeError(ExtractionError):

--- a/musicbot/opus_loader.py
+++ b/musicbot/opus_loader.py
@@ -10,6 +10,4 @@ def load_opus_lib():
     except OSError:
          pass
 
-
     raise RuntimeError('Could not load an opus lib.')
-

--- a/musicbot/opus_loader.py
+++ b/musicbot/opus_loader.py
@@ -17,7 +17,7 @@ def load_opus_lib(opus_libs=OPUS_LIBS):
     try:
         opus._load_default()
         return
-    except OSError:
+    except (OSError, AttributeError):
         pass
 
     raise RuntimeError('Could not load an opus lib. Tried %s' % (', '.join(opus_libs)))

--- a/musicbot/opus_loader.py
+++ b/musicbot/opus_loader.py
@@ -14,4 +14,10 @@ def load_opus_lib(opus_libs=OPUS_LIBS):
         except OSError:
             pass
 
+    try:
+        opus._load_default()
+        return
+    except OSError:
+        pass
+
     raise RuntimeError('Could not load an opus lib. Tried %s' % (', '.join(opus_libs)))

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -344,7 +344,7 @@ class Playlist(EventEmitter, Serializable):
         """
             (very) Roughly estimates the time till the queue will 'position'
         """
-        if any(e.duration for e in islice(self.entries, position - 1) == None):
+        if any(e.duration == None for e in islice(self.entries, position - 1)):
             raise InvalidDataError('no duration data')
         else:
             estimated_time = sum(e.duration for e in islice(self.entries, position - 1))


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Warn no duration data instead of showing negative estimated time. This also adds ffprobe-ing or use pymediainfo if available to get the duration of downloaded entries.


### Related issues (if applicable)

