### PR TITLE
Normalize audio with loudnorm instead of volumedetect.

### DIFF
--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -218,8 +218,7 @@ class URLPlaylistEntry(BasePlaylistEntry):
 
             if self.playlist.bot.config.use_experimental_equalization:
                 try:
-                    mean, maximum = await self.get_mean_volume(self.filename)
-                    aoptions = '-af "volume={}dB"'.format((maximum * -1))
+                    aoptions = await self.get_mean_volume(self.filename)
                 except Exception as e:
                     log.error('There as a problem with working out EQ, likely caused by a strange installation of FFmpeg. '
                               'This has not impacted the ability for the bot to work, but will mean your tracks will not be equalised.')
@@ -268,24 +267,53 @@ class URLPlaylistEntry(BasePlaylistEntry):
 
     async def get_mean_volume(self, input_file):
         log.debug('Calculating mean volume of {0}'.format(input_file))
-        cmd = '"' + self.get('ffmpeg') + '" -i "' + input_file + '" -af "volumedetect" -f null /dev/null'
+        cmd = '"' + self.get('ffmpeg') + '" -i "' + input_file + '" -af loudnorm=I=-24.0:LRA=7.0:TP=-2.0:linear=true:print_format=json -f null /dev/null'
         output = await self.run_command(cmd)
         output = output.decode("utf-8")
+        log.debug(output)
         # print('----', output)
-        mean_volume_matches = re.findall(r"mean_volume: ([\-\d\.]+) dB", output)
-        if (mean_volume_matches):
-            mean_volume = float(mean_volume_matches[0])
-        else:
-            mean_volume = float(0)
 
-        max_volume_matches = re.findall(r"max_volume: ([\-\d\.]+) dB", output)
-        if (max_volume_matches):
-            max_volume = float(max_volume_matches[0])
+        I_matches = re.findall(r'"input_i" : "([-]?([0-9]*\.[0-9]+))",', output)
+        if (I_matches):
+            log.debug('I_matches={}'.format(I_matches[0][0]))
+            I = float(I_matches[0][0])
         else:
-            max_volume = float(0)
+            log.debug('Could not parse I in normalise json.')
+            I = float(0)
 
-        log.debug('Calculated mean volume as {0}'.format(mean_volume))
-        return mean_volume, max_volume
+        LRA_matches = re.findall(r'"input_lra" : "([-]?([0-9]*\.[0-9]+))",', output)
+        if (LRA_matches):
+            log.debug('LRA_matches={}'.format(LRA_matches[0][0]))
+            LRA = float(LRA_matches[0][0])
+        else:
+            log.debug('Could not parse LRA in normalise json.')
+            LRA = float(0)
+
+        TP_matches = re.findall(r'"input_tp" : "([-]?([0-9]*\.[0-9]+))",', output)
+        if (TP_matches):
+            log.debug('TP_matches={}'.format(TP_matches[0][0]))
+            TP = float(TP_matches[0][0])
+        else:
+            log.debug('Could not parse TP in normalise json.')
+            TP = float(0)
+
+        thresh_matches = re.findall(r'"input_thresh" : "([-]?([0-9]*\.[0-9]+))",', output)
+        if (thresh_matches):
+            log.debug('thresh_matches={}'.format(thresh_matches[0][0]))
+            thresh = float(thresh_matches[0][0])
+        else:
+            log.debug('Could not parse thresh in normalise json.')
+            thresh = float(0)
+
+        offset_matches = re.findall(r'"target_offset" : "([-]?([0-9]*\.[0-9]+))', output)
+        if (offset_matches):
+            log.debug('offset_matches={}'.format(offset_matches[0][0]))
+            offset = float(offset_matches[0][0])
+        else:
+            log.debug('Could not parse offset in normalise json.')
+            offset = float(0)
+
+        return '-af loudnorm=I=-24.0:LRA=7.0:TP=-2.0:linear=true:measured_I={}:measured_LRA={}:measured_TP={}:measured_thresh={}:offset={}'.format(I, LRA, TP, thresh, offset)
 
     # noinspection PyShadowingBuiltins
     async def _really_download(self, *, hash=False):

--- a/musicbot/opus_loader.py
+++ b/musicbot/opus_loader.py
@@ -1,17 +1,13 @@
 from discord import opus
 
-OPUS_LIBS = ['libopus-0.x86.dll', 'libopus-0.x64.dll', 'libopus-0.dll', 'libopus.so.0', 'libopus.0.dylib']
-
-
-def load_opus_lib(opus_libs=OPUS_LIBS):
+def load_opus_lib():
     if opus.is_loaded():
-        return True
+        return
 
-    for opus_lib in opus_libs:
-        try:
-            opus.load_opus(opus_lib)
-            return
-        except OSError:
-            pass
+    try:
+        opus._load_default()
+        return
+    except OSError:
+         pass
 
-    raise RuntimeError('Could not load an opus lib. Tried %s' % (', '.join(opus_libs)))
+    raise RuntimeError('Could not load an opus lib.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pynacl==1.2.1
-discord.py[voice]
+git+https://github.com/Rapptz/discord.py@master#egg=discord.py[voice]
 pip
 youtube_dl
 colorlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pynacl==1.2.1
-git+https://github.com/Rapptz/discord.py@master#egg=discord.py[voice]
+discord.py[voice]==1.2.4
 pip
 youtube_dl
 colorlog


### PR DESCRIPTION
The current volumedetect approach measures the loudest part of the file and increases the gain until it's just shy of clipping. This is a good first approach, but a bit naive for actually targeting a certain loudness. More dynamic tracks will still seem much quieter than tracks continually pushing the loudness ceiling. 
loudnorm takes more time to process audio than volumedetect, but in return will properly normalize to a target loudness using the EBU R128 loudness standard. See: http://k.ylo.ph/2016/04/04/loudnorm.html