### PR TITLE
Removes usage of the _manual_delete_check function

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2892,7 +2892,6 @@ class MusicBot(discord.Client):
             self.server_specific_data[guild][
                 "last_np_msg"
             ] = await self.safe_send_message(channel, np_text)
-            await self._manual_delete_check(message)
         else:
             return Response(
                 self.str.get(
@@ -3152,7 +3151,6 @@ class MusicBot(discord.Client):
             index - 1
         ).meta.get("author", None):
             entry = player.playlist.delete_entry_at_index((index - 1))
-            await self._manual_delete_check(message)
             if entry.meta.get("channel", False) and entry.meta.get("author", False):
                 return Response(
                     self.str.get(
@@ -3237,7 +3235,6 @@ class MusicBot(discord.Client):
                 if player.repeatsong:
                     player.repeatsong = False
                 player.skip()
-                await self._manual_delete_check(message)
                 return Response(
                     self.str.get("cmd-skip-force", "Force skipped `{}`.").format(
                         current_entry.title


### PR DESCRIPTION
…ed to delete messages that were already deleted. Ran black

After creating your pull request, tick these boxes if they are applicable to you.

- [X] I have tested my changes against the `review` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [X] I have tested my changes on Python 3.8 or higher
- [X] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
Removes usage of the _manual_delete_check function, since it only tried to delete messages that were already deleted


### Related issues (if applicable)

