### PR TITLE
Fix error thrown when non-yt link is used.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -723,7 +723,9 @@ class MusicBot(discord.Client):
             if match:
                 # TODO: come up with a good way to extract thumbnails from ytdl data.
                 videoID = match.group(1)
-                content.set_image(url=f"https://i1.ytimg.com/vi/{videoID}/hqdefault.jpg")
+                content.set_image(
+                    url=f"https://i1.ytimg.com/vi/{videoID}/hqdefault.jpg"
+                )
             else:
                 log.error("Unknown link or unable to get video ID.")
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -719,17 +719,19 @@ class MusicBot(discord.Client):
                 url,
             )
 
+            content = self._gen_embed()
             if match:
+                # TODO: come up with a good way to extract thumbnails from ytdl data.
                 videoID = match.group(1)
+                content.set_image(url=f"https://i1.ytimg.com/vi/{videoID}/hqdefault.jpg")
             else:
                 log.error("Unknown link or unable to get video ID.")
-            content = self._gen_embed()
+
             if self.config.now_playing_mentions:
                 content.title = None
                 content.add_field(name="\n", value=newmsg, inline=True)
             else:
                 content.title = newmsg
-            content.set_image(url=f"https://i1.ytimg.com/vi/{videoID}/hqdefault.jpg")
 
         # send it in specified channel
         self.server_specific_data[guild]["last_np_msg"] = await self.safe_send_message(
@@ -3287,8 +3289,11 @@ class MusicBot(discord.Client):
                     url,
                 )
 
+                thumb_url = None
                 if match:
+                    # TODO: come up with a good way to extract thumbnails from the ytdl data.
                     videoID = match.group(1)
+                    thumb_url = f"https://i1.ytimg.com/vi/{videoID}/hqdefault.jpg"
                 else:
                     log.error("Unknown link or unable to get video ID.")
 
@@ -3302,9 +3307,8 @@ class MusicBot(discord.Client):
                 content.add_field(
                     name=f"Currently {action_text}", value=np_text, inline=True
                 )
-                content.set_image(
-                    url=f"https://i1.ytimg.com/vi/{videoID}/hqdefault.jpg"
-                )
+                if thumb_url:
+                    content.set_image(url=thumb_url)
 
             self.server_specific_data[guild][
                 "last_np_msg"


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8.10 on windows and 3.10.12 on linux
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This fixes an error thrown when playing links that aren't youtube links.
