### PR TITLE
Porting bot to Python 3.8 and bugfixes

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -191,19 +191,7 @@ class MusicBot(discord.Client):
             return
 
         shandler = logging.StreamHandler(stream=sys.stdout)
-        shandler.setFormatter(colorlog.LevelFormatter(
-            fmt = {
-                'DEBUG': '{log_color}[{levelname}:{module}] {message}',
-                'INFO': '{log_color}{message}',
-                'WARNING': '{log_color}{levelname}: {message}',
-                'ERROR': '{log_color}[{levelname}:{module}] {message}',
-                'CRITICAL': '{log_color}[{levelname}:{module}] {message}',
-
-                'EVERYTHING': '{log_color}[{levelname}:{module}] {message}',
-                'NOISY': '{log_color}[{levelname}:{module}] {message}',
-                'VOICEDEBUG': '{log_color}[{levelname}:{module}][{relativeCreated:.9f}] {message}',
-                'FFMPEG': '{log_color}[{levelname}:{module}][{relativeCreated:.9f}] {message}'
-            },
+        sformatter = colorlog.LevelFormatter(
             log_colors = {
                 'DEBUG':    'cyan',
                 'INFO':     'white',
@@ -215,10 +203,23 @@ class MusicBot(discord.Client):
                 'NOISY':      'white',
                 'FFMPEG':     'bold_purple',
                 'VOICEDEBUG': 'purple',
-        },
+            },
             style = '{',
             datefmt = ''
-        ))
+        )
+        sformatter.fmt = {
+            'DEBUG': '{log_color}[{levelname}:{module}] {message}',
+            'INFO': '{log_color}{message}',
+            'WARNING': '{log_color}{levelname}: {message}',
+            'ERROR': '{log_color}[{levelname}:{module}] {message}',
+            'CRITICAL': '{log_color}[{levelname}:{module}] {message}',
+
+            'EVERYTHING': '{log_color}[{levelname}:{module}] {message}',
+            'NOISY': '{log_color}[{levelname}:{module}] {message}',
+            'VOICEDEBUG': '{log_color}[{levelname}:{module}][{relativeCreated:.9f}] {message}',
+            'FFMPEG': '{log_color}[{levelname}:{module}][{relativeCreated:.9f}] {message}'
+        }
+        shandler.setFormatter(sformatter)
         shandler.setLevel(self.config.debug_level)
         logging.getLogger(__package__).addHandler(shandler)
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -181,14 +181,14 @@ class Config:
 
         if self.bound_channels:
             try:
-                self.bound_channels = set(x for x in self.bound_channels.replace(',', ' ').split() if x)
+                self.bound_channels = set(int(x) for x in self.bound_channels.replace(',', ' ').split() if x)
             except:
                 log.warning("BindToChannels data is invalid, will not bind to any channels")
                 self.bound_channels = set()
 
         if self.autojoin_channels:
             try:
-                self.autojoin_channels = set(x for x in self.autojoin_channels.replace(',', ' ').split() if x)
+                self.autojoin_channels = set(int(x) for x in self.autojoin_channels.replace(',', ' ').split() if x)
             except:
                 log.warning("AutojoinChannels data is invalid, will not autojoin any channels")
                 self.autojoin_channels = set()
@@ -198,17 +198,13 @@ class Config:
                 self.nowplaying_channels = set(int(x) for x in self.nowplaying_channels.replace(',', ' ').split() if x)
             except:
                 log.warning("NowPlayingChannels data is invalid, will use the default behavior for all servers")
-                self.autojoin_channels = set()
+                self.nowplaying_channels = set()
 
         self._spotify = False
         if self.spotify_clientid and self.spotify_clientsecret:
             self._spotify = True
 
         self.delete_invoking = self.delete_invoking and self.delete_messages
-
-        self.bound_channels = set(int(item) for item in self.bound_channels)
-
-        self.autojoin_channels = set(int(item) for item in self.autojoin_channels)
 
         ap_path, ap_name = os.path.split(self.auto_playlist_file)
         apn_name, apn_ext = os.path.splitext(ap_name)

--- a/musicbot/opus_loader.py
+++ b/musicbot/opus_loader.py
@@ -8,6 +8,6 @@ def load_opus_lib():
         opus._load_default()
         return
     except OSError:
-         pass
+        pass
 
     raise RuntimeError('Could not load an opus lib.')

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -140,7 +140,7 @@ class Playlist(EventEmitter, Serializable):
             except Exception as e:
                 log.error('Could not extract information from {} ({}), falling back to direct'.format(song_url, e), exc_info=True)
 
-        if info.get('is_live') is None and info.get('extractor', None) is not 'generic':  # wew hacky
+        if info.get('is_live') is None and info.get('extractor', None) != 'generic':  # wew hacky
             raise ExtractionError("This is not a stream.")
 
         dest_url = song_url

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pynacl==1.2.1
+pynacl==1.3.0
 discord.py[voice]==1.2.4
 pip
 youtube_dl

--- a/run.py
+++ b/run.py
@@ -176,7 +176,10 @@ def finalize_logging():
     dlog = logging.getLogger('discord')
     dlh = logging.StreamHandler(stream=sys.stdout)
     dlh.terminator = ''
-    dlh.setFormatter(logging.Formatter('.'))
+    try:
+        dlh.setFormatter(logging.Formatter('.'))
+    except ValueError:
+        dlh.setFormatter(logging.Formatter('.', validate = False)) # pylint: disable=unexpected-keyword-arg
     dlog.addHandler(dlh)
 
 

--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,7 @@ declare -A python3=( ["0"]=`python3 -c 'import sys; version=sys.version_info[:3]
 PYTHON35_VERSION=`python3.5 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[2]))' || { echo "no py35"; }`
 PYTHON36_VERSION=`python3.6 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[1]))' || { echo "no py36"; }`
 PYTHON37_VERSION=`python3.7 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[1]))' || { echo "no py37"; }`
+PYTHON38_VERSION=`python3.8 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[1]))' || { echo "no py38"; }`
 
 
 if [ "${python[0]}" -eq "3" ]; then # Python = 3
@@ -47,6 +48,11 @@ fi
 
 if [ "$PYTHON37_VERSION" -eq "7" ]; then # Python3.7 = 3.7
     python3.7 run.py
+    exit
+fi
+
+if [ "$PYTHON38_VERSION" -eq "8" ]; then # Python3.8 = 3.8
+    python3.8 run.py
     exit
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,7 @@ declare -A python3=( ["0"]=`python3 -c 'import sys; version=sys.version_info[:3]
 PYTHON35_VERSION=`python3.5 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[2]))' || { echo "no py35"; }`
 PYTHON36_VERSION=`python3.6 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[1]))' || { echo "no py36"; }`
 PYTHON37_VERSION=`python3.7 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[1]))' || { echo "no py37"; }`
+PYTHON38_VERSION=`python3.8 -c 'import sys; version=sys.version_info[:3]; print("{0}".format(version[1]))' || { echo "no py38"; }`
 
 
 if [ "${python[0]}" -eq "3" ]; then # Python = 3
@@ -47,6 +48,11 @@ fi
 
 if [ "$PYTHON37_VERSION" -eq "7" ]; then # Python3.7 = 3.7
     python3.7 update.py
+    exit
+fi
+
+if [ "$PYTHON38_VERSION" -eq "8" ]; then # Python3.8 = 3.8
+    python3.8 update.py
     exit
 fi
 


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
This PR circumvent logging formatter from validating formattings, use an equality check instead of an identity check (where appropriate) to stop Python from producing SyntaxWarning and add Python 3.8 version check to bash scripts.

This also fix bot incorrectly setting autojoin to an empty set when nowplaying config is invalid instead of setting nowplaying to an empty set.

This PR should allow the bot to be able to run with Python 3.8 on any platform

This change was tested on Python 3.8.0/Windows, Python 3.7.1/Windows, Python 3.5.4/Windows, Python 3.8.0/Ubuntu 18.04, Python 3.6.8/Ubuntu 18.04


### Related issues (if applicable)

