### PR TITLE
Inactive player timeout & timer touch ups.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -180,6 +180,10 @@ LeaveInactiveVCTimeOut = 300
 # Sets if if the bot should leave once all songs have finished playing.
 LeaveAfterSong = no
 
+# Set a period of seconds that the player can be idle to disconnect it.
+# leave this set 0 to disable.
+LeavePlayerInactiveFor = 0
+
 # Round robin queue
 # When enabled the bot will automatically rotate between user requested songs.
 RoundRobinQueue = no

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -184,7 +184,7 @@ LeaveInactiveVC = no
 LeaveInactiveVCTimeOut = 300
 
 # Sets if if the bot should leave immediately once all songs have finished playing.
-LeaveAfterQueueEmpty = no
+LeaveAfterSong = no
 
 # Set a period of seconds that a player can be paused or not playing before it will disconnect.
 # This setting is independent of LeaveAfterQueueEmpty.

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -172,18 +172,24 @@ CustomEmbedFooter =
 # Sets if you'd like the bot to deafen when joining a voice channel.
 SelfDeafen = yes
 
-# Sets if you would like to have the bot leave a VC with no one in it. Excluding itself.
+# Sets if the bot should leave a voice channel when it becomes empty.
 LeaveInactiveVC = no
 
-# Sets how long you'd like to wait before leaving a voice channel that is inactive.
-# Time is in seconds.
+# Sets how long the bot should wait before leaving a voice channel that is inactive.
+# Only applies if LeaveInactiveVC is enabled.
+# Time can be set in seconds or as a duration phrase containing any of: day, hour, minute, second
+# Examples:
+#   .5 hours,  1 day,  77min
+# Default value is 300 seconds.
 LeaveInactiveVCTimeOut = 300
 
-# Sets if if the bot should leave once all songs have finished playing.
-LeaveAfterSong = no
+# Sets if if the bot should leave immediately once all songs have finished playing.
+LeaveAfterQueueEmpty = no
 
-# Set a period of seconds that the player can be idle to disconnect it.
-# leave this set 0 to disable.
+# Set a period of seconds that a player can be paused or not playing before it will disconnect.
+# This setting is independent of LeaveAfterQueueEmpty.
+# Time can be set in seconds or using duration as described in LeaveInactiveVCTimeOut
+# Set to 0 to disable.  Default value is 0.
 LeavePlayerInactiveFor = 0
 
 # Round robin queue

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1522,7 +1522,7 @@ class MusicBot(discord.Client):
         write_file(self.config.auto_playlist_file, self.autoplaylist)
         log.debug("Removed {} from autoplaylist".format(url))
 
-    async def handle_timeout(self, guild: discord.Guild):
+    async def handle_vc_inactivity(self, guild: discord.Guild):
         event, active = self.server_specific_data[guild]["inactive_vc_timer"]
 
         self.server_specific_data[guild]["inactive_vc_timer"] = (event, True)
@@ -1538,7 +1538,7 @@ class MusicBot(discord.Client):
             log.debug(
                 f"Channel activity timer for {guild.name} has expired. Disconnecting."
             )
-            await self.on_timeout_expired(guild.me.voice.channel)
+            await self.on_inactivity_timeout_expired(guild.me.voice.channel)
         else:
             log.debug(
                 f"Channel activity timer canceled for: {guild.me.voice.channel.name} in {guild.name}"
@@ -1577,7 +1577,7 @@ class MusicBot(discord.Client):
             log.debug(
                 f"Player activity timer for {guild.name} has expired. Disconnecting."
             )
-            await self.on_timeout_expired(guild.me.voice.channel)
+            await self.on_inactivity_timeout_expired(guild.me.voice.channel)
         else:
             log.debug(
                 f"Player activity timer canceled for: {guild.me.voice.channel.name} in {guild.name}"
@@ -4739,7 +4739,7 @@ class MusicBot(discord.Client):
                         "{}{}".format(self.config.command_prefix, command_name)
                     )
 
-    async def on_timeout_expired(self, voice_channel):
+    async def on_inactivity_timeout_expired(self, voice_channel):
         guild = voice_channel.guild
 
         if voice_channel:
@@ -4781,7 +4781,7 @@ class MusicBot(discord.Client):
                     log.info(
                         f"{before.channel.name} has been detected as empty. Handling timeouts."
                     )
-                    await self.handle_timeout(guild)
+                    await self.handle_vc_inactivity(guild)
             elif after.channel and member != self.user:
                 if self.user in after.channel.members:
                     if (
@@ -4799,7 +4799,7 @@ class MusicBot(discord.Client):
                     log.info(
                         f"The bot got moved and the voice channel {after.channel.name} is empty. Handling timeouts."
                     )
-                    await self.handle_timeout(guild)
+                    await self.handle_vc_inactivity(guild)
                 else:
                     if active:
                         log.info(

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -4749,12 +4749,12 @@ class MusicBot(discord.Client):
                 if self.config.embeds:
                     embed = self._gen_embed()
                     embed.title = "Leaving voice channel"
-                    embed.description = f"Leaving voice channel {voice_channel.name} in {voice_channel.guild} due to inactivity."
+                    embed.description = f"Leaving voice channel {voice_channel.name} due to inactivity."
                     await self.safe_send_message(channel, embed, expire_in=30)
                 else:
                     await self.safe_send_message(
                         channel,
-                        f"Leaving voice channel {voice_channel.name} in {voice_channel.guild} due to inactivity.",
+                        f"Leaving voice channel {voice_channel.name} in due to inactivity.",
                         expire_in=30,
                     )
             except Exception:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -567,8 +567,14 @@ class MusicBot(discord.Client):
 
         if guild.id in self.players:
             player = self.players.pop(guild.id)
-            if self.config.leave_player_inactive_for > 0:
-                await self.reset_player_inactivity(player)
+
+            await self.reset_player_inactivity(player)
+
+            if self.config.leave_inactive_channel:
+                event, active = self.server_specific_data[guild]["inactive_vc_timer"]
+                if active and not event.is_set():
+                    event.set()
+
             player.kill()
 
         await self.update_now_playing_status()

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1568,7 +1568,7 @@ class MusicBot(discord.Client):
 
         try:
             log.debug(
-                f"Player activity timer waiting {self.config.leave_player_inactive_for} seconds to leave channel: {guild.me.voice.channel.name}"
+                f"Player activity timer waiting {self.config.leave_player_inactive_for} seconds to leave channel: {channel.name}"
             )
             await discord.utils.sane_wait_for(
                 [event.wait()], timeout=self.config.leave_player_inactive_for
@@ -1577,10 +1577,10 @@ class MusicBot(discord.Client):
             log.debug(
                 f"Player activity timer for {guild.name} has expired. Disconnecting."
             )
-            await self.on_inactivity_timeout_expired(guild.me.voice.channel)
+            await self.on_inactivity_timeout_expired(channel)
         else:
             log.debug(
-                f"Player activity timer canceled for: {guild.me.voice.channel.name} in {guild.name}"
+                f"Player activity timer canceled for: {channel.name} in {guild.name}"
             )
         finally:
             log.debug(f"Cleaning up player activity timer for guild {guild.name}.")
@@ -1592,7 +1592,7 @@ class MusicBot(discord.Client):
             return
         guild = player.voice_client.channel.guild
         event, active = self.server_specific_data[guild]["inactive_player_timer"]
-        if active:
+        if active and not event.is_set():
             event.set()
             log.debug("Player activity timer is being reset.")
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -780,7 +780,7 @@ class MusicBot(discord.Client):
 
     async def on_player_finished_playing(self, player, **_):
         log.debug("Running on_player_finished_playing")
-        if self.config.leave_after_song:
+        if self.config.leave_after_queue_empty:
             guild = player.voice_client.guild
             if player.playlist.entries.__len__() == 0:
                 log.info("Player finished and queue is empty, leaving voice channel...")
@@ -1465,7 +1465,7 @@ class MusicBot(discord.Client):
             )
             log.info(
                 "  Leave at song end/empty queue: "
-                + ["Disabled", "Enabled"][self.config.leave_after_song]
+                + ["Disabled", "Enabled"][self.config.leave_after_queue_empty]
             )
             log.info(
                 f"  Leave when player idles: {'Disabled' if self.config.leave_player_inactive_for == 0 else 'Enabled'}"

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -910,14 +910,19 @@ class MusicBot(discord.Client):
         if not self.config.status_message:
             entry = None
             paused = False
-            activeplayers = sum(1 for p in self.players.values() if p.is_playing)
-            if activeplayers > 1:
+            activeplayers = [p for p in self.players.values() if p.is_playing]
+            if len(activeplayers) > 1:
                 game = discord.Game(
                     type=0, name="music on %s guilds" % activeplayers
                 )
 
-            elif activeplayers == 1:
-                player = discord.utils.get(self.players.values(), is_playing=True)
+            elif len(activeplayers) == 1:
+                player = activeplayers[0]
+                paused = player.is_paused
+                entry = player.current_entry
+
+            elif len(self.players):
+                player = list(self.players.values())[0]
                 paused = player.is_paused
                 entry = player.current_entry
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1555,7 +1555,7 @@ class MusicBot(discord.Client):
         guild = channel.guild
         event, event_active = self.server_specific_data[guild]["inactive_player_timer"]
 
-        if channel in self.autojoin_channels:
+        if str(channel.id) in str(self.config.autojoin_channels):
             log.debug(
                 f"Ignoring player inactivity in auto-joined channel:  {channel.name}"
             )

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1528,23 +1528,22 @@ class MusicBot(discord.Client):
         self.server_specific_data[guild]["inactive_vc_timer"] = (event, True)
 
         try:
-            log.debug(
+            log.info(
                 f"Channel activity waiting {self.config.leave_inactive_channel_timeout} seconds to leave channel: {guild.me.voice.channel.name}"
             )
             await discord.utils.sane_wait_for(
                 [event.wait()], timeout=self.config.leave_inactive_channel_timeout
             )
         except asyncio.TimeoutError:
-            log.debug(
+            log.info(
                 f"Channel activity timer for {guild.name} has expired. Disconnecting."
             )
             await self.on_inactivity_timeout_expired(guild.me.voice.channel)
         else:
-            log.debug(
+            log.info(
                 f"Channel activity timer canceled for: {guild.me.voice.channel.name} in {guild.name}"
             )
         finally:
-            log.debug(f"Cleaning up channel activity timer for guild {guild.name}.")
             self.server_specific_data[guild]["inactive_vc_timer"] = (event, False)
             event.clear()
 
@@ -1567,23 +1566,22 @@ class MusicBot(discord.Client):
         self.server_specific_data[guild]["inactive_player_timer"] = (event, True)
 
         try:
-            log.debug(
+            log.info(
                 f"Player activity timer waiting {self.config.leave_player_inactive_for} seconds to leave channel: {channel.name}"
             )
             await discord.utils.sane_wait_for(
                 [event.wait()], timeout=self.config.leave_player_inactive_for
             )
         except asyncio.TimeoutError:
-            log.debug(
+            log.info(
                 f"Player activity timer for {guild.name} has expired. Disconnecting."
             )
             await self.on_inactivity_timeout_expired(channel)
         else:
-            log.debug(
+            log.info(
                 f"Player activity timer canceled for: {channel.name} in {guild.name}"
             )
         finally:
-            log.debug(f"Cleaning up player activity timer for guild {guild.name}.")
             self.server_specific_data[guild]["inactive_player_timer"] = (event, False)
             event.clear()
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -763,13 +763,13 @@ class MusicBot(discord.Client):
     async def on_player_pause(self, player, entry, **_):
         log.debug("Running on_player_pause")
         await self.update_now_playing_status(entry, True)
-        await self.handle_player_inactivity(player)
+        self.loop.create_task(self.handle_player_inactivity(player))
         # await self.serialize_queue(player.voice_client.channel.guild)
 
     async def on_player_stop(self, player, **_):
         log.debug("Running on_player_stop")
-        await self.handle_player_inactivity(player)
         await self.update_now_playing_status()
+        self.loop.create_task(self.handle_player_inactivity(player))
 
     async def on_player_finished_playing(self, player, **_):
         log.debug("Running on_player_finished_playing")
@@ -4783,7 +4783,7 @@ class MusicBot(discord.Client):
                     log.info(
                         f"{before.channel.name} has been detected as empty. Handling timeouts."
                     )
-                    await self.handle_vc_inactivity(guild)
+                    self.loop.create_task(self.handle_vc_inactivity(guild))
             elif after.channel and member != self.user:
                 if self.user in after.channel.members:
                     if (
@@ -4801,7 +4801,7 @@ class MusicBot(discord.Client):
                     log.info(
                         f"The bot got moved and the voice channel {after.channel.name} is empty. Handling timeouts."
                     )
-                    await self.handle_vc_inactivity(guild)
+                    self.loop.create_task(self.handle_vc_inactivity(guild))
                 else:
                     if active:
                         log.info(

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -932,7 +932,9 @@ class MusicBot(discord.Client):
                 name = "{}{}".format(prefix, entry.title)[:128]
                 game = discord.Game(type=0, name=name)
         else:
-            game = discord.Game(type=0, name=self.config.status_message.strip()[:128])
+            game = discord.Game(
+                type=0, name=self.config.status_message.strip()[:128]
+            )
 
         async with self.aiolocks[_func_()]:
             if game != self.last_status:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -912,9 +912,7 @@ class MusicBot(discord.Client):
             paused = False
             activeplayers = [p for p in self.players.values() if p.is_playing]
             if len(activeplayers) > 1:
-                game = discord.Game(
-                    type=0, name="music on %s guilds" % activeplayers
-                )
+                game = discord.Game(type=0, name="music on %s guilds" % activeplayers)
 
             elif len(activeplayers) == 1:
                 player = activeplayers[0]
@@ -932,9 +930,7 @@ class MusicBot(discord.Client):
                 name = "{}{}".format(prefix, entry.title)[:128]
                 game = discord.Game(type=0, name=name)
         else:
-            game = discord.Game(
-                type=0, name=self.config.status_message.strip()[:128]
-            )
+            game = discord.Game(type=0, name=self.config.status_message.strip()[:128])
 
         async with self.aiolocks[_func_()]:
             if game != self.last_status:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -571,6 +571,7 @@ class MusicBot(discord.Client):
                 await self.reset_player_inactivity(player)
             player.kill()
 
+        await self.update_now_playing_status()
         await vc.disconnect()
 
     async def disconnect_all_voice_clients(self):

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1536,6 +1536,9 @@ class MusicBot(discord.Client):
     async def handle_vc_inactivity(self, guild: discord.Guild):
         event, active = self.server_specific_data[guild]["inactive_vc_timer"]
 
+        if active:
+            log.debug(f"Channel activity already waiting in guild: {guild}")
+            return
         self.server_specific_data[guild]["inactive_vc_timer"] = (event, True)
 
         try:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -4749,7 +4749,9 @@ class MusicBot(discord.Client):
                 if self.config.embeds:
                     embed = self._gen_embed()
                     embed.title = "Leaving voice channel"
-                    embed.description = f"Leaving voice channel {voice_channel.name} due to inactivity."
+                    embed.description = (
+                        f"Leaving voice channel {voice_channel.name} due to inactivity."
+                    )
                     await self.safe_send_message(channel, embed, expire_in=30)
                 else:
                     await self.safe_send_message(

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -208,7 +208,7 @@ class Config:
         )
         self.leave_after_queue_empty = config.getboolean(
             "MusicBot",
-            "LeaveAfterQueueEmpty",
+            "LeaveAfterSong",
             fallback=ConfigDefaults.leave_after_queue_empty,
         )
         self.leave_player_inactive_for = config.get(

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -195,16 +195,23 @@ class Config:
         self.self_deafen = config.getboolean(
             "MusicBot", "SelfDeafen", fallback=ConfigDefaults.self_deafen
         )
-        self.leave_inactives = config.getboolean(
-            "MusicBot", "LeaveInactiveVC", fallback=ConfigDefaults.leave_inactiveVC
+        self.leave_inactive_channel = config.getboolean(
+            "MusicBot",
+            "LeaveInactiveVC",
+            fallback=ConfigDefaults.leave_inactive_channel,
         )
-        self.leave_inactiveVCTimeOut = config.getint(
+        self.leave_inactive_channel_timeout = config.getint(
             "MusicBot",
             "LeaveInactiveVCTimeOut",
-            fallback=ConfigDefaults.leave_inactiveVCTimeOut,
+            fallback=ConfigDefaults.leave_inactive_channel_timeout,
         )
         self.leave_after_song = config.getboolean(
             "MusicBot", "LeaveAfterSong", fallback=ConfigDefaults.leave_after_song
+        )
+        self.leave_player_inactive_for = config.getint(
+            "MusicBot",
+            "LeavePlayerInactiveFor",
+            fallback=ConfigDefaults.leave_player_inactive_for,
         )
         self.searchlist = config.getboolean(
             "MusicBot", "SearchList", fallback=ConfigDefaults.searchlist
@@ -545,9 +552,10 @@ class ConfigDefaults:
     usealias = True
     searchlist = False
     self_deafen = True
-    leave_inactiveVC = False
-    leave_inactiveVCTimeOut = 300
+    leave_inactive_channel = False
+    leave_inactive_channel_timeout = 300
     leave_after_song = False
+    leave_player_inactive_for = 0
     defaultsearchresults = 3
     footer_text = "Just-Some-Bots/MusicBot ({})".format(BOTVERSION)
     defaultround_robin_queue = False

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -120,7 +120,7 @@ class Config:
         self.storage_limit_bytes = config.get(
             "MusicBot", "StorageLimitBytes", fallback=ConfigDefaults.storage_limit_bytes
         )
-        self.storage_limit_days = config.get(
+        self.storage_limit_days = config.getint(
             "MusicBot", "StorageLimitDays", fallback=ConfigDefaults.storage_limit_days
         )
         self.now_playing_mentions = config.getboolean(
@@ -424,9 +424,6 @@ class Config:
                     ),
                 )
                 self.storage_limit_bytes = ConfigDefaults.storage_limit_bytes
-
-        if self.storage_limit_days:
-            self.storage_limit_days = format_time_to_seconds(self.storage_limit_days)
 
         if self.leave_inactive_channel_timeout:
             self.leave_inactive_channel_timeout = format_time_to_seconds(

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -207,7 +207,9 @@ class Config:
             fallback=ConfigDefaults.leave_inactive_channel_timeout,
         )
         self.leave_after_queue_empty = config.getboolean(
-            "MusicBot", "LeaveAfterQueueEmpty", fallback=ConfigDefaults.leave_after_queue_empty
+            "MusicBot",
+            "LeaveAfterQueueEmpty",
+            fallback=ConfigDefaults.leave_after_queue_empty,
         )
         self.leave_player_inactive_for = config.get(
             "MusicBot",

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -7,7 +7,7 @@ import configparser
 
 from .exceptions import HelpfulError
 from .constants import VERSION as BOTVERSION
-from .utils import format_size_to_bytes
+from .utils import format_size_to_bytes, format_time_to_seconds
 
 log = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class Config:
         self.storage_limit_bytes = config.get(
             "MusicBot", "StorageLimitBytes", fallback=ConfigDefaults.storage_limit_bytes
         )
-        self.storage_limit_days = config.getint(
+        self.storage_limit_days = config.get(
             "MusicBot", "StorageLimitDays", fallback=ConfigDefaults.storage_limit_days
         )
         self.now_playing_mentions = config.getboolean(
@@ -201,7 +201,7 @@ class Config:
             "LeaveInactiveVC",
             fallback=ConfigDefaults.leave_inactive_channel,
         )
-        self.leave_inactive_channel_timeout = config.getint(
+        self.leave_inactive_channel_timeout = config.get(
             "MusicBot",
             "LeaveInactiveVCTimeOut",
             fallback=ConfigDefaults.leave_inactive_channel_timeout,
@@ -209,7 +209,7 @@ class Config:
         self.leave_after_song = config.getboolean(
             "MusicBot", "LeaveAfterSong", fallback=ConfigDefaults.leave_after_song
         )
-        self.leave_player_inactive_for = config.getint(
+        self.leave_player_inactive_for = config.get(
             "MusicBot",
             "LeavePlayerInactiveFor",
             fallback=ConfigDefaults.leave_player_inactive_for,
@@ -424,6 +424,19 @@ class Config:
                     ),
                 )
                 self.storage_limit_bytes = ConfigDefaults.storage_limit_bytes
+
+        if self.storage_limit_days:
+            self.storage_limit_days = format_time_to_seconds(self.storage_limit_days)
+
+        if self.leave_inactive_channel_timeout:
+            self.leave_inactive_channel_timeout = format_time_to_seconds(
+                self.leave_inactive_channel_timeout
+            )
+
+        if self.leave_player_inactive_for:
+            self.leave_player_inactive_for = format_time_to_seconds(
+                self.leave_player_inactive_for
+            )
 
     # TODO: Add save function for future editing of options with commands
     #       Maybe add warnings about fields missing from the config file

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -206,8 +206,8 @@ class Config:
             "LeaveInactiveVCTimeOut",
             fallback=ConfigDefaults.leave_inactive_channel_timeout,
         )
-        self.leave_after_song = config.getboolean(
-            "MusicBot", "LeaveAfterSong", fallback=ConfigDefaults.leave_after_song
+        self.leave_after_queue_empty = config.getboolean(
+            "MusicBot", "LeaveAfterQueueEmpty", fallback=ConfigDefaults.leave_after_queue_empty
         )
         self.leave_player_inactive_for = config.get(
             "MusicBot",
@@ -578,7 +578,7 @@ class ConfigDefaults:
     self_deafen = True
     leave_inactive_channel = False
     leave_inactive_channel_timeout = 300
-    leave_after_song = False
+    leave_after_queue_empty = False
     leave_player_inactive_for = 0
     defaultsearchresults = 3
     footer_text = "Just-Some-Bots/MusicBot ({})".format(BOTVERSION)

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import logging
 import aiohttp

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -243,3 +243,36 @@ def format_size_to_bytes(size_str: str, strict_si=False) -> int:
         elif size_str.endswith("byte"):
             size_str = size_str[0:-4]
     return int(size_str)
+
+
+def format_time_to_seconds(time_str: str) -> int:
+    """Convert a phrase containing time duration(s) to seconds as int
+    This function allows for intresting/sloppy time notations like:
+    - 1yearand2seconds  = 31556954
+    - 8s 1d             = 86408
+    - .5 hours          = 1800
+    - 99 + 1            = 100
+    - 3600              = 3600
+    Only partial seconds are not supported, thus ".5s + 1.5s" will be 1 not 2.
+
+    Param `time_str` is assumed to contain a time duration.
+    Returns 0 if no time value is recognised, rather than raise a ValueError.
+    """
+    # TODO: find a good way to make this i18n friendly.
+    time_lex = re.compile(r"(\d*\.?\d+)\s*(y|d|h|m|s)?", re.I)
+    unit_seconds = {
+        "y": 31556952,
+        "d": 86400,
+        "h": 3600,
+        "m": 60,
+        "s": 1,
+    }
+    total_sec = 0
+    for value, unit in time_lex.findall(time_str):
+        print(value, unit)
+        if not unit:
+            unit = "s"
+        else:
+            unit = unit[0].lower().strip()
+        total_sec += int(float(value) * unit_seconds[unit])
+    return total_sec

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -270,7 +270,6 @@ def format_time_to_seconds(time_str: str) -> int:
     }
     total_sec = 0
     for value, unit in time_lex.findall(time_str):
-        print(value, unit)
         if not unit:
             unit = "s"
         else:


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10.12
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR builds on the recently added channel inactivity timer. 
It adds one new option `LeavePlayerInactiveFor` which allows control over automatically disconnecting a player from voice when it is paused, or otherwise not playing music for the set duration.   It does not impact the `LeaveAfterSong` setting which will still immediately disconnect. 
Some variable and function names were changed to be more consistent and clarify their intent in code.  
In addition, the timer options can now be set using a phrase containing time duration(s) which are briefly documented in the `example_options.ini` file.

