### PR TITLE
Allow cache config shorthand & clarify functionality.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -72,11 +72,13 @@ SaveVideos = yes
 
 # Set a time limit for stored files. Set to 0 to disable.
 # Files which aren't used for this period of time will be removed.
+# On *nix/Mac, this uses last-access time. On Windows, file-creation time is used.
 # Only applies when SaveVideos option is enabled.
 StorageLimitDays = 0
 
 # Set a size limit for the entire cache. Set to 0 to disable.
-# When storage exceeds this size, files with older access times are removed first.
+# Accepts exact number of bytes or a shorthand notation like 20 MB
+# When storage exceeds this size, files with older access/creation times are removed first.
 # Only applies when SaveVideos option is enabled.
 StorageLimitBytes = 0
 

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -72,7 +72,7 @@ SaveVideos = yes
 
 # Set a time limit for stored files. Set to 0 to disable.
 # Files which aren't used for this period of time will be removed.
-# On *nix/Mac, this uses last-access time. On Windows, file-creation time is used.
+# On Linux/Mac, this uses last-access time. On Windows, file-creation time is used.
 # Only applies when SaveVideos option is enabled.
 StorageLimitDays = 0
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -44,7 +44,7 @@ from .utils import (
     _func_,
     _get_variable,
     format_song_duration,
-    format_size_bytes,
+    format_size_from_bytes,
 )
 
 load_opus_lib()
@@ -291,8 +291,8 @@ class MusicBot(discord.Client):
             log.debug(
                 "Deleted {0} files from cache, total of {1}.  Cache is now {2} over {3} file(s).".format(
                     removed_count,
-                    format_size_bytes(removed_size),
-                    format_size_bytes(cached_size),
+                    format_size_from_bytes(removed_size),
+                    format_size_from_bytes(cached_size),
                     len(cached_files) - removed_count,
                 )
             )
@@ -743,7 +743,7 @@ class MusicBot(discord.Client):
             self.cached_audio_bytes = self.cached_audio_bytes + entry.downloaded_bytes
             if self.cached_audio_bytes > self.config.storage_limit_bytes:
                 log.debug(
-                    f"Cache level requires cleanup. {format_size_bytes(self.cached_audio_bytes)}"
+                    f"Cache level requires cleanup. {format_size_from_bytes(self.cached_audio_bytes)}"
                 )
                 self._delete_old_audiocache()
 
@@ -1408,7 +1408,7 @@ class MusicBot(discord.Client):
                     f"    Delete if unused for {self.config.storage_limit_days} days"
                 )
             if self.config.save_videos and self.config.storage_limit_bytes:
-                size = format_size_bytes(self.config.storage_limit_bytes)
+                size = format_size_from_bytes(self.config.storage_limit_bytes)
                 log.info(f"    Delete if size exceeds {size}")
 
             if self.config.status_message:
@@ -3771,7 +3771,7 @@ class MusicBot(discord.Client):
         if opt == "info":
             save_videos = ["Disabled", "Enabled"][self.config.save_videos]
             time_limit = f"{self.config.storage_limit_days} days"
-            size_limit = format_size_bytes(self.config.storage_limit_bytes)
+            size_limit = format_size_from_bytes(self.config.storage_limit_bytes)
             size_now = ""
 
             if not self.config.storage_limit_bytes:
@@ -3787,7 +3787,7 @@ class MusicBot(discord.Client):
                     cached_files += 1
                     cached_bytes += os.path.getsize(cache_file)
                 self.cached_audio_bytes = cached_bytes
-                cached_size = format_size_bytes(cached_bytes)
+                cached_size = format_size_from_bytes(cached_bytes)
                 size_now = self.str.get(
                     "cmd-cache-size-now", "\n\n**Cached Now:**  {0} in {1} file(s)"
                 ).format(cached_size, cached_files)

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -7,7 +7,7 @@ import configparser
 
 from .exceptions import HelpfulError
 from .constants import VERSION as BOTVERSION
-from .utils import size_format_to_bytes
+from .utils import format_size_to_bytes
 
 log = logging.getLogger(__name__)
 
@@ -407,7 +407,7 @@ class Config:
 
         if self.storage_limit_bytes:
             try:
-                self.storage_limit_bytes = size_format_to_bytes(
+                self.storage_limit_bytes = format_size_to_bytes(
                     self.storage_limit_bytes
                 )
             except ValueError:

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -7,6 +7,7 @@ import configparser
 
 from .exceptions import HelpfulError
 from .constants import VERSION as BOTVERSION
+from .utils import size_format_to_bytes
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +117,7 @@ class Config:
         self.save_videos = config.getboolean(
             "MusicBot", "SaveVideos", fallback=ConfigDefaults.save_videos
         )
-        self.storage_limit_bytes = config.getint(
+        self.storage_limit_bytes = config.get(
             "MusicBot", "StorageLimitBytes", fallback=ConfigDefaults.storage_limit_bytes
         )
         self.storage_limit_days = config.getint(
@@ -403,6 +404,19 @@ class Config:
 
         if not self.footer_text:
             self.footer_text = ConfigDefaults.footer_text
+
+        if self.storage_limit_bytes:
+            try:
+                self.storage_limit_bytes = size_format_to_bytes(
+                    self.storage_limit_bytes
+                )
+            except ValueError:
+                log.exception(
+                    "StorageLimitBytes has invalid config value '{}' using default instead.".format(
+                        self.storage_limit_bytes,
+                    ),
+                )
+                self.storage_limit_bytes = ConfigDefaults.storage_limit_bytes
 
     # TODO: Add save function for future editing of options with commands
     #       Maybe add warnings about fields missing from the config file

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -180,7 +180,7 @@ def format_song_duration(ftd):
     )
 
 
-def format_size_bytes(size: int):
+def format_size_from_bytes(size: int):
     suffix = {0: "", 1: "Ki", 2: "Mi", 3: "Gi", 4: "Ti"}
     power = 1024
     i = 0
@@ -190,7 +190,7 @@ def format_size_bytes(size: int):
     return f"{size:.3f} {suffix[i]}B"
 
 
-def size_format_to_bytes(size_str: str, strict_si=False) -> int:
+def format_size_to_bytes(size_str: str, strict_si=False) -> int:
     """Convert human-friendly *bytes notation into integer.
     Note: this function is not intended to convert Bits notation.
 

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -188,3 +188,58 @@ def format_size_bytes(size: int):
         size /= power
         i += 1
     return f"{size:.3f} {suffix[i]}B"
+
+
+def size_format_to_bytes(size_str: str, strict_si=False) -> int:
+    """Convert human-friendly *bytes notation into integer.
+    Note: this function is not intended to convert Bits notation.
+
+    Option `strict_si` will use 1000 rather than 1024 for SI suffixes.
+    """
+    si_units = 1024
+    if strict_si:
+        si_units = 1000
+    suffix_list = {
+        "kilobyte": si_units,
+        "megabyte": si_units**2,
+        "gigabyte": si_units**3,
+        "terabyte": si_units**4,
+        "petabyte": si_units**5,
+        "exabyte": si_units**6,
+        "zetabyte": si_units**7,
+        "yottabyte": si_units**8,
+        "kb": si_units,
+        "mb": si_units**2,
+        "gb": si_units**3,
+        "tb": si_units**4,
+        "pb": si_units**5,
+        "eb": si_units**6,
+        "zb": si_units**7,
+        "yb": si_units**8,
+        "kibibyte": 1024,
+        "mebibyte": 1024**2,
+        "gibibyte": 1024**3,
+        "tebibyte": 1024**4,
+        "pebibyte": 1024**5,
+        "exbibyte": 1024**6,
+        "zebibyte": 1024**7,
+        "yobibyte": 1024**8,
+        "kib": 1024,
+        "mib": 1024**2,
+        "gib": 1024**3,
+        "tib": 1024**4,
+        "pib": 1024**5,
+        "eib": 1024**6,
+        "zib": 1024**7,
+        "yib": 1024**8,
+    }
+    size_str = size_str.lower().strip().strip("s")
+    for suffix in suffix_list:
+        if size_str.endswith(suffix):
+            return int(float(size_str[0 : -len(suffix)]) * suffix_list[suffix])
+    else:
+        if size_str.endswith("b"):
+            size_str = size_str[0:-1]
+        elif size_str.endswith("byte"):
+            size_str = size_str[0:-4]
+    return int(size_str)


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [X] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR adds the ability to use shorthand size notations like "2GB" or "512 MB" for the recently added `StorageLimitBytes` option.  It provides clarified documentation for the `StorageLimit*` options in the `example_options.ini` file.  

Additional small code refactor to make related function names more clear as well.