### PR TITLE
Simplify autopause logic

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2801,6 +2801,10 @@ class MusicBot(discord.Client):
 
         log.info("Joining {0.guild.name}/{0.name}".format(author.voice.channel))
 
+        # edge case: we're summoned by a deafened member and should pause on join
+        if self.config.auto_pause:
+            player.once("play", lambda player, **_: self._autopause(player))
+
         return Response(
             self.str.get("cmd-summon-reply", "Connected to `{0.name}`").format(
                 author.voice.channel

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -4168,7 +4168,7 @@ class MusicBot(discord.Client):
         def set_autopause(value):
             self.server_specific_data[player.voice_client.guild]["auto_paused"] = value
 
-        if self._check_if_empty(player.voice_client.channel):  # channel is not empty
+        if self._check_if_empty(player.voice_client.channel):  # channel is empty
             if not auto_paused and player.is_playing:
                 log.info(
                     autopause_msg.format(

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -292,22 +292,15 @@ class MusicBot(discord.Client):
             dlogger.addHandler(dhandler)
 
     @staticmethod
-    def _check_if_empty(
-        vchannel: discord.abc.GuildChannel, *, excluding_me=True, excluding_deaf=True
-    ):
-        def is_active(member):
-            if excluding_me and member == vchannel.guild.me:
-                return False
+    def _check_if_empty(vchannel: discord.abc.GuildChannel, *, deaf_as_inactive=True):
+        def is_inactive(member):
+            return (
+                member.bot
+                or (not member.voice)
+                or (deaf_as_inactive and (member.voice.deaf or member.voice.self_deaf))
+            )
 
-            if excluding_deaf and any([member.voice.deaf, member.voice.self_deaf]):
-                return False
-
-            if member.bot:
-                return False
-
-            return True
-
-        return not any(is_active(m) for m in vchannel.members)
+        return all(is_inactive(m) for m in vchannel.members)
 
     def _autopause(self, player):
         if self._check_if_empty(player.voice_client.channel):

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -379,7 +379,9 @@ class MusicBot(discord.Client):
 
                     if self.config.auto_playlist:
                         if self.config.auto_pause:
-                            player.once("play", lambda player, **_: self._autopause(player))
+                            player.once(
+                                "play", lambda player, **_: self._autopause(player)
+                            )
                         if not player.playlist.entries:
                             await self.on_player_finished_playing(player)
 
@@ -484,7 +486,9 @@ class MusicBot(discord.Client):
             return channel.guild.voice_client
         else:
             client = await channel.connect(timeout=60, reconnect=True)
-            await channel.guild.change_voice_state(channel=channel, self_mute=False, self_deaf=True)
+            await channel.guild.change_voice_state(
+                channel=channel, self_mute=False, self_deaf=True
+            )
             return client
 
     async def disconnect_voice_client(self, guild):
@@ -4190,7 +4194,6 @@ class MusicBot(discord.Client):
 
                 set_autopause(False)
                 player.resume()
-
 
     async def on_guild_update(self, before: discord.Guild, after: discord.Guild):
         if before.region != after.region:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -307,7 +307,7 @@ class MusicBot(discord.Client):
 
             return True
 
-        return not sum(1 for m in vchannel.members if check(m))
+        return not any(check(m) for m in vchannel.members)
 
     async def _join_startup_channels(self, channels, *, autosummon=True):
         joined_servers = set()
@@ -4175,17 +4175,10 @@ class MusicBot(discord.Client):
         autopause_msg = "{state} in {channel.guild.name}/{channel.name} {reason}"
         auto_paused = self.server_specific_data[channel.guild]["auto_paused"]
 
-        def is_active(member):
-            return member.voice and not any(
-                [member.voice.deaf, member.voice.self_deaf, member.bot]
-            )
-
         def set_autopause(value):
             self.server_specific_data[player.voice_client.guild]["auto_paused"] = value
 
-        if any(
-            is_active(m) for m in player.voice_client.channel.members
-        ):  # channel is not empty
+        if self._check_if_empty(player.voice_client.channel):  # channel is not empty
             if auto_paused and player.is_paused:
                 log.info(
                     autopause_msg.format(


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher
- [x] Auto-formatted changes using `black`

----

### Description

The autopause logic in `on_voice_state_update` is quite complex and distinguishes a lot of different cases, but in the end (as far as I can tell), there are just two possible scenarios: The channel is effectively empty, so we pause, or the channel is not empty, so we resume if we previously auto-paused (or we left the channel, but that's handled separately before).

This patch simplifies that logic and also re-uses existing functions to check for empty channels and perform the auto-pause. It should not change visible behaviour except for some slight changes in info log messages. I have verified that autopause continues to work as expected.

To be honest, I'm not entirely sure when the lines `player.once("play", lambda player, **_: self._autopause(player))` (l.382 & l.736) trigger and what they do, but the code executed for those should not be changed by this patch.

**Update:** Figured it out, should work as expected. Also fixed an edge-case where summoning the bot to a deaf-only channel did not autopause.

### Related issues (if applicable)

