### PR TITLE
fix for timer events in server specific data.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -125,7 +125,7 @@ class MusicBot(discord.Client):
                 False,  # event state tracking.
             ),
             "inactive_vc_timer": (
-                asyncio.Event(),
+                None,  # also a asyncio.Event(),
                 False,
             ),  # The boolean is going show if the timeout is active or not
         }

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -121,7 +121,7 @@ class MusicBot(discord.Client):
             "auto_paused": False,
             "halt_playlist_unpack": False,
             "inactive_player_timer": (
-                asyncio.Event(),
+                None,  # will be an asyncio.Event()
                 False,  # event state tracking.
             ),
             "inactive_vc_timer": (
@@ -547,6 +547,10 @@ class MusicBot(discord.Client):
 
             if self.config.leave_inactive_channel:
                 event, active = self.server_specific_data[guild.id]["inactive_vc_timer"]
+                # TODO: do server specific defaults properly!
+                if event is None:
+                    event = asyncio.Event()
+
                 if active and not event.is_set():
                     event.set()
 
@@ -1553,6 +1557,10 @@ class MusicBot(discord.Client):
     async def handle_vc_inactivity(self, guild: discord.Guild):
         event, active = self.server_specific_data[guild.id]["inactive_vc_timer"]
 
+        # TODO: do server specific defaults properly!
+        if event is None:
+            event = asyncio.Event()
+
         if active:
             log.debug(f"Channel activity already waiting in guild: {guild}")
             return
@@ -1586,6 +1594,9 @@ class MusicBot(discord.Client):
         event, event_active = self.server_specific_data[guild.id][
             "inactive_player_timer"
         ]
+        # TODO: do server specific defaults properly!
+        if event is None:
+            event = asyncio.Event()
 
         if str(channel.id) in str(self.config.autojoin_channels):
             log.debug(
@@ -1626,6 +1637,9 @@ class MusicBot(discord.Client):
             return
         guild = player.voice_client.channel.guild
         event, active = self.server_specific_data[guild.id]["inactive_player_timer"]
+        # TODO: do server specific defaults properly!
+        if event is None:
+            event = asyncio.Event()
         if active and not event.is_set():
             event.set()
             log.debug("Player activity timer is being reset.")
@@ -5105,6 +5119,10 @@ class MusicBot(discord.Client):
         if self.config.leave_inactive_channel:
             guild = member.guild
             event, active = self.server_specific_data[guild.id]["inactive_vc_timer"]
+
+            # TODO: do server specific defaults properly!
+            if event is None:
+                event = asyncio.Event()
 
             if before.channel and self.user in before.channel.members:
                 if str(before.channel.id) in str(self.config.autojoin_channels):


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10
- [ ] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This should stop the shared reference of asyncio.Event() by essentially setting one if there is None whenever any call uses it. It is the shortest patch method I can think of without building another function or refactoring server data.

Note this PR does not apply Black format, as black has updated. 
