### PR TITLE
Change from outdated version, to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pynacl==1.3.0
-discord.py[voice]==1.2.5
+discord.py[voice]
 pip
 youtube_dl
 colorlog


### PR DESCRIPTION
This prevents the keyword argument deny_new when starting.

After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
Pull request to update to discord.py[voice] latest to prevent deny_new argument.


### Related issues (if applicable)

