### PR TITLE
docs: fix simple typo, divison -> division

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2096,7 +2096,7 @@ class MusicBot(discord.Client):
 
         num_voice = sum(1 for m in voice_channel.members if not (
             m.voice.deaf or m.voice.self_deaf or m == self.user))
-        if num_voice == 0: num_voice = 1 # incase all users are deafened, to avoid divison by zero
+        if num_voice == 0: num_voice = 1 # incase all users are deafened, to avoid division by zero
 
         num_skips = player.skip_state.add_skipper(author.id, message)
 


### PR DESCRIPTION
There is a small typo in musicbot/bot.py.

Should read `division` rather than `divison`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md