### PR TITLE
Fix load_opus_lib()

### DIFF
--- a/musicbot/opus_loader.py
+++ b/musicbot/opus_loader.py
@@ -1,17 +1,13 @@
 from discord import opus
 
-OPUS_LIBS = ['libopus-0.x86.dll', 'libopus-0.x64.dll', 'libopus-0.dll', 'libopus.so.0', 'libopus.0.dylib']
-
-
-def load_opus_lib(opus_libs=OPUS_LIBS):
+def load_opus_lib():
     if opus.is_loaded():
-        return True
+        return
 
-    for opus_lib in opus_libs:
-        try:
-            opus.load_opus(opus_lib)
-            return
-        except OSError:
-            pass
+    try:
+        opus._load_default()
+        return
+    except OSError:
+         pass
 
-    raise RuntimeError('Could not load an opus lib. Tried %s' % (', '.join(opus_libs)))
+    raise RuntimeError('Could not load an opus lib.')


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Due to a change in discord.py, we now have to call the function that loads opus (it happened by default before).
Commit:
Rapptz/discord.py@fedf26b#diff-13bd70296c0893a14f18d701b84d6459L103-R118

### Related issues (if applicable)

