### PR TITLE
Cache autoplay retention option & cache folder option.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -194,7 +194,8 @@ RoundRobinQueue = no
 # Path to your i18n file. Do not set this if you do not know what it does.
 i18nFile = 
 
-# A folder path where you want to store audio cache. 
+# A folder path where you want to store downloaded media files. It can be left empty.
 # This directory will be created if it does not exist.
-# Default is "audio_cache" in the same directory bot run files are located.
+# Default folder is named "audio_cache" in the current working directory.
+# This directory is used for temporary storage even if SaveVideos is disabled.  
 AudioCachePath = 

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -193,3 +193,8 @@ RoundRobinQueue = no
 [Files]
 # Path to your i18n file. Do not set this if you do not know what it does.
 i18nFile = 
+
+# A folder path where you want to store audio cache. 
+# This directory will be created if it does not exist.
+# Default is "audio_cache" in the same directory bot run files are located.
+AudioCachePath = 

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -70,6 +70,10 @@ SkipRatio = 0.5
 # If "yes", videos will not be re-downloaded if queued again, at the cost of hard-drive space.
 SaveVideos = yes
 
+# Never purge videos from cache if they are listed in the auto playlist file.
+# Only applies while SaveVideos option is enabled.
+StorageRetainAutoPlay = yes
+
 # Set a time limit for stored files. Set to 0 to disable.
 # Files which aren't used for this period of time will be removed.
 # On Linux/Mac, this uses last-access time. On Windows, file-creation time is used.

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -582,6 +582,8 @@ class MusicBot(discord.Client):
     async def on_player_play(self, player, entry):
         log.debug("Running on_player_play")
         await self.update_now_playing_status(entry)
+        # manage the cache since we may have downloaded something.
+        self.filecache.handle_new_cache_entry(entry)
         player.skip_state.reset()
 
         # This is the one event where it's ok to serialize autoplaylist entries
@@ -689,9 +691,6 @@ class MusicBot(discord.Client):
         )
 
         # TODO: Check channel voice state?
-
-        # manage the cache since we may have downloaded something.
-        self.filecache.handle_new_cache_entry(entry)
 
     async def on_player_resume(self, player, entry, **_):
         log.debug("Running on_player_resume")

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -104,8 +104,6 @@ class MusicBot(discord.Client):
             log.warning("Autoplaylist is empty, disabling.")
             self.config.auto_playlist = False
         else:
-            if self.config.storage_retain_autoplay:
-                await self._preload_autoplay_filenames()
             log.info(
                 "Loaded autoplaylist with {} entries".format(len(self.autoplaylist))
             )
@@ -1095,6 +1093,14 @@ class MusicBot(discord.Client):
         with open("data/server_names.txt", "w", encoding="utf8") as f:
             for guild in sorted(self.guilds, key=lambda s: int(s.id)):
                 f.write("{:<22} {}\n".format(guild.id, guild.name))
+
+        # be sure to load autoplay retention data before we handle cache.
+        if (
+            self.config.storage_retain_autoplay
+            and self.config.save_videos
+            and self.config.auto_playlist
+        ):
+            await self._preload_autoplay_filenames()
 
         if os.path.isdir(AUDIO_CACHE_PATH):
             if self._delete_old_audiocache(remove_dir=True):

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -428,7 +428,7 @@ class MusicBot(discord.Client):
             self.autoplaylist.remove(song_url)
             log.info(
                 "Removing{} song from session autoplaylist: {}".format(
-                    " unplayable" if ex and not instanceof(ex, UserWarning) else "",
+                    " unplayable" if ex and not isinstance(ex, UserWarning) else "",
                     song_url,
                 ),
             )

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -26,10 +26,11 @@ from . import downloader
 from . import exceptions
 from .aliases import Aliases, AliasesDefault
 from .config import Config, ConfigDefaults
-from .constants import DISCORD_MSG_CHAR_LIMIT, AUDIO_CACHE_PATH
+from .constants import DISCORD_MSG_CHAR_LIMIT
 from .constants import VERSION as BOTVERSION
 from .constructs import SkipState, Response
 from .entry import StreamPlaylistEntry
+from .filecache import AudioFileCache
 from .json import Json
 from .opus_loader import load_opus_lib
 from .permissions import Permissions, PermissionsDefaults
@@ -78,7 +79,6 @@ class MusicBot(discord.Client):
         self.exit_signal = None
         self.init_ok = False
         self.cached_app_info = None
-        self.cached_audio_bytes = 0  # Only used with SaveVideos option.
         self.last_status = None
 
         self.config = Config(config_file)
@@ -93,10 +93,12 @@ class MusicBot(discord.Client):
 
         self.blacklist = set(load_file(self.config.blacklist_file))
         self.autoplaylist = load_file(self.config.auto_playlist_file)
-        self.autoplay_filenames = set()
 
         self.aiolocks = defaultdict(asyncio.Lock)
-        self.downloader = downloader.Downloader(download_folder="audio_cache")
+        self.filecache = AudioFileCache(self)
+        self.downloader = downloader.Downloader(
+            download_folder=self.config.audio_cache_path
+        )
 
         log.info("Starting MusicBot {}".format(BOTVERSION))
 
@@ -107,6 +109,7 @@ class MusicBot(discord.Client):
             log.info(
                 "Loaded autoplaylist with {} entries".format(len(self.autoplaylist))
             )
+            self.filecache.load_autoplay_cachemap()
 
         if self.blacklist:
             log.debug("Loaded blacklist with {} entries".format(len(self.blacklist)))
@@ -124,36 +127,6 @@ class MusicBot(discord.Client):
         self.server_specific_data = defaultdict(ssd_defaults.copy)
 
         super().__init__(intents=intents)
-
-    async def _preload_autoplay_filenames(self):
-        log.debug("Fetching autoplaylist file names.")
-        for ap_url in self.autoplaylist:
-            try:
-                # TODO: check file extensions, since those could be different.
-                filename = await self.downloader.url_to_filename(self, ap_url)
-                self.autoplay_filenames.add(filename)
-            except Exception:
-                log.exception("Autoplay URL could not be converted to a filename.")
-
-    async def _remove_autoplay_filename(self, url):
-        try:
-            ap_filename = await self.downloader.url_to_filename(self, url)
-            self.autoplay_filenames.remove(ap_filename)
-        except (ExtractionError, WrongEntryTypeError):
-            log.debug("Autoplay URL could not be converted to a filename.")
-        except KeyError:
-            log.debug("Autoplay URL does not exist to be removed.")
-        except Exception:
-            log.exception("Exception while trying to remove autoplay filename.")
-
-    async def _add_autoplay_filename(self, url):
-        try:
-            ap_filename = await self.downloader.url_to_filename(self, url)
-            self.autoplay_filenames.add(ap_filename)
-        except (ExtractionError, WrongEntryTypeError):
-            log.debug("Autoplay URL could not be converted to a filename.")
-        except Exception:
-            log.exception("Exception while trying to add autoplay filename.")
 
     async def _doBotInit(self):
         self.http.user_agent = "MusicBot/%s" % BOTVERSION
@@ -258,121 +231,6 @@ class MusicBot(discord.Client):
             lambda m: m.id == self.config.owner_id and (m.voice if voice else True),
             server.members if server else self.get_all_members(),
         )
-
-    def _delete_old_audiocache(self, path=AUDIO_CACHE_PATH, remove_dir=False):
-        def _unlink_path(path: pathlib.Path):
-            try:
-                path.unlink(missing_ok=True)
-                return True
-            except Exception:
-                log.exception(f"Failed to delete cache file:  {path}")
-                return False
-
-        if self.config.save_videos:
-            # Sort cache by access or creation time and delete any that are older than set limit.
-            # Accumulate file sizes until a set limit is reached and purge remaining files.
-            if (
-                self.config.storage_limit_bytes == 0
-                and self.config.storage_limit_days == 0
-            ):
-                log.debug("Skip delete audio cache, no limits set.")
-                return False
-
-            if os.name == "nt":
-                # On Windows, creation time (ctime) is the only reliable way to do this.
-                # mtime is usually older than download time. atime is changed on multiple files by some part of the player.
-                # To make this consistent everywhere, we need to store last-played times for songs on our own.
-                cached_files = sorted(
-                    pathlib.Path(path).iterdir(), key=os.path.getctime, reverse=True
-                )
-            else:
-                cached_files = sorted(
-                    pathlib.Path(path).iterdir(), key=os.path.getatime, reverse=True
-                )
-
-            max_age = time.time() - (86400 * self.config.storage_limit_days)
-            cached_size = 0
-            removed_count = 0
-            removed_size = 0
-            retained_count = 0
-            retained_size = 0
-            for cache_file in cached_files:
-                file_size = os.path.getsize(cache_file)
-
-                # Do not purge files from autoplaylist if retention is enabled.
-                if self.config.storage_retain_autoplay:
-                    if os.path.basename(cache_file) in self.autoplay_filenames:
-                        retained_count += 1
-                        retained_size += file_size
-                        continue
-
-                # get file access/creation time.
-                if os.name == "nt":
-                    file_time = os.path.getctime(cache_file)
-                else:
-                    file_time = os.path.getatime(cache_file)
-
-                # enforce size limit before time limit.
-                if (
-                    self.config.storage_limit_bytes
-                    and self.config.storage_limit_bytes <= (cached_size + file_size)
-                ):
-                    _unlink_path(cache_file)
-                    removed_count += 1
-                    removed_size += file_size
-                    continue
-
-                if self.config.storage_limit_days:
-                    if file_time < max_age:
-                        _unlink_path(cache_file)
-                        removed_count += 1
-                        removed_size += file_size
-                        continue
-
-                cached_size += file_size
-            self.cached_audio_bytes = cached_size
-            if removed_count:
-                log.debug(
-                    "Audio cache deleted {} file{}, total of {} removed.".format(
-                        removed_count,
-                        "" if removed_count == 1 else "s",
-                        format_size_from_bytes(removed_size),
-                    )
-                )
-            if retained_count:
-                log.debug(
-                    "Audio cached retained {} files from autoplaylist, total of {} retained.".format(
-                        retained_count,
-                        format_size_from_bytes(retained_size),
-                        "" if retained_count == 1 else "s",
-                    )
-                )
-            cached_count = len(cached_files) - removed_count
-            cached_size += retained_size
-            log.debug(
-                "Audio cache is now {} over {} file{}.".format(
-                    format_size_from_bytes(cached_size),
-                    cached_count,
-                    "" if cached_count == 1 else "s",
-                )
-            )
-        elif remove_dir:
-            try:
-                shutil.rmtree(path)
-                self.cached_audio_bytes = 0
-                return True
-            except Exception:
-                try:
-                    os.rename(path, path + "__")
-                except Exception:
-                    return False
-                try:
-                    shutil.rmtree(path)
-                except Exception:
-                    os.rename(path + "__", path)
-                    return False
-
-        return True
 
     def _setup_logging(self):
         if len(logging.getLogger(__package__).handlers) > 1:
@@ -559,18 +417,20 @@ class MusicBot(discord.Client):
 
         return self.cached_app_info
 
-    async def remove_from_autoplaylist(
+    async def remove_url_from_autoplaylist(
         self, song_url: str, *, ex: Exception = None, delete_from_ap=False
     ):
         if song_url not in self.autoplaylist:
             log.debug('URL "{}" not in autoplaylist, ignoring'.format(song_url))
             return
 
-        async with self.aiolocks[_func_()]:
+        async with self.aiolocks["autoplaylist_update_lock"]:
             self.autoplaylist.remove(song_url)
-            await self._remove_autoplay_filename(url)
             log.info(
-                "Removing unplayable song from session autoplaylist: %s" % song_url
+                "Removing{} song from session autoplaylist: {}".format(
+                    " unplayable" if ex and not instanceof(ex, UserWarning) else "",
+                    song_url,
+                ),
             )
 
             with open(
@@ -578,8 +438,9 @@ class MusicBot(discord.Client):
             ) as f:
                 f.write(
                     "# Entry removed {ctime}\n"
+                    "# URL:  {url}\n"
                     "# Reason: {ex}\n"
-                    "{url}\n\n{sep}\n\n".format(
+                    "\n{sep}\n\n".format(
                         ctime=time.ctime(),
                         ex=str(ex).replace(
                             "\n", "\n#" + " " * 10
@@ -590,8 +451,39 @@ class MusicBot(discord.Client):
                 )
 
             if delete_from_ap:
-                log.info("Updating autoplaylist")
-                write_file(self.config.auto_playlist_file, self.autoplaylist)
+                log.info("Updating autoplaylist file...")
+                # read the original file in and remove lines with the URL.
+                # this is done to preserve the comments and formatting.
+                try:
+                    apl = pathlib.Path(self.config.auto_playlist_file)
+                    data = apl.read_text()
+                    data = data.replace(song_url, f"#Removed# {song_url}")
+                    apl.write_text(data)
+                except Exception:
+                    log.exception("Failed to save autoplaylist file.")
+
+    async def add_url_to_autoplaylist(self, song_url: str):
+        if song_url in self.autoplaylist:
+            log.debug("URL already in autoplaylist, ignoring")
+            return
+
+        async with self.aiolocks["autoplaylist_update_lock"]:
+            # Note, this does not update the player's copy of the list.
+            self.autoplaylist.append(song_url)
+            log.info(f"Adding new URL to autoplaylist: {song_url}")
+
+            try:
+                # append to the file to preserve its formatting.
+                with open(self.config.auto_playlist_file, "r+") as fh:
+                    lines = fh.readlines()
+                    if lines[-1].endswith("\n"):
+                        lines.append(f"{song_url}\n")
+                    else:
+                        lines.append(f"\n{song_url}\n")
+                    fh.seek(0)
+                    fh.writelines(lines)
+            except Exception:
+                log.exception("Failed to save autoplaylist file.")
 
     @ensure_appinfo
     async def generate_invite_link(
@@ -798,15 +690,8 @@ class MusicBot(discord.Client):
 
         # TODO: Check channel voice state?
 
-        if self.config.save_videos and self.config.storage_limit_bytes:
-            # TODO: Improve this so it isn't called every song when cache is full.
-            #  ideal second option for keeping cache between min and max.
-            self.cached_audio_bytes = self.cached_audio_bytes + entry.downloaded_bytes
-            if self.cached_audio_bytes > self.config.storage_limit_bytes:
-                log.debug(
-                    f"Cache level requires cleanup. {format_size_from_bytes(self.cached_audio_bytes)}"
-                )
-                self._delete_old_audiocache()
+        # manage the cache since we may have downloaded something.
+        self.filecache.handle_new_cache_entry(entry)
 
     async def on_player_resume(self, player, entry, **_):
         log.debug("Running on_player_resume")
@@ -885,7 +770,7 @@ class MusicBot(discord.Client):
                             'Error processing "{url}": {ex}'.format(url=song_url, ex=e)
                         )
 
-                    await self.remove_from_autoplaylist(
+                    await self.remove_url_from_autoplaylist(
                         song_url, ex=e, delete_from_ap=self.config.remove_ap
                     )
                     continue
@@ -896,7 +781,9 @@ class MusicBot(discord.Client):
                     )
                     log.exception()
 
-                    self.autoplaylist.remove(song_url)
+                    await self.remove_url_from_autoplaylist(
+                        song_url, ex=e, delete_from_ap=self.config.remove_ap
+                    )
                     continue
 
                 if info.get("entries", None):  # or .get('_type', '') == 'playlist'
@@ -1094,19 +981,7 @@ class MusicBot(discord.Client):
             for guild in sorted(self.guilds, key=lambda s: int(s.id)):
                 f.write("{:<22} {}\n".format(guild.id, guild.name))
 
-        # be sure to load autoplay retention data before we handle cache.
-        if (
-            self.config.storage_retain_autoplay
-            and self.config.save_videos
-            and self.config.auto_playlist
-        ):
-            await self._preload_autoplay_filenames()
-
-        if os.path.isdir(AUDIO_CACHE_PATH):
-            if self._delete_old_audiocache(remove_dir=True):
-                log.debug("Deleted old audio cache")
-            else:
-                log.debug("Could not delete old audio cache, moving on.")
+        self.filecache.delete_old_audiocache(remove_dir=True)
 
     async def _scheck_server_permissions(self):
         log.debug("Checking server permissions")
@@ -1554,16 +1429,6 @@ class MusicBot(discord.Client):
 
             return url
 
-    def _add_url_to_autoplaylist(self, url):
-        self.autoplaylist.append(url)
-        write_file(self.config.auto_playlist_file, self.autoplaylist)
-        log.debug("Appended {} to autoplaylist".format(url))
-
-    def _remove_url_from_autoplaylist(self, url):
-        self.autoplaylist.remove(url)
-        write_file(self.config.auto_playlist_file, self.autoplaylist)
-        log.debug("Removed {} from autoplaylist".format(url))
-
     async def handle_timeout(self, guild: discord.Guild):
         event, active = self.server_specific_data[guild]["timeout_event"]
 
@@ -1759,8 +1624,7 @@ class MusicBot(discord.Client):
         if url:
             if option in ["+", "add"]:
                 if url not in self.autoplaylist:
-                    self._add_url_to_autoplaylist(url)
-                    await self._add_autoplay_filename(url)
+                    await self.add_url_to_autoplaylist(url)
                     return Response(
                         self.str.get(
                             "cmd-save-success", "Added <{0}> to the autoplaylist."
@@ -1777,8 +1641,7 @@ class MusicBot(discord.Client):
                     )
             elif option in ["-", "remove"]:
                 if url in self.autoplaylist:
-                    self._remove_url_from_autoplaylist(url)
-                    await self._remove_autoplay_filename(url)
+                    await self.remove_url_from_autoplaylist(url, delete_from_ap=True)
                     return Response(
                         self.str.get(
                             "cmd-unsave-success", "Removed <{0}> from the autoplaylist."
@@ -3827,10 +3690,10 @@ class MusicBot(discord.Client):
             {command_prefix}cache
 
         Display cache storage info or clear cache files.
-        Valid options are:  info, clear
+        Valid options are:  info, update, clear
         """
         opt = opt.lower()
-        if opt not in ["info", "clear"]:
+        if opt not in ["info", "update", "clear"]:
             raise exceptions.CommandError(
                 self.str.get(
                     "cmd-cache-invalid-arg",
@@ -3839,6 +3702,13 @@ class MusicBot(discord.Client):
                 expire_in=30,
             )
 
+        # actually query the filesystem.
+        if opt == "update":
+            self.filecache.scan_audio_cache()
+            # force output of info after we have updated it.
+            opt = "info"
+
+        # report cache info as it is.
         if opt == "info":
             save_videos = ["Disabled", "Enabled"][self.config.save_videos]
             time_limit = f"{self.config.storage_limit_days} days"
@@ -3851,17 +3721,13 @@ class MusicBot(discord.Client):
             if not self.config.storage_limit_days:
                 time_limit = "Unlimited"
 
-            if os.path.isdir(AUDIO_CACHE_PATH):
-                cached_bytes = 0
-                cached_files = 0
-                for cache_file in pathlib.Path(AUDIO_CACHE_PATH).iterdir():
-                    cached_files += 1
-                    cached_bytes += os.path.getsize(cache_file)
-                self.cached_audio_bytes = cached_bytes
-                cached_size = format_size_from_bytes(cached_bytes)
-                size_now = self.str.get(
-                    "cmd-cache-size-now", "\n\n**Cached Now:**  {0} in {1} file(s)"
-                ).format(cached_size, cached_files)
+            cached_bytes, cached_files = self.filecache.get_cache_size()
+            size_now = self.str.get(
+                "cmd-cache-size-now", "\n\n**Cached Now:**  {0} in {1} file(s)"
+            ).format(
+                format_size_from_bytes(cached_bytes),
+                cached_files,
+            )
 
             return Response(
                 self.str.get(
@@ -3871,9 +3737,10 @@ class MusicBot(discord.Client):
                 delete_after=60,
             )
 
+        # clear cache according to settings.
         if opt == "clear":
-            if os.path.isdir(AUDIO_CACHE_PATH):
-                if self._delete_old_audiocache():
+            if self.filecache.cache_dir_exists():
+                if self.filecache.delete_old_audiocache():
                     return Response(
                         self.str.get(
                             "cmd-cache-clear-success",
@@ -3896,6 +3763,7 @@ class MusicBot(discord.Client):
                 ),
                 delete_after=30,
             )
+        # TODO: maybe add a "purge" option that fully empties cache regardless of settings.
 
     async def cmd_queue(self, channel, player):
         """

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1420,6 +1420,9 @@ class MusicBot(discord.Client):
     @staticmethod
     def _get_song_url_or_none(url, player):
         """Return song url if provided or one is currently playing, else returns None"""
+        if not player:
+            return url
+
         if url or (
             player.current_entry
             and not isinstance(player.current_entry, StreamPlaylistEntry)
@@ -1612,14 +1615,14 @@ class MusicBot(discord.Client):
                 delete_after=35,
             )
 
-    async def cmd_autoplaylist(self, player, option, url=None):
+    async def cmd_autoplaylist(self, _player, option, url=None):
         """
         Usage:
             {command_prefix}autoplaylist [ + | - | add | remove] [url]
 
         Adds or removes the specified song or currently playing song to/from the playlist.
         """
-        url = self._get_song_url_or_none(url, player)
+        url = self._get_song_url_or_none(url, _player)
 
         if url:
             if option in ["+", "add"]:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -461,6 +461,7 @@ class MusicBot(discord.Client):
                     apl.write_text(data)
                 except Exception:
                     log.exception("Failed to save autoplaylist file.")
+                self.filecache.remove_autoplay_cachemap_entry_by_url(song_url)
 
     async def add_url_to_autoplaylist(self, song_url: str):
         if song_url in self.autoplaylist:

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -123,6 +123,11 @@ class Config:
         self.storage_limit_days = config.getint(
             "MusicBot", "StorageLimitDays", fallback=ConfigDefaults.storage_limit_days
         )
+        self.storage_retain_autoplay = config.getboolean(
+            "MusicBot",
+            "StorageRetainAutoPlay",
+            fallback=ConfigDefaults.storage_retain_autoplay,
+        )
         self.now_playing_mentions = config.getboolean(
             "MusicBot",
             "NowPlayingMentions",
@@ -535,6 +540,7 @@ class ConfigDefaults:
     skips_required = 4
     skip_ratio_required = 0.5
     save_videos = True
+    storage_retain_autoplay = True
     storage_limit_bytes = 0
     storage_limit_days = 0
     now_playing_mentions = False

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -10,5 +10,4 @@ try:
 except Exception:
     VERSION = "version_unknown"
 
-AUDIO_CACHE_PATH = os.path.join(os.getcwd(), "audio_cache")
 DISCORD_MSG_CHAR_LIMIT = 2000

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -120,3 +120,78 @@ class Downloader:
             self.thread_pool,
             functools.partial(self.safe_ytdl.extract_info, *args, **kwargs),
         )
+
+    async def url_to_filename(self, bot, song_url: str) -> str:
+        """
+        Validates a song_url to be played and returns only the filename.
+
+        :param song_url: The song url to add to the playlist.
+        """
+
+        try:
+            info = await self.extract_info(bot.loop, song_url, download=False)
+        except Exception as e:
+            raise ExtractionError(
+                "Could not extract information from {}\n\n{}".format(song_url, e)
+            )
+
+        if not info:
+            raise ExtractionError("Could not extract information from %s" % song_url)
+
+        # TODO: if/when playlists work in autoplaylist.txt we will need to handle this.
+        if info.get("_type", None) == "playlist":
+            raise WrongEntryTypeError(
+                "This is a playlist.",
+                True,
+                info.get("webpage_url", None) or info.get("url", None),
+            )
+
+        if info.get("is_live", False):
+            raise WrongEntryTypeError(
+                "This is a live stream.",
+                True,
+                info.get("webpage_url", None) or info.get("url", None),
+            )
+
+        if info["extractor"] in ["generic", "Dropbox"]:
+            log.debug("Detected a generic extractor, or Dropbox")
+            try:
+                headers = await get_header(bot.session, info["url"])
+                content_type = headers.get("CONTENT-TYPE")
+                log.debug("Got content type {}".format(content_type))
+            except Exception as e:
+                log.warning(
+                    "Failed to get content type for url {} ({})".format(song_url, e)
+                )
+                content_type = None
+
+            if content_type:
+                if content_type.startswith(("application/", "image/")):
+                    if not any(x in content_type for x in ("/ogg", "/octet-stream")):
+                        # How does a server say `application/ogg` what the actual fuck
+                        raise ExtractionError(
+                            'Invalid content type "%s" for url %s'
+                            % (content_type, song_url)
+                        )
+
+                elif (
+                    content_type.startswith("text/html")
+                    and info["extractor"] == "generic"
+                ):
+                    log.warning(
+                        "Got text/html for content-type, this might be a stream."
+                    )
+                    raise WrongEntryTypeError(
+                        "This is a playlist.",
+                        True,
+                        info.get("webpage_url", None) or info.get("url", None),
+                    )
+
+                elif not content_type.startswith(("audio/", "video/")):
+                    log.warning(
+                        'Questionable content-type "{}" for url {}'.format(
+                            content_type, song_url
+                        )
+                    )
+
+        return self.downloader.ytdl.prepare_filename(info)

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -144,7 +144,7 @@ class AudioFileCache:
             # enforce size limit before time limit.
             if (
                 self.config.storage_limit_bytes
-                and self.config.storage_limit_bytes < cached_size + file_size
+                and self.config.storage_limit_bytes < cached_size
             ):
                 self._delete_cache_file(cache_file)
                 removed_count += 1

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -127,6 +127,7 @@ class AudioFileCache:
             if self._check_autoplay_cachemap(cache_file):
                 retained_count += 1
                 retained_size += file_size
+                cached_size += file_size
                 continue
 
             # get file access/creation time.
@@ -171,7 +172,7 @@ class AudioFileCache:
                 )
             )
         self.file_count = len(cached_files) - removed_count
-        self.size_bytes = cached_size + retained_size
+        self.size_bytes = cached_size
         log.debug(
             "Audio cache is now {} over {} file{}.".format(
                 format_size_from_bytes(self.size_bytes),

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -5,7 +6,9 @@ import pathlib
 import shutil
 import time
 
-from .utils import _func_, format_size_from_bytes
+from .utils import format_size_from_bytes
+from .bot import MusicBot
+from .entry import Entry
 
 log = logging.getLogger(__name__)
 
@@ -15,7 +18,7 @@ class AudioFileCache:
     This class provides methods to manage the audio file cache and get info about it.
     """
 
-    def __init__(self, bot):
+    def __init__(self, bot: MusicBot) -> None:
         self.bot = bot
         self.config = bot.config
         self.cache_path = pathlib.Path(bot.config.audio_cache_path)
@@ -25,17 +28,19 @@ class AudioFileCache:
 
         # Stores filenames without extension associated to a playlist URL.
         self.auto_playlist_cachemap = {}
+        self.cachemap_file_lock = asyncio.Lock()
 
-    def cache_dir_exists(self):
+    def cache_dir_exists(self) -> bool:
+        """Wrapper for self.cache.is_dir() for external use."""
         return self.cache_path.is_dir()
 
-    def get_cache_size(self):
+    def get_cache_size(self) -> tuple[int, int]:
         """
         Returns AudioFileCache size as a two member tuple containing size_bytes and file_count.
         """
         return (self.size_bytes, self.file_count)
 
-    def scan_audio_cache(self):
+    def scan_audio_cache(self) -> tuple[int, int]:
         """
         Scan the audio cache directory and return a tuple with info.
         Returns (size_in_bytes:int, number_of_files:int)
@@ -51,7 +56,10 @@ class AudioFileCache:
 
         return self.get_cache_size()
 
-    def _delete_cache_file(self, path: pathlib.Path):
+    def _delete_cache_file(self, path: pathlib.Path) -> bool:
+        """
+        Wrapper for pathlib unlink(missing_ok=True) while logging exceptions.
+        """
         try:
             path.unlink(missing_ok=True)
             return True
@@ -59,9 +67,126 @@ class AudioFileCache:
             log.exception(f"Failed to delete cache file:  {path}")
             return False
 
-    def delete_old_audiocache(self, remove_dir=False):
+    def _delete_cache_dir(self) -> bool:
+        """
+        Attempts immediate removal of the cache file directory while logging errors.
+        """
+        try:
+            shutil.rmtree(self.cache_path)
+            self.cached_audio_bytes = 0
+            log.debug("Audio cache directory has been removed.")
+            return True
+        except Exception:
+            new_name = self.cache_path.stem + "__"
+            try:
+                new_path = self.cache_path.rename(self.cache_path.with_stem(new_name))
+            except Exception:
+                log.debug("Audio cache directory could not be removed or renamed.")
+                return False
+            try:
+                shutil.rmtree(new_path)
+            except Exception:
+                new_path.rename(self.cache_path)
+                log.debug("Audio cache directory could not be removed.")
+                return False
+
+    def _process_cache_delete(self) -> bool:
+        """
+        Sorts cache by access or creation time and deletes any that are older than set limits.
+        Will retain cached autoplaylist if enabled and files are in the cachemap.
+        """
+        if self.config.storage_limit_bytes == 0 and self.config.storage_limit_days == 0:
+            log.debug("Audio cache has no limits set, nothing to delete.")
+            return False
+
+        if os.name == "nt":
+            # On Windows, creation time (ctime) is the only reliable way to do this.
+            # mtime is usually older than download time. atime is changed on multiple files by some part of the player.
+            # To make this consistent everywhere, we need to store last-played times for songs on our own.
+            cached_files = sorted(
+                pathlib.Path(self.cache_path).iterdir(),
+                key=os.path.getctime,
+                reverse=True,
+            )
+        else:
+            cached_files = sorted(
+                pathlib.Path(self.cache_path).iterdir(),
+                key=os.path.getatime,
+                reverse=True,
+            )
+
+        max_age = time.time() - (86400 * self.config.storage_limit_days)
+        cached_size = 0
+        removed_count = 0
+        removed_size = 0
+        retained_count = 0
+        retained_size = 0
+        # Accumulate file sizes until a set limit is reached and purge remaining files.
+        for cache_file in cached_files:
+            file_size = os.path.getsize(cache_file)
+
+            # Do not purge files from autoplaylist if retention is enabled.
+            if self._check_autoplay_cachemap(cache_file):
+                retained_count += 1
+                retained_size += file_size
+                continue
+
+            # get file access/creation time.
+            if os.name == "nt":
+                file_time = os.path.getctime(cache_file)
+            else:
+                file_time = os.path.getatime(cache_file)
+
+            # enforce size limit before time limit.
+            if (
+                self.config.storage_limit_bytes
+                and self.config.storage_limit_bytes < cached_size + file_size
+            ):
+                self._delete_cache_file(cache_file)
+                removed_count += 1
+                removed_size += file_size
+                continue
+
+            if self.config.storage_limit_days:
+                if file_time < max_age:
+                    self._delete_cache_file(cache_file)
+                    removed_count += 1
+                    removed_size += file_size
+                    continue
+
+            cached_size += file_size
+
+        if removed_count:
+            log.debug(
+                "Audio cache deleted {} file{}, total of {} removed.".format(
+                    removed_count,
+                    "" if removed_count == 1 else "s",
+                    format_size_from_bytes(removed_size),
+                )
+            )
+        if retained_count:
+            log.debug(
+                "Audio cached retained {} file{} from autoplaylist, total of {} retained.".format(
+                    retained_count,
+                    "" if retained_count == 1 else "s",
+                    format_size_from_bytes(retained_size),
+                )
+            )
+        self.file_count = len(cached_files) - removed_count
+        self.size_bytes = cached_size + retained_size
+        log.debug(
+            "Audio cache is now {} over {} file{}.".format(
+                format_size_from_bytes(self.size_bytes),
+                self.file_count,
+                "" if self.file_count == 1 else "s",
+            )
+        )
+        return True
+
+    def delete_old_audiocache(self, remove_dir: bool = False) -> bool:
         """
         Handle deletion of cache data according to settings and return bool status.
+        Will return False if no cache directory exists, and error prevented deletion.
         Param `remove_dir` is intened only to be used in bot-startup.
         """
 
@@ -70,144 +195,41 @@ class AudioFileCache:
             return False
 
         if self.config.save_videos:
-            # Sort cache by access or creation time and delete any that are older than set limit.
-            # Accumulate file sizes until a set limit is reached and purge remaining files.
-            if (
-                self.config.storage_limit_bytes == 0
-                and self.config.storage_limit_days == 0
-            ):
-                log.debug("Audio cache has no limits set, nothing to delete.")
-                return False
-
-            if os.name == "nt":
-                # On Windows, creation time (ctime) is the only reliable way to do this.
-                # mtime is usually older than download time. atime is changed on multiple files by some part of the player.
-                # To make this consistent everywhere, we need to store last-played times for songs on our own.
-                cached_files = sorted(
-                    pathlib.Path(self.cache_path).iterdir(),
-                    key=os.path.getctime,
-                    reverse=True,
-                )
-            else:
-                cached_files = sorted(
-                    pathlib.Path(self.cache_path).iterdir(),
-                    key=os.path.getatime,
-                    reverse=True,
-                )
-
-            max_age = time.time() - (86400 * self.config.storage_limit_days)
-            cached_size = 0
-            removed_count = 0
-            removed_size = 0
-            retained_count = 0
-            retained_size = 0
-            for cache_file in cached_files:
-                file_size = os.path.getsize(cache_file)
-
-                # Do not purge files from autoplaylist if retention is enabled.
-                if self._check_autoplay_cachemap(cache_file):
-                    retained_count += 1
-                    retained_size += file_size
-                    continue
-
-                # get file access/creation time.
-                if os.name == "nt":
-                    file_time = os.path.getctime(cache_file)
-                else:
-                    file_time = os.path.getatime(cache_file)
-
-                # enforce size limit before time limit.
-                if (
-                    self.config.storage_limit_bytes
-                    and self.config.storage_limit_bytes <= (cached_size + file_size)
-                ):
-                    self._delete_cache_file(cache_file)
-                    removed_count += 1
-                    removed_size += file_size
-                    continue
-
-                if self.config.storage_limit_days:
-                    if file_time < max_age:
-                        self._delete_cache_file(cache_file)
-                        removed_count += 1
-                        removed_size += file_size
-                        continue
-
-                cached_size += file_size
-
-            if removed_count:
-                log.debug(
-                    "Audio cache deleted {} file{}, total of {} removed.".format(
-                        removed_count,
-                        "" if removed_count == 1 else "s",
-                        format_size_from_bytes(removed_size),
-                    )
-                )
-            if retained_count:
-                log.debug(
-                    "Audio cached retained {} file{} from autoplaylist, total of {} retained.".format(
-                        retained_count,
-                        "" if retained_count == 1 else "s",
-                        format_size_from_bytes(retained_size),
-                    )
-                )
-            self.file_count = len(cached_files) - removed_count
-            self.size_bytes = cached_size + retained_size
-            log.debug(
-                "Audio cache is now {} over {} file{}.".format(
-                    format_size_from_bytes(self.size_bytes),
-                    self.file_count,
-                    "" if self.file_count == 1 else "s",
-                )
-            )
+            return self._process_cache_delete()
         elif remove_dir:
-            try:
-                shutil.rmtree(self.cache_path)
-                self.cached_audio_bytes = 0
-                log.debug("Audio cache directory has been removed.")
-                return True
-            except Exception:
-                new_name = self.cache_path.stem + "__"
-                try:
-                    new_path = self.cache_path.rename(
-                        self.cache_path.with_stem(new_name)
-                    )
-                except Exception:
-                    log.debug("Audio cache directory could not be removed or renamed.")
-                    return False
-                try:
-                    shutil.rmtree(new_path)
-                except Exception:
-                    new_path.rename(self.cache_path)
-                    log.debug("Audio cache directory could not be removed.")
-                    return False
+            return self._delete_cache_dir()
 
         return True
 
-    def handle_new_cache_entry(self, entry):
-        # ignore partial downloads
-        if entry.cache_busted:
-            log.noise("Audio cache file marked as busted, ignoring it.")
-            return
-
+    def handle_new_cache_entry(self, entry: Entry) -> None:
+        """
+        Test given entry for cachemap inclusion and run cache limit checks.
+        """
         if entry.url in self.bot.autoplaylist:
-            log.noise("Audio cache entry is an autoplaylist URL.")
-            self.add_autoplay_cachemap_entry(entry)
-
-        if self.config.save_videos and self.config.storage_limit_bytes:
-            # TODO: Improve this so it isn't called every song when cache is full.
-            #  idealy a second option for keeping cache between min and max.
-            # TODO: Maybe check for storage_limit_days at runtime too, currently avoided for the reason above.
-            self.size_bytes = self.size_bytes + entry.downloaded_bytes
-            if self.size_bytes > self.config.storage_limit_bytes:
-                log.debug(
-                    f"Cache level requires cleanup. {format_size_from_bytes(self.size_bytes)}"
+            # ignore partial downloads
+            if entry.cache_busted:
+                log.noise(
+                    "Audio cache file is from autoplaylist but marked as busted, ignoring it."
                 )
+            else:
+                self.add_autoplay_cachemap_entry(entry)
+
+        if self.config.save_videos:
+            if self.config.storage_limit_bytes:
+                # TODO: This could be improved with min/max options, preventing calls to clear on each new entry.
+                self.size_bytes = self.size_bytes + entry.downloaded_bytes
+                if self.size_bytes > self.config.storage_limit_bytes:
+                    log.debug(
+                        f"Cache level requires cleanup. {format_size_from_bytes(self.size_bytes)}"
+                    )
+                    self.delete_old_audiocache()
+            elif self.config.storage_limit_days:
+                # Only running time check if it is the only option enabled, cuts down on IO.
                 self.delete_old_audiocache()
 
-    def load_autoplay_cachemap(self):
+    def load_autoplay_cachemap(self) -> None:
         """
-        Load cachemap file if it exists and settings are enabled.
+        Load cachemap json file if it exists and settings are enabled.
         Cachemap file path is generated in Config using the auto playlist file name.
         The cache map is a dict with filename keys for playlist url values.
         Filenames are stored without their extension due to ytdl potentially getting a different format.
@@ -221,7 +243,7 @@ class AudioFileCache:
             return
 
         if not os.path.isfile(self.config.auto_playlist_cachemap_file):
-            log.debug("Auto playlist has no cache map, moving on.")
+            log.debug("Autoplaylist has no cache map, moving on.")
             self.auto_playlist_cachemap = {}
             return
 
@@ -229,13 +251,16 @@ class AudioFileCache:
             try:
                 self.auto_playlist_cachemap = json.load(fh)
                 log.info(
-                    f"Loaded auto playlist cache map with {len(self.auto_playlist_cachemap)} entries."
+                    f"Loaded autoplaylist cache map with {len(self.auto_playlist_cachemap)} entries."
                 )
             except Exception:
-                log.exception("Failed to load auto playlist cache map.")
+                log.exception("Failed to load autoplaylist cache map.")
                 self.auto_playlist_cachemap = {}
 
-    async def save_autoplay_cachemap(self):
+    async def save_autoplay_cachemap(self) -> None:
+        """
+        Uses asyncio.Lock to save cachemap as a json file, if settings are enabled.
+        """
         if (
             not self.config.storage_retain_autoplay
             or not self.config.auto_playlist
@@ -243,19 +268,19 @@ class AudioFileCache:
         ):
             return
 
-        async with self.aiolocks[_func_()]:
+        async with self.cachemap_file_lock:
             try:
                 with open(self.config.auto_playlist_cachemap_file, "w") as fh:
                     json.dump(self.auto_playlist_cachemap, fh)
-                    log.info(
-                        f"Saved auto playlist cache map with {len(self.auto_playlist_cachemap)} entries."
+                    log.debug(
+                        f"Saved autoplaylist cache map with {len(self.auto_playlist_cachemap)} entries."
                     )
             except Exception:
-                log.exception("Failed to save auto playlist cache map.")
+                log.exception("Failed to save autoplaylist cache map.")
 
-    def add_autoplay_cachemap_entry(self, entry):
+    def add_autoplay_cachemap_entry(self, entry: Entry) -> None:
         """
-        Store an entry in auto playlist cachemap, and update the cachemap file if needed.
+        Store an entry in autoplaylist cachemap, and update the cachemap file if needed.
         """
         if (
             not self.config.storage_retain_autoplay
@@ -269,7 +294,7 @@ class AudioFileCache:
         if filename in self.auto_playlist_cachemap:
             if self.auto_playlist_cachemap[filename] != entry.url:
                 log.warning(
-                    "Auto playlist cache map conflict on Key: {}  Old: {}  New: {}".format(
+                    "Autoplaylist cache map conflict on Key: {}  Old: {}  New: {}".format(
                         filename,
                         self.auto_playlist_cachemap[filename],
                         entry.url,
@@ -284,7 +309,7 @@ class AudioFileCache:
         if change_made:
             self.bot.loop.create_task(self.save_autoplay_cachemap())
 
-    def remove_autoplay_cachemap_entry(self, entry):
+    def remove_autoplay_cachemap_entry(self, entry: Entry) -> None:
         """
         Remove an entry from cachemap and update cachemap file if needed.
         """
@@ -300,7 +325,7 @@ class AudioFileCache:
             del self.auto_playlist_cachemap[filename]
             self.bot.loop.create_task(self.save_autoplay_cachemap())
 
-    def remove_autoplay_cachemap_entry_by_url(self, url):
+    def remove_autoplay_cachemap_entry_by_url(self, url: str) -> None:
         """
         Remove all entries having the given URL from cachemap and update cachemap if needed.
         """

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -1,0 +1,310 @@
+import json
+import pathlib
+import logging
+
+log = logging.get_logger(__name__)
+
+
+class AudioFileCache:
+    """
+    This class provides methods to manage the audio file cache and get info about it.
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = bot.config
+        self.cache_path = pathlib.Path(bot.config.audio_cache_path)
+
+        self.size_bytes = 0
+        self.file_count = 0
+
+        # Stores filenames without extension associated to a playlist URL.
+        self.auto_playlist_cachemap = {}
+
+    def cache_dir_exists(self):
+        return self.cache_path.is_dir()
+
+    def get_cache_size(self):
+        """
+        Returns AudioFileCache size as a two member tuple containing size_bytes and file_count.
+        """
+        return (self.size_bytes, self.file_count)
+
+    def scan_audio_cache(self):
+        """
+        Scan the audio cache directory and return a tuple with info.
+        Returns (size_in_bytes:int, number_of_files:int)
+        """
+        cached_bytes = 0
+        cached_files = 0
+        if os.path.isdir(self.cache_path):
+            for cache_file in pathlib.Path(self.cache_path).iterdir():
+                cached_files += 1
+                cached_bytes += os.path.getsize(cache_file)
+        self.size_bytes = cached_bytes
+        self.file_count = cached_files
+
+        return self.get_cache_size()
+
+    def _delete_cache_file(self, path: pathlib.Path):
+        try:
+            path.unlink(missing_ok=True)
+            return True
+        except Exception:
+            log.exception(f"Failed to delete cache file:  {path}")
+            return False
+
+    def delete_old_audiocache(self, remove_dir=False):
+        """
+        Handle deletion of cache data according to settings and return bool status.
+        Param `remove_dir` is intened only to be used in bot-startup.
+        """
+
+        if not os.path.isdir(self.cache_path):
+            log.debug("Audio cache directory is missing, nothing to delete.")
+            return False
+
+        if self.config.save_videos:
+            # Sort cache by access or creation time and delete any that are older than set limit.
+            # Accumulate file sizes until a set limit is reached and purge remaining files.
+            if (
+                self.config.storage_limit_bytes == 0
+                and self.config.storage_limit_days == 0
+            ):
+                log.debug("Audio cache has no limits set, nothing to delete.")
+                return False
+
+            if os.name == "nt":
+                # On Windows, creation time (ctime) is the only reliable way to do this.
+                # mtime is usually older than download time. atime is changed on multiple files by some part of the player.
+                # To make this consistent everywhere, we need to store last-played times for songs on our own.
+                cached_files = sorted(
+                    pathlib.Path(self.cache_path).iterdir(),
+                    key=os.path.getctime,
+                    reverse=True,
+                )
+            else:
+                cached_files = sorted(
+                    pathlib.Path(self.cache_path).iterdir(),
+                    key=os.path.getatime,
+                    reverse=True,
+                )
+
+            max_age = time.time() - (86400 * self.config.storage_limit_days)
+            cached_size = 0
+            removed_count = 0
+            removed_size = 0
+            retained_count = 0
+            retained_size = 0
+            for cache_file in cached_files:
+                file_size = os.path.getsize(cache_file)
+
+                # Do not purge files from autoplaylist if retention is enabled.
+                if self._check_autoplay_cachemap(cache_file):
+                    retained_count += 1
+                    retained_size += file_size
+                    continue
+
+                # get file access/creation time.
+                if os.name == "nt":
+                    file_time = os.path.getctime(cache_file)
+                else:
+                    file_time = os.path.getatime(cache_file)
+
+                # enforce size limit before time limit.
+                if (
+                    self.config.storage_limit_bytes
+                    and self.config.storage_limit_bytes <= (cached_size + file_size)
+                ):
+                    self._delete_cache_file(cache_file)
+                    removed_count += 1
+                    removed_size += file_size
+                    continue
+
+                if self.config.storage_limit_days:
+                    if file_time < max_age:
+                        self._delete_cache_file(cache_file)
+                        removed_count += 1
+                        removed_size += file_size
+                        continue
+
+                cached_size += file_size
+
+            if removed_count:
+                log.debug(
+                    "Audio cache deleted {} file{}, total of {} removed.".format(
+                        removed_count,
+                        "" if removed_count == 1 else "s",
+                        format_size_from_bytes(removed_size),
+                    )
+                )
+            if retained_count:
+                log.debug(
+                    "Audio cached retained {} files from autoplaylist, total of {} retained.".format(
+                        retained_count,
+                        format_size_from_bytes(retained_size),
+                        "" if retained_count == 1 else "s",
+                    )
+                )
+            self.file_count = len(cached_files) - removed_count
+            self.size_bytes = cached_size + retained_size
+            log.debug(
+                "Audio cache is now {} over {} file{}.".format(
+                    format_size_from_bytes(self.size_bytes),
+                    self.file_count,
+                    "" if self.file_count == 1 else "s",
+                )
+            )
+        elif remove_dir:
+            try:
+                shutil.rmtree(path)
+                self.cached_audio_bytes = 0
+                log.debug("Audio cache directory has been removed.")
+                return True
+            except Exception:
+                try:
+                    os.rename(path, path + "__")
+                except Exception:
+                    log.debug("Audio cache directory could not be removed or renamed.")
+                    return False
+                try:
+                    shutil.rmtree(path)
+                except Exception:
+                    os.rename(path + "__", path)
+                    log.debug("Audio cache directory could not be removed.")
+                    return False
+
+        return True
+
+    def handle_new_cache_entry(self, entry):
+        # ignore partial downloads
+        if entry.cache_busted:
+            return
+
+        if entry.url in self.bot.autoplaylist:
+            self.add_autoplay_cachemap_entry(entry)
+
+        if self.config.save_videos and self.config.storage_limit_bytes:
+            # TODO: Improve this so it isn't called every song when cache is full.
+            #  idealy a second option for keeping cache between min and max.
+            self.size_bytes = self.size_bytes + entry.downloaded_bytes
+            if self.size_bytes > self.config.storage_limit_bytes:
+                log.debug(
+                    f"Cache level requires cleanup. {format_size_from_bytes(self.size_bytes)}"
+                )
+                self.delete_old_audiocache()
+
+    def load_autoplay_cachemap(self):
+        """
+        Load cachemap file if it exists and settings are enabled.
+        Cachemap file path is generated in Config using the auto playlist file name.
+        The cache map is a dict with filename keys for playlist url values.
+        Filenames are stored without their extension due to ytdl potentially getting a different format.
+        """
+        if (
+            not self.config.storage_retain_autoplay
+            or not self.config.auto_playlist
+            or not self.config.save_videos
+        ):
+            self.auto_playlist_cachemap = {}
+            return
+
+        if not os.path.isfile(self.config.auto_playlist_cachemap_file):
+            log.debug("Auto playlist has no cache map, moving on.")
+            self.auto_playlist_cachemap = {}
+            return
+
+        with open(self.config.auto_playlist_cachemap_file, "r") as fh:
+            try:
+                self.auto_playlist_cachemap = json.load(fh)
+                log.info(
+                    f"Loaded auto playlist cache map with {len(self.auto_playlist_cachemap)} entries."
+                )
+            except Exception:
+                log.exception("Failed to load auto playlist cache map.")
+                self.auto_playlist_cachemap = {}
+
+    async def save_autoplay_cachemap(self):
+        if (
+            not self.config.storage_retain_autoplay
+            or not self.config.auto_playlist
+            or not self.config.save_videos
+        ):
+            return
+
+        async with self.aiolocks[_func_()]:
+            try:
+                with open(self.config.auto_playlist_cachemap_file, "w") as fh:
+                    json.dump(self.auto_playlist_cachemap, fh)
+                    log.info(
+                        f"Saved auto playlist cache map with {len(self.auto_playlist_cachemap)} entries."
+                    )
+            except Exception:
+                log.exception("Failed to save auto playlist cache map.")
+
+    def add_autoplay_cachemap_entry(self, entry):
+        if (
+            not self.config.storage_retain_autoplay
+            or not self.config.auto_playlist
+            or not self.config.save_videos
+        ):
+            return
+
+        filename = pathlib.Path(entry.filename).stem
+        if filename in self.auto_playlist_cachemap:
+            if self.auto_playlist_cachemap[filename] != entry.url:
+                log.warning(
+                    "Auto playlist cache map conflict on Key: {}  Old: {}  New: {}".format(
+                        filename,
+                        self.auto_playlist_cachemap[filename],
+                        entry.url,
+                    )
+                )
+        self.auto_playlist_cachemap[filename] = entry.url
+
+    def remove_autoplay_cachemap_entry(self, entry):
+        if (
+            not self.config.storage_retain_autoplay
+            or not self.config.auto_playlist
+            or not self.config.save_videos
+        ):
+            return
+
+        filename = pathlib.Path(entry.filename).stem
+        if filename in self.auto_playlist_cachemap:
+            del self.auto_playlist_cachemap[filename]
+
+    def remove_autoplay_cachemap_entry_by_url(self, url):
+        if (
+            not self.config.storage_retain_autoplay
+            or not self.config.auto_playlist
+            or not self.config.save_videos
+        ):
+            return
+
+        to_remove = set()
+        for map_key, map_url in self.auto_playlist_cachemap.items():
+            if map_url == url:
+                to_remove.add(map_key)
+        for key in to_remove:
+            del self.auto_playlist_cachemap[key]
+
+    def _check_autoplay_cachemap(self, filename: pathlib.Path) -> bool:
+        """
+        Test if filename is a valid autoplaylist file still.
+        Returns True if map entry URL is still in autoplaylist.
+        If settings are disabled for cache retention this will also return false.
+        """
+        if (
+            not self.config.storage_retain_autoplay
+            or not self.config.auto_playlist
+            or not self.config.save_videos
+        ):
+            return False
+
+        if filename.stem in self.auto_playlist_cachemap:
+            cached_url = self.auto_playlist_cachemap[filename.stem]
+            if cached_url in self.bot.autoplaylist:
+                return True
+
+        return False

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -7,8 +7,6 @@ import shutil
 import time
 
 from .utils import format_size_from_bytes
-from .bot import MusicBot
-from .entry import Entry
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +16,7 @@ class AudioFileCache:
     This class provides methods to manage the audio file cache and get info about it.
     """
 
-    def __init__(self, bot: MusicBot) -> None:
+    def __init__(self, bot: 'MusicBot') -> None:
         self.bot = bot
         self.config = bot.config
         self.cache_path = pathlib.Path(bot.config.audio_cache_path)
@@ -201,8 +199,8 @@ class AudioFileCache:
 
         return True
 
-    def handle_new_cache_entry(self, entry: Entry) -> None:
-        """
+    def handle_new_cache_entry(self, entry: 'BasePlaylistEntry') -> None:
+        """1
         Test given entry for cachemap inclusion and run cache limit checks.
         """
         if entry.url in self.bot.autoplaylist:
@@ -278,7 +276,7 @@ class AudioFileCache:
             except Exception:
                 log.exception("Failed to save autoplaylist cache map.")
 
-    def add_autoplay_cachemap_entry(self, entry: Entry) -> None:
+    def add_autoplay_cachemap_entry(self, entry: 'BasePlaylistEntry') -> None:
         """
         Store an entry in autoplaylist cachemap, and update the cachemap file if needed.
         """
@@ -309,7 +307,7 @@ class AudioFileCache:
         if change_made:
             self.bot.loop.create_task(self.save_autoplay_cachemap())
 
-    def remove_autoplay_cachemap_entry(self, entry: Entry) -> None:
+    def remove_autoplay_cachemap_entry(self, entry: 'BasePlaylistEntry') -> None:
         """
         Remove an entry from cachemap and update cachemap file if needed.
         """

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -6,7 +6,12 @@ import pathlib
 import shutil
 import time
 
+from typing import TYPE_CHECKING
 from .utils import format_size_from_bytes
+
+if TYPE_CHECKING:
+    from .bot import MusicBot
+    from .entry import BasePlaylistEntry
 
 log = logging.getLogger(__name__)
 
@@ -16,7 +21,7 @@ class AudioFileCache:
     This class provides methods to manage the audio file cache and get info about it.
     """
 
-    def __init__(self, bot: 'MusicBot') -> None:
+    def __init__(self, bot: "MusicBot") -> None:
         self.bot = bot
         self.config = bot.config
         self.cache_path = pathlib.Path(bot.config.audio_cache_path)
@@ -200,7 +205,7 @@ class AudioFileCache:
 
         return True
 
-    def handle_new_cache_entry(self, entry: 'BasePlaylistEntry') -> None:
+    def handle_new_cache_entry(self, entry: "BasePlaylistEntry") -> None:
         """1
         Test given entry for cachemap inclusion and run cache limit checks.
         """
@@ -277,7 +282,7 @@ class AudioFileCache:
             except Exception:
                 log.exception("Failed to save autoplaylist cache map.")
 
-    def add_autoplay_cachemap_entry(self, entry: 'BasePlaylistEntry') -> None:
+    def add_autoplay_cachemap_entry(self, entry: "BasePlaylistEntry") -> None:
         """
         Store an entry in autoplaylist cachemap, and update the cachemap file if needed.
         """
@@ -308,7 +313,7 @@ class AudioFileCache:
         if change_made:
             self.bot.loop.create_task(self.save_autoplay_cachemap())
 
-    def remove_autoplay_cachemap_entry(self, entry: 'BasePlaylistEntry') -> None:
+    def remove_autoplay_cachemap_entry(self, entry: "BasePlaylistEntry") -> None:
         """
         Remove an entry from cachemap and update cachemap file if needed.
         """


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10.12
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black) and Flake8

----

### Description

Yet another cache-related PR, and easily the biggest.  This PR primarily focuses on adding the `StorageRetainAutoPlay` option to allow autoplaylist cache to be retained regardless of the other cache settings.  The retention depends on `SaveVideos` being enabled still.  
The option can only retain autoplaylist entries that have been stored in the cachemap.  Cachemap entries are stored only when they are played.  Rational for this design is taken from the fact that the autoplaylist.txt file can be an arbitrarily large size, and extracting information on each entry would be too time consuming to do at start-up.  

Currently the "cachemap" is a JSON file associating filenames without extensions to their respective URL in the autoplaylist file. The cachmap is named using the filename stem of the autoplaylist file, and saved in the same folder with the original list file.  

This PR resulted in a sizable refactor of the cache related code and some of the code related to autoplaylist management.  
Much of it has been tested, but some edge cases like `ContentTooShortError` processing will likely need testing in the wild and future adjustment.  

### Related issues

#1854 
#1549 
#173 

This also checks a box in planned features issue # 1 ;)