### PR TITLE
Better SSL Patch

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1159,19 +1159,24 @@ class MusicBot(discord.Client):
 
     async def _cleanup(self):
         try:
-            await self.logout()
+            await self.close()  # changed in d.py 2.0
+        except Exception:
+            log.exception("Issue while closing discord client connection.")
+            pass
+        try:
             await self.session.close()
-        except:
+        except Exception:
+            log.exception("Issue while cleaning up aiohttp session.")
             pass
 
         pending = asyncio.all_tasks(loop=self.loop)
 
         for task in pending:
             task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
     # noinspection PyMethodOverriding
     async def run(self):

--- a/musicbot/spotify.py
+++ b/musicbot/spotify.py
@@ -77,9 +77,7 @@ class Spotify:
 
     async def make_post(self, url, payload, headers=None):
         """Makes a POST request and returns the results"""
-        async with self.aiosession.post(
-            url, data=payload, headers=headers
-        ) as r:
+        async with self.aiosession.post(url, data=payload, headers=headers) as r:
             if r.status != 200:
                 raise SpotifyError(
                     "Issue making POST request to {0}: [{1.status}] {2}".format(

--- a/musicbot/spotify.py
+++ b/musicbot/spotify.py
@@ -2,9 +2,7 @@ import aiohttp
 import asyncio
 import asyncio.exceptions
 import base64
-import certifi
 import logging
-import ssl
 import time
 
 from .exceptions import SpotifyError
@@ -27,13 +25,12 @@ class Spotify:
     OAUTH_TOKEN_URL = "https://accounts.spotify.com/api/token"
     API_BASE = "https://api.spotify.com/v1/"
 
-    def __init__(self, client_id, client_secret, aiosession=None, loop=None):
+    def __init__(self, client_id, client_secret, aiosession, loop=None):
         self.client_id = client_id
         self.client_secret = client_secret
         self.guest_mode = client_id is None or client_secret is None
 
-        self.ssl_context = ssl.create_default_context(cafile=certifi.where())
-        self.aiosession = aiosession if aiosession else aiohttp.ClientSession()
+        self.aiosession = aiosession
         self.loop = loop if loop else asyncio.get_event_loop()
 
         self.token = None
@@ -69,7 +66,7 @@ class Spotify:
 
     async def make_get(self, url, headers=None):
         """Makes a GET request and returns the results"""
-        async with self.aiosession.get(url, headers=headers, ssl=self.ssl_context) as r:
+        async with self.aiosession.get(url, headers=headers) as r:
             if r.status != 200:
                 raise SpotifyError(
                     "Issue making GET request to {0}: [{1.status}] {2}".format(
@@ -81,7 +78,7 @@ class Spotify:
     async def make_post(self, url, payload, headers=None):
         """Makes a POST request and returns the results"""
         async with self.aiosession.post(
-            url, data=payload, headers=headers, ssl=self.ssl_context
+            url, data=payload, headers=headers
         ) as r:
             if r.status != 200:
                 raise SpotifyError(
@@ -142,7 +139,6 @@ class Spotify:
         try:
             async with self.aiosession.get(
                 "https://open.spotify.com/get_access_token?reason=transport&productType=web_player",
-                ssl=self.ssl_context,
             ) as r:
                 if r.status != 200:
                     try:

--- a/run.py
+++ b/run.py
@@ -413,6 +413,10 @@ async def main():
             ssl.SSLCertVerificationError,
             aiohttp.client_exceptions.ClientConnectorCertificateError,
         ) as e:
+            if m and m.session:
+                # make sure we close the session(s)
+                await m._cleanup()
+
             if (
                 isinstance(e, aiohttp.client_exceptions.ClientConnectorCertificateError)
                 and isinstance(e.__cause__, ssl.SSLCertVerificationError)

--- a/run.py
+++ b/run.py
@@ -28,7 +28,7 @@ class GIT(object):
     def works(cls):
         try:
             return bool(subprocess.check_output("git --version", shell=True))
-        except:
+        except Exception:
             return False
 
 
@@ -42,7 +42,7 @@ class PIP(object):
             return PIP.run_python_m(*command.split(), check_output=check_output)
         except subprocess.CalledProcessError as e:
             return e.returncode
-        except:
+        except Exception:
             traceback.print_exc()
             print("Error using -m method")
 
@@ -67,7 +67,7 @@ class PIP(object):
 
             try:
                 pip.main(args)
-            except:
+            except Exception:
                 traceback.print_exc()
             finally:
                 sys.stdout = sys.__stdout__
@@ -114,7 +114,7 @@ class PIP(object):
                 return expectedversion.split()[1]
             else:
                 return [x.split()[1] for x in datas if x.startswith("Version: ")][0]
-        except:
+        except Exception:
             pass
 
     @classmethod
@@ -153,7 +153,7 @@ def finalize_logging():
             if os.path.isfile("logs/musicbot.log.last"):
                 os.unlink("logs/musicbot.log.last")
             os.rename("logs/musicbot.log", "logs/musicbot.log.last")
-        except:
+        except Exception:
             pass
 
     with open("logs/musicbot.log", "w", encoding="utf8") as f:
@@ -245,12 +245,12 @@ def req_ensure_py3():
             try:
                 subprocess.check_output('py -3.8 -c "exit()"', shell=True)
                 pycom = "py -3.8"
-            except:
+            except Exception:
                 log.info('Trying "python3"')
                 try:
                     subprocess.check_output('python3 -c "exit()"', shell=True)
                     pycom = "python3"
-                except:
+                except Exception:
                     pass
 
             if pycom:
@@ -269,7 +269,7 @@ def req_ensure_py3():
                     .strip()
                     .decode()
                 )
-            except:
+            except Exception:
                 pass
 
             if pycom:
@@ -449,12 +449,12 @@ async def main():
 
                 err = PIP.run_install("--upgrade -r requirements.txt")
 
-                if (
-                    err
-                ):  # TODO: add the specific error check back as not to always tell users to sudo it
+                if err:  # TODO: add the specific error check back.
+                    # The proper thing to do here is tell the user to fix their install, not help make it worse.
+                    # Comprehensive return codes aren't really a feature of pip, we'd need to read the log, and so does the user.
                     print()
                     log.critical(
-                        "You may need to %s to install dependencies."
+                        "This is not recommended! You can try to %s to install dependencies anyways."
                         % ["use sudo", "run as admin"][sys.platform.startswith("win")]
                     )
                     break
@@ -500,7 +500,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    # py3.8 made ProactorEventLoop default.
+    # py3.8 made ProactorEventLoop default on windows.
     # Now we need to make adjustments for a bug in aiohttp :)
-    loop = asynio.get_event_loop_policy().get_event_loop()
+    loop = asyncio.get_event_loop_policy().get_event_loop()
     loop.run_until_complete(main())

--- a/run.py
+++ b/run.py
@@ -432,11 +432,11 @@ async def main():
             if e.verify_code == 20:  # X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
                 if use_certifi:
                     log.exception("Could not get Issuer Cert even with certifi.  Try: pip install --upgrade certifi ")
+                    break
                 else:
                     log.warning("Could not get Issuer Certificate from default trust store, trying certifi instead.")
                     use_certifi = True
                     pass
-            break
 
         except SyntaxError:
             log.exception("Syntax error (this is a bug, not your fault)")

--- a/run.py
+++ b/run.py
@@ -417,13 +417,14 @@ async def main():
                 # make sure we close the session(s)
                 await m._cleanup()
 
-            if (
-                isinstance(e, aiohttp.client_exceptions.ClientConnectorCertificateError)
-                and isinstance(e.__cause__, ssl.SSLCertVerificationError)
-            ):
+            if isinstance(
+                e, aiohttp.client_exceptions.ClientConnectorCertificateError
+            ) and isinstance(e.__cause__, ssl.SSLCertVerificationError):
                 e = e.__cause__
             else:
-                log.critical("Certificate error is not a verification error, not trying certifi and exiting.")
+                log.critical(
+                    "Certificate error is not a verification error, not trying certifi and exiting."
+                )
                 break
 
             # In case the local trust store does not have the cert locally, we can try certifi.
@@ -431,10 +432,14 @@ async def main():
             # These verify_code values come from OpenSSL:  https://www.openssl.org/docs/man1.0.2/man1/verify.html
             if e.verify_code == 20:  # X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY
                 if use_certifi:
-                    log.exception("Could not get Issuer Cert even with certifi.  Try: pip install --upgrade certifi ")
+                    log.exception(
+                        "Could not get Issuer Cert even with certifi.  Try: pip install --upgrade certifi "
+                    )
                     break
                 else:
-                    log.warning("Could not get Issuer Certificate from default trust store, trying certifi instead.")
+                    log.warning(
+                        "Could not get Issuer Certificate from default trust store, trying certifi instead."
+                    )
                     use_certifi = True
                     pass
 

--- a/run.py
+++ b/run.py
@@ -390,12 +390,6 @@ async def main():
 
     finalize_logging()
 
-    import asyncio
-
-    if sys.platform == "win32":
-        loop = asyncio.ProactorEventLoop()  # needed for subprocesses
-        asyncio.set_event_loop(loop)
-
     tried_requirementstxt = False
     use_certifi = False
     tryagain = True
@@ -494,7 +488,6 @@ async def main():
                     traceback.print_exc()
                 break
 
-            asyncio.set_event_loop(asyncio.new_event_loop())
             loops += 1
 
         sleeptime = min(loops * 2, max_wait_time)
@@ -507,4 +500,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # py3.8 made ProactorEventLoop default.
+    # Now we need to make adjustments for a bug in aiohttp :)
+    loop = asynio.get_event_loop_policy().get_event_loop()
+    loop.run_until_complete(main())


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 and 3.10 in Windows and Linux
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black) & Flake8

----

### Description

This PR extends certifi patching to the discord http client session.   This deals with `SSLCertVerificationError` and `ClientConnectorCertificateError` by restarting the bot to load certifi certs only when the local trust store is missing them.  

Additionally this PR addresses some issues with _cleanup() and run.py to reduce errors and remove outdated code. 

