### PR TITLE
Add docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ config/autoplaylist.txt
 config/autoplaylist_removed.txt
 config/whitelist.txt
 config/blacklist.txt
+
+docker-compose.yml

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,8 @@
+services:
+  musicbot:
+    build: .
+    volumes:
+      - ./config:/musicbot/config/
+      - ./audio_cache:/musicbot/audio_cache
+      - ./data:/musicbot/data
+      - ./logs:/musicbot/logs


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description

This adds a simple `docker-compose.example.yml` file, which users can copy to `docker-compose.yml` to easily get MusicBot up and running with Docker. The compose file includes a `build` directive to build the local Dockerfile, and a list of `mounts` ported from said Dockerfile.

I named the file `docker-compose.example.yml` and added `docker-compose.yml` to `.gitignore` in case someone wants to make changes to the mount points or add environment variables locally without accidentally adding them to the git repo.


### Related issues (if applicable)

n/a  