### PR TITLE
optimize docker build time by caching pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:edge
 
 # Add project source
 WORKDIR /usr/src/musicbot
-COPY . ./
+COPY requirements.txt ./
 
 # Install dependencies
 RUN apk update \
@@ -28,7 +28,7 @@ RUN apk update \
 \
 # Clean up build dependencies
 && apk del .build-deps
-
+COPY . ./
 # Create volume for mapping the config
 VOLUME /usr/src/musicbot/config
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pynacl==1.2.1
-discord.py[voice]==1.2.4
+discord.py[voice]==1.2.5
 pip
 youtube_dl
 colorlog


### PR DESCRIPTION
https://www.aptible.com/documentation/deploy/tutorials/faq/dockerfile-caching/pip-dockerfile-caching.html

After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
optimizes docker build times by caching pip install
