### PR TITLE
fix check for python3 to not only check for 3.5

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -28,15 +28,10 @@ if [ "${python3[0]}" -eq "5" ]; then # Python3 = 3.5
             python3 run.py
             exit
     fi
-    elif [ "${python3[1]}" -ge "6" ]; then # Python >= 3.6
-        python run.py
+    elif [ "${python3[0]}" -ge "6" ]; then # Python >= 3.6
+        python3 run.py
         exit
     fi
-fi
-
-if [ "${python3[0]}" -ge "6" ]; then # Python3 >= 3.6
-    python3 run.py
-    exit
 fi
 
 if [ "$PYTHON35_VERSION" -ge "3" ]; then # Python3.5 > 3.5.3

--- a/run.sh
+++ b/run.sh
@@ -28,6 +28,10 @@ if [ "${python3[0]}" -eq "5" ]; then # Python3 = 3.5
             python3 run.py
             exit
     fi
+    elif [ "${python3[1]}" -ge "6" ]; then # Python >= 3.6
+        python run.py
+        exit
+    fi
 fi
 
 if [ "${python3[0]}" -ge "6" ]; then # Python3 >= 3.6


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Checks if python3 version is 5, and if not, also actually checks for version 6 or higher, as it was supposed to in the first place.