### PR TITLE
Fix skip tally and cmd prefix bugs

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3721,9 +3721,6 @@ class MusicBot(discord.Client):
                 expire_in=30,
             )
 
-        # TODO: ignore person if they're deaf or take them out of the list or something?
-        # Currently is recounted if they vote, deafen, then vote
-
         num_voice = sum(
             1
             for m in voice_channel.members

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1079,13 +1079,11 @@ class MusicBot(discord.Client):
 
     def _get_guild_cmd_prefix(self, guild: discord.Guild):
         if self.config.enable_options_per_guild:
-            prefix = self.server_specific_data[guild.id]["command_prefix"]
-            if not prefix:
-                return self.config.command_prefix
-            else:
-                return prefix
-        else:
-            return self.config.command_prefix
+            if guild:
+                prefix = self.server_specific_data[guild.id]["command_prefix"]
+                if prefix:
+                    return prefix
+        return self.config.command_prefix
 
     #######################################################################################################################
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3694,7 +3694,6 @@ class MusicBot(discord.Client):
                 and not permissions.skiplooped
                 and player.repeatsong
             ):
-                
                 raise exceptions.PermissionsError(
                     self.str.get(
                         "cmd-skip-force-noperms-looped-song",
@@ -3733,7 +3732,13 @@ class MusicBot(discord.Client):
         if num_voice == 0:
             num_voice = 1  # incase all users are deafened, to avoid divison by zero
 
-        num_skips = player.skip_state.add_skipper(author.id, message)
+        player.skip_state.add_skipper(author.id, message)
+        num_skips = sum(
+            1
+            for m in voice_channel.members
+            if not (m.voice.deaf or m.voice.self_deaf or m == self.user)
+            and m.id in player.skip_state.skippers
+        )
 
         skips_remaining = (
             min(


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 on Linux
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR changes logic in `cmd_skip` to count votes similarly to counting valid members in the channel.  The votes of members who deafen or leave the channel are no longer counted toward the skip vote.   

An additional bug fix in this PR addresses an issue with the bot sending messages to non-guild channels.  If the channel is a non-guild channel, such as private messages, the bot will use the default command prefix as set in `options.ini` config file.

