### PR TITLE
Stop spotify playlists fetch on clear command

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2274,6 +2274,9 @@ class MusicBot(discord.Client):
 
         song_url = song_url.strip("<>")
 
+        if self.server_specific_data[channel.guild.id]["halt_playlist_unpack"]:
+            self.server_specific_data[channel.guild.id]["halt_playlist_unpack"] = False
+
         async with channel.typing():
             if leftover_args:
                 song_url = " ".join([song_url, *leftover_args])
@@ -3513,8 +3516,6 @@ class MusicBot(discord.Client):
 
         # This lets us signal to playlist queuing loops to stop adding to the queue.
         self.server_specific_data[guild.id]["halt_playlist_unpack"] = True
-        await asyncio.sleep(3)
-        self.server_specific_data[guild.id]["halt_playlist_unpack"] = False
 
         return Response(
             self.str.get("cmd-clear-reply", "Cleared `{0}`'s queue").format(

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3501,7 +3501,7 @@ class MusicBot(discord.Client):
             delete_after=15,
         )
 
-    async def cmd_clear(self, player, author):
+    async def cmd_clear(self, guild, player, author):
         """
         Usage:
             {command_prefix}clear
@@ -3512,9 +3512,9 @@ class MusicBot(discord.Client):
         player.playlist.clear()
 
         # This lets us signal to playlist queuing loops to stop adding to the queue.
-        self.server_specific_data[channel.guild.id]["halt_playlist_unpack"] = True
+        self.server_specific_data[guild.id]["halt_playlist_unpack"] = True
         await asyncio.sleep(3)
-        self.server_specific_data[channel.guild.id]["halt_playlist_unpack"] = False
+        self.server_specific_data[guild.id]["halt_playlist_unpack"] = False
 
         return Response(
             self.str.get("cmd-clear-reply", "Cleared `{0}`'s queue").format(


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8.10 on windows and 3.10.12 on linux
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

Adds yet another server-specific data entry to stop playlist loops from queuing songs after a `clear` command has been issued.   This PR has only focused on the spotify lists, since those seem the worst offender.   
Please inform if other playlist logic should be checked! 

In short, when command `clear` is issued the halt flag is set, and it will be cleared when the next call to play a song is made. 

### Related issues (if applicable)

closes #2375 