### PR TITLE
Fix SoundCloud sets

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -484,7 +484,9 @@ class MusicBot(discord.Client):
             return channel.guild.voice_client
         else:
             client = await channel.connect(timeout=60, reconnect=True)
-            await channel.guild.change_voice_state(channel=channel, self_mute=False, self_deaf=True)
+            await channel.guild.change_voice_state(
+                channel=channel, self_mute=False, self_deaf=True
+            )
             return client
 
     async def disconnect_voice_client(self, guild):

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -319,7 +319,7 @@ class Playlist(EventEmitter, Serializable):
             gooditems.reverse()
         return gooditems
 
-    async def async_process_sc_bc_playlist(self, playlist_url, *, head, **meta):
+    async def async_process_sc_bc_playlist(self, playlist_url, *, head=False, **meta):
         """
         Processes soundcloud set and bancdamp album links from `playlist_url` in a questionable, async fashion.
 


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.5.3 or higher

----

### Description
For whatever reason, and I'm unsure when head would even get set, as youtube playlists have the same head requirement but doesn't have this set anywhere.
This PR aims to resolve this head error by setting it to False if it's not set prior.

### Related issues (if applicable)
Closes #2271 
