### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -140,7 +140,7 @@ class Playlist(EventEmitter, Serializable):
             except Exception as e:
                 log.error('Could not extract information from {} ({}), falling back to direct'.format(song_url, e), exc_info=True)
 
-        if info.get('is_live') is None and info.get('extractor', None) is not 'generic':  # wew hacky
+        if info.get('is_live') is None and info.get('extractor', None) != 'generic':  # wew hacky
             raise ExtractionError("This is not a stream.")
 
         dest_url = song_url


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. On n Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.5.3 or higher

----

### Description



### Related issues (if applicable)

