### PR TITLE
Update most guides to Python 3.8+

### DIFF
--- a/_docs/installing/debian.md
+++ b/_docs/installing/debian.md
@@ -18,7 +18,7 @@ sudo apt-get install git libopus-dev libffi-dev libsodium-dev ffmpeg -y
 sudo apt-get install build-essential libncursesw5-dev libgdbm-dev libc6-dev zlib1g-dev libsqlite3-dev tk-dev libssl-dev openssl -y
 
 # If using Debian Stretch or lower, you need to install Python too using...
-sudo apt-get install python3.5 python3-pip -y
+sudo apt-get install python3.8 python3-pip -y
 
 # Clone the MusicBot to your home directory
 cd ~
@@ -26,8 +26,8 @@ git clone https://github.com/Just-Some-Bots/MusicBot.git MusicBot -b master
 cd MusicBot
 
 # Install dependencies
-sudo -H python3.5 -m pip install --upgrade pip
-sudo -H python3.5 -m pip install --upgrade -r requirements.txt
+sudo -H python3.8 -m pip install --upgrade pip
+sudo -H python3.8 -m pip install --upgrade -r requirements.txt
 ~~~
 
-After this, you can find a folder called `MusicBot` inside your home directory. [Configure]({{ site.baseurl }}/using/configuration) it, and then run `./run.sh` to start the bot.
+After this, you can find a folder called `MusicBot` inside your home directory. [Configure]({{ site.baseurl }}/using/configuration) it, and then run `bash ./run.sh` to start the bot.

--- a/_docs/installing/debian.md
+++ b/_docs/installing/debian.md
@@ -17,8 +17,24 @@ sudo apt-get upgrade -y
 sudo apt-get install git libopus-dev libffi-dev libsodium-dev ffmpeg -y
 sudo apt-get install build-essential libncursesw5-dev libgdbm-dev libc6-dev zlib1g-dev libsqlite3-dev tk-dev libssl-dev openssl -y
 
-# If using Debian Stretch or lower, you need to install Python too using...
-sudo apt-get install python3.8 python3-pip -y
+# Install Python 3.8
+mkdir pytemp
+cd pytemp
+wget https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tgz
+tar zxf Python-3.8.7.tgz
+cd Python-3.8.7
+./configure --enable-optimizations
+make -j4
+sudo make altinstall
+cd ..
+
+# Install pip
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3.8 get-pip.py
+
+# Remove temporary python directory
+cd ..
+rm -r pytemp
 
 # Clone the MusicBot to your home directory
 cd ~

--- a/_docs/installing/openbsd.md
+++ b/_docs/installing/openbsd.md
@@ -12,7 +12,7 @@ WARNING: If you have the py3-PyNaCl package installed, the final `pip install` c
 
 ~~~ bash
 # Install Python and libraries available as packages
-doas pkg_add python # select version 3.7.4
+doas pkg_add python # select version 3.8 or above
 doas pkg_add py3-aiohttp youtube-dl ffmpeg libsodium git
 
 # Ensure pip is set up

--- a/_docs/installing/raspbian.md
+++ b/_docs/installing/raspbian.md
@@ -15,10 +15,31 @@ sudo apt-get update -y
 sudo apt-get upgrade -y
 
 # Install dependencies
-sudo apt install python3-pip
 sudo apt install git
 sudo apt install libopus-dev
 sudo apt install ffmpeg
+sudo apt-get install -y build-essential tk-dev libncurses5-dev \
+libncursesw5-dev libreadline6-dev libdb5.3-dev libgdbm-dev libsqlite3-dev \
+libssl-dev libbz2-dev libexpat1-dev liblzma-dev zlib1g-dev libffi-dev
+
+# Install Python 3.8
+mkdir pytemp
+cd pytemp
+wget https://www.python.org/ftp/python/3.8.7/Python-3.8.7.tgz
+tar zxf Python-3.8.7.tgz
+cd Python-3.8.7
+./configure --enable-optimizations
+make -j4
+sudo make altinstall
+cd ..
+
+# Install pip
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3.8 get-pip.py
+
+# Remove temporary python directory
+cd ..
+rm -r pytemp
 
 # Clone the MusicBot
 cd ~
@@ -27,4 +48,4 @@ cd MusicBot
 sudo python3 -m pip install --upgrade -r requirements.txt
 ```
 
-After this, you can find a folder called `MusicBot` inside your home directory. [Configure]({{ site.baseurl }}/using/configuration) it, and then run `./run.sh` to start the bot.
+After this, you can find a folder called `MusicBot` inside your home directory. [Configure]({{ site.baseurl }}/using/configuration) it, and then run `bash ./run.sh` to start the bot.

--- a/_docs/installing/raspbian.md
+++ b/_docs/installing/raspbian.md
@@ -45,7 +45,7 @@ rm -r pytemp
 cd ~
 git clone https://github.com/Just-Some-Bots/MusicBot.git MusicBot -b master
 cd MusicBot
-sudo python3 -m pip install --upgrade -r requirements.txt
+sudo python3.8 -m pip install --upgrade -r requirements.txt
 ```
 
 After this, you can find a folder called `MusicBot` inside your home directory. [Configure]({{ site.baseurl }}/using/configuration) it, and then run `bash ./run.sh` to start the bot.

--- a/_docs/installing/ubuntu.md
+++ b/_docs/installing/ubuntu.md
@@ -12,11 +12,6 @@ Installing MusicBot on Ubuntu via the command line is the **recommended way to i
 
 ~~~ bash
 
-# Install Python 3.7 and add external repositories (only if you haven't got any python versions installed)
-sudo add-apt-repository ppa:deadsnakes/ppa
-sudo apt-get update
-sudo apt-get install python3.7 -y
-
 # Install build tools
 sudo apt-get install build-essential unzip -y
 sudo apt-get install software-properties-common -y
@@ -39,22 +34,29 @@ sudo python3 -m pip install -U -r requirements.txt
 ## Ubuntu 18.04
 
 ~~~ bash
+# Add external repositories
+sudo add-apt-repository ppa:deadsnakes/ppa
+
 # Install build tools
 sudo apt-get install build-essential unzip -y
 sudo apt-get install software-properties-common -y
 
 # Install system dependencies
 sudo apt-get update -y
-sudo apt-get install git ffmpeg libopus-dev libffi-dev libsodium-dev python3-pip 
+sudo apt-get install git ffmpeg libopus-dev libffi-dev libsodium-dev python3.8
 sudo apt-get upgrade -y
+
+# Install pip
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+python3.8 get-pip.py
 
 # Clone the MusicBot to your home directory
 git clone https://github.com/Just-Some-Bots/MusicBot.git ~/MusicBot -b master
 cd ~/MusicBot
 
 # Install Python dependencies
-sudo python3 -m pip install -U pip
-sudo python3 -m pip install -U -r requirements.txt
+sudo python3.8 -m pip install -U pip
+sudo python3.8 -m pip install -U -r requirements.txt
 ~~~
 
 ## Ubuntu 16.04
@@ -70,50 +72,21 @@ sudo add-apt-repository ppa:deadsnakes/ppa -y
 
 # Install system dependencies
 sudo apt-get update -y
-sudo apt-get install git ffmpeg libopus-dev libffi-dev libsodium-dev python3.6 -y
+sudo apt-get install git ffmpeg libopus-dev libffi-dev libsodium-dev python3.8 -y
 sudo apt-get upgrade -y
 
 # Install pip
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python3.6 get-pip.py
+python3.8 get-pip.py
 
 # Clone the MusicBot to your home directory
 git clone https://github.com/Just-Some-Bots/MusicBot.git ~/MusicBot -b master
 cd ~/MusicBot
 
 # Install Python dependencies
-sudo python3.6 -m pip install -U pip
-sudo python3.6 -m pip install -U -r requirements.txt 
+sudo python3.8 -m pip install -U pip
+sudo python3.8 -m pip install -U -r requirements.txt 
 ~~~
 
-## Ubuntu 14.04
 
-~~~ bash
-# Install build tools
-sudo apt-get install build-essential unzip -y
-sudo apt-get install software-properties-common -y
-
-# Add external repositories
-sudo add-apt-repository ppa:deadsnakes/ppa -y
-sudo add-apt-repository ppa:mc3man/trusty-media -y
-sudo add-apt-repository ppa:chris-lea/libsodium -y
-
-# Install system dependencies
-sudo apt-get update -y
-sudo apt-get install git python3.6 libav-tools libopus-dev libffi-dev libsodium-dev -y
-sudo apt-get upgrade -y
-
-# Install pip
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-python3.6 get-pip.py
-
-# Clone the MusicBot to your home directory
-git clone https://github.com/Just-Some-Bots/MusicBot.git ~/MusicBot -b master
-cd ~/MusicBot
-
-# Install Python dependencies
-sudo python3.6 -m pip install -U pip
-sudo python3.6 -m pip install -U -r requirements.txt 
-~~~
-
-After doing those commands, you can [configure]({{ site.baseurl }}/using/configuration) the bot and then run it using `sudo ./run.sh`.
+After doing those commands, you can [configure]({{ site.baseurl }}/using/configuration) the bot and then run it using `bash ./run.sh`.

--- a/_docs/installing/windows.md
+++ b/_docs/installing/windows.md
@@ -10,8 +10,8 @@ order: 2
 
 MusicBot can be installed on Windows 7 through 11, though it requires installing some programs on your computer first.
 
-1. Install [Python 3.7](https://www.python.org/ftp/python/3.7.0/python-3.7.0.exe).
-2. During the setup, tick `Install launcher for all users (recommended)` and `Add Python 3.7 to PATH` when prompted.
+1. Install [Python 3.10](https://www.python.org/ftp/python/3.10.1/python-3.10.1-amd64.exe).
+2. During the setup, tick `Install launcher for all users (recommended)` and `Add Python 3.10 to PATH` when prompted.
 3. Install [Git for Windows](http://gitforwindows.org/).
 4. During the setup, tick `Git from the command line and also 3rd-party software`, `Checkout Windows-style, commit Unix-style endings`, and `Use MinTTY (the default terminal MSYS2)`.
 5. Open Git Bash by right-clicking an empty space inside of a folder (e.g My Documents) and clicking `Git Bash here`.

--- a/_docs/installing/windows.md
+++ b/_docs/installing/windows.md
@@ -10,8 +10,8 @@ order: 2
 
 MusicBot can be installed on Windows 7 through 11, though it requires installing some programs on your computer first.
 
-1. Install [Python 3.10](https://www.python.org/ftp/python/3.10.1/python-3.10.1-amd64.exe).
-2. During the setup, tick `Install launcher for all users (recommended)` and `Add Python 3.10 to PATH` when prompted.
+1. Install [Python 3.8](https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe).
+2. During the setup, tick `Install launcher for all users (recommended)` and `Add Python 3.8 to PATH` when prompted.
 3. Install [Git for Windows](http://gitforwindows.org/).
 4. During the setup, tick `Git from the command line and also 3rd-party software`, `Checkout Windows-style, commit Unix-style endings`, and `Use MinTTY (the default terminal MSYS2)`.
 5. Open Git Bash by right-clicking an empty space inside of a folder (e.g My Documents) and clicking `Git Bash here`.


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
Many guides despite the recent merge still point users to the now unsupported Python 3.7
This PR aims to point Linux users to Python 3.8 as this is the current standard for new distributions, and Windows users to Python 3.10
This PR is missing CentOS due to it needing a rewrite, and is also missing MacOS as I lack a mac of any kind to test with and write a guide for it.

### Related issues (if applicable)

