### PR TITLE
Update "Updating.md" with py3.8

### DIFF
--- a/_docs/using/updating.md
+++ b/_docs/using/updating.md
@@ -8,10 +8,10 @@ order: 4
 [![GitHub forks](https://img.shields.io/github/forks/Just-Some-Bots/MusicBot.svg)](https://github.com/Just-Some-Bots/MusicBot/network)
 [![Python version](https://img.shields.io/badge/python-3.5%2C%203.6%2C%203.7-blue.svg)](https://python.org)
 
-> MucicBot version 1.9.8 requires Python 3.5.3 or higher. If you are updating the MusicBot with version below than 1.9.8, reinstall Python with the following version.
-> - Windows: [[Download](https://www.python.org/ftp/python/3.7.0/python-3.7.0.exe)]
-> - Mac: [[Download](https://www.python.org/ftp/python/3.6.6/python-3.6.6-macosx10.6.pkg)]
-> - Linux: Install Python 3.6 and pip using your package manager
+> Recent MucicBot versions require Python 3.8 or higher. If you are updating the MusicBot with version that still looks like 1.9.8, reinstall Python with the following version.
+> - Windows: [[Download](https://www.python.org/ftp/python/3.8.10/python-3.8.10-amd64.exe)]
+> - Mac: [[Download](https://www.python.org/ftp/python/3.8.10/python-3.8.10-macosx10.9.pkg)]
+> - Linux: Install Python 3.8 and pip using your package manager
 >
 > If you are updating the MusicBot with version below than 1.9.7-rc2. Please follow instructions in the `Manual update` section.
 


### PR DESCRIPTION
How did I miss this

After creating your pull request, tick these boxes if they are applicable to you.

- [ ] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.8 or higher
- [ ] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
The updating page on the wiki still shows py3.6/7
Not major, but definitely should have been gotten when I updated the guides before


### Related issues (if applicable)

