### PR TITLE
Fix custom status message handling

### DIFF
--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -471,6 +471,12 @@ class Config:
         create_empty_file_ifnoexist("config/blacklist.txt")
         create_empty_file_ifnoexist("config/whitelist.txt")
 
+        if self.status_message and len(self.status_message) > 128:
+            log.warning(
+                "StatusMessage config option is too long, it will be limited to 128 characters."
+            )
+            self.status_message = self.status_message[:128]
+
         if not self.footer_text:
             self.footer_text = ConfigDefaults.footer_text
 


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR provides a fix for custom status message handling that was broken by my recent experimental changes.  
This will keep the experimental status updates but should also ensure StatusMessage option is respected in all cases.  

This removes some dead code related to now playing status messages as well.
