### PR TITLE
Graceful invalid queue

### DIFF
--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -284,9 +284,11 @@ class URLPlaylistEntry(BasePlaylistEntry):
 
         vernum: Optional[int] = raw_json.get("version", None)
         if not vernum:
-            raise InvalidDataError("Entry data is missing version number.")
+            log.error("Entry data is missing version number, cannot deserialize.")
+            return None
         if vernum != URLPlaylistEntry.SERIAL_VERSION:
-            raise InvalidDataError("Entry data has the wrong version number.")
+            log.error("Entry data has the wrong version number, cannot deserialize.")
+            return None
 
         try:
             info = YtdlpResponseDict(raw_json["info"])
@@ -720,9 +722,11 @@ class StreamPlaylistEntry(BasePlaylistEntry):
 
         vernum = raw_json.get("version", None)
         if not vernum:
-            raise InvalidDataError("Entry data is missing version number.")
+            log.error("Entry data is missing version number, cannot deserialize.")
+            return None
         if vernum != URLPlaylistEntry.SERIAL_VERSION:
-            raise InvalidDataError("Entry data has the wrong version number.")
+            log.error("Entry data has the wrong version number, cannot deserialize.")
+            return None
 
         try:
             info = YtdlpResponseDict(raw_json["info"])

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -19,9 +19,9 @@ if TYPE_CHECKING:
     from .bot import MusicBot
     from .playlist import Playlist
 
-    AsyncFuture=asyncio.Future[Any]
+    AsyncFuture = asyncio.Future[Any]
 else:
-    AysncFuture=asyncio.Future
+    AysncFuture = asyncio.Future
 
 # Type alias
 EntryTypes = Union[URLPlaylistEntry, StreamPlaylistEntry]

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
     from .bot import MusicBot
     from .playlist import Playlist
 
+    AsyncFuture=asyncio.Future[Any]
+else:
+    AysncFuture=asyncio.Future
+
 # Type alias
 EntryTypes = Union[URLPlaylistEntry, StreamPlaylistEntry]
 

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -99,7 +99,7 @@ class MusicPlayer(EventEmitter, Serializable):
         self._play_lock = asyncio.Lock()
         self._current_player: Optional[VoiceClient] = None
         self._current_entry: Optional[EntryTypes] = None
-        self._stderr_future: Optional[asyncio.Future[Any]] = None
+        self._stderr_future: Optional[AsyncFuture] = None
 
         self._source: Optional[SourcePlaybackCounter] = None
 
@@ -528,7 +528,7 @@ class MusicPlayer(EventEmitter, Serializable):
 # TODO: I need to add a check if the event loop is closed?
 
 
-def filter_stderr(stderr: io.BytesIO, future: asyncio.Future[Any]) -> None:
+def filter_stderr(stderr: io.BytesIO, future: AsyncFuture) -> None:
     """
     Consume a `stderr` bytes stream and check it for errors or warnings.
     Set the given `future` with either an error found in the stream or

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     AsyncFuture = asyncio.Future[Any]
 else:
-    AysncFuture = asyncio.Future
+    AsyncFuture = asyncio.Future
 
 # Type alias
 EntryTypes = Union[URLPlaylistEntry, StreamPlaylistEntry]


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

Fix for recent bug with old serialized queue data.  This will prevent old queue from breaking the bot by not raising an error about it.  It will log an error instead and return None for the invalid entry.

This also patches a python 3.8 compat issue that made it by in the last PRs.  

