### PR TITLE
Add commands for config and permission editing and reloading.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -102,6 +102,13 @@ UseAutoPlaylist = yes
 # songs will be played in a sequential order instead.
 AutoPlaylistRandom = yes
 
+# Enable automatic skip of auto-playlist songs when a user plays a new song.
+# This only applies to the current playing song if it was added by the auto-playlist.
+AutoPlaylistAutoSkip = yes
+
+# Remove songs from the auto-playlist if they are found in the song blocklist.
+AutoPlaylistRemoveBlocked = yes
+
 # Pause the music when nobody is in a voice channel, until someone joins again.
 AutoPause = yes
 
@@ -190,8 +197,9 @@ LeaveInactiveVC = no
 # Default value is 300 seconds.
 LeaveInactiveVCTimeOut = 300
 
-# Sets if if the bot should leave immediately once all songs have finished playing.
-LeaveAfterSong = no
+# If enabled, MusicBot will leave the channel immediately when the song queue is empty.
+# Default is set to:  no
+LeaveAfterQueueEmpty = no
 
 # Set a period of seconds that a player can be paused or not playing before it will disconnect.
 # This setting is independent of LeaveAfterQueueEmpty.
@@ -203,14 +211,39 @@ LeavePlayerInactiveFor = 0
 # When enabled the bot will automatically rotate between user requested songs.
 RoundRobinQueue = no
 
-# This setting allows you to quickly enable or disable use of User Blocklist. 
+# Enable the user block list feature, without emptying the block list.
+# Default is set to:  yes
 EnableUserBlocklist = yes
 
 # This setting allows you to quickly enable or disable the use of Song Blocklist.
-EnableSongBlockList = no
+# Default is set to:  no
+EnableSongBlocklist = no
+
+# Allow MusicBot to use system ping command to detect network outage and availability.
+# This is useful if you keep the bot joined to a channel or playing music 24/7.
+# MusicBot must be restarted to enable network testing.
+# By default this is disabled.
+EnableNetworkChecker = no
 
 
 [Files]
+# Configure automatic log file rotation at restart, and limit the number of files kept.
+# When disabled, only one log is kept and its contents are replaced each run.
+# Default is 0, or disabled.  Maximum allowed number is 100."
+LogsMaxKept = 0
+
+# Configure the log file date format used when LogsMaxKept is enabled.
+# If left blank, a warning is logged and the default will be used instead.
+# Learn more about time format codes from the tables and data here:
+#    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
+# Default value is:  ".ended-%Y-%j-%H%m%S"
+LogsDateFormat = .ended-%Y-%j-%H%m%S
+
+# An optional file path to an auto playlist text file.
+# Each line of the file will be treated similarly to using the play command.
+# Default value is:  config/autoplaylist.txt
+AutoPlaylistFile =
+
 # Path to your i18n file. Do not set this if you do not know what it does.
 i18nFile = 
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -5798,25 +5798,25 @@ class MusicBot(discord.Client):
                 show loaded groups and list permission options.
 
             {command_prefix}setperms reload
-                reloads permissions from the permissions.ini file
+                reloads permissions from the permissions.ini file.
 
             {command_prefix}setperms add [GroupName]
-                add new group with defaults
+                add new group with defaults.
 
             {command_prefix}setperms remove [GroupName]
-                remove existing group
+                remove existing group.
 
             {command_prefix}setperms help [PermName]
                 show help text for the permission option.
 
-            {command_prefix}setperms show [GroupName]
-                show permission value
+            {command_prefix}setperms show [GroupName] [PermName]
+                show permission value for given group and permission.
 
             {command_prefix}setperms save [GroupName]
                 save permissions group to file.
 
             {command_prefix}setperms set [GroupName] [PermName] [Value]
-                set permission value
+                set permission value for the group.
         """
         if user_mentions:
             raise exceptions.CommandError(
@@ -5908,6 +5908,11 @@ class MusicBot(discord.Client):
         else:
             group_arg = leftover_args.pop(0)
         if option in ["set", "show"]:
+            if not leftover_args:
+                raise exceptions.CommandError(
+                    f"The {option} sub-command requires a group and permission name.",
+                    expire_in=30,
+                )
             option_arg = leftover_args.pop(0)
 
         if user_mentions:
@@ -5928,7 +5933,7 @@ class MusicBot(discord.Client):
             if p_opt is None:
                 option_arg = f"[{group_arg}] > {option_arg}"
                 raise exceptions.CommandError(
-                    f"The option `{option_arg}` is not available.",
+                    f"The permission `{option_arg}` is not available.",
                     expire_in=30,
                 )
             opt = p_opt
@@ -5957,7 +5962,9 @@ class MusicBot(discord.Client):
                 self.permissions.add_group(group_arg)
 
             return Response(
-                f"Successfully added new group:  `{group_arg}`",
+                f"Successfully added new group:  `{group_arg}`\n"
+                f"You can now customizse the permissions with:  `setperms set {group_arg}`\n"
+                f"Make sure to save the new group with:  `setperms save {group_arg}`",
                 delete_after=30,
             )
 
@@ -5971,7 +5978,8 @@ class MusicBot(discord.Client):
                 self.permissions.remove_group(group_arg)
 
             return Response(
-                f"Successfully removed group:  `{group_arg}`",
+                f"Successfully removed group:  `{group_arg}`"
+                f"Make sure to save this change with:  `setperms save {group_arg}`",
                 delete_after=30,
             )
 
@@ -6032,7 +6040,7 @@ class MusicBot(discord.Client):
                 )
             return Response(
                 f"Permission `{opt}` was updated for this session.\n"
-                f"To save the change use `perms save {opt.section} {opt.option}`",
+                f"To save the change use `setperms save {opt.section} {opt.option}`",
                 delete_after=30,
             )
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -28,6 +28,11 @@ from . import downloader, exceptions
 from .aliases import Aliases, AliasesDefault
 from .config import Config, ConfigDefaults
 from .constants import (
+    DEFAULT_DATA_NAME_CUR_SONG,
+    DEFAULT_DATA_NAME_QUEUE,
+    DEFAULT_DATA_NAME_SERVERS,
+    DEFAULT_OWNER_GROUP_NAME,
+    DEFAULT_PERMS_GROUP_NAME,
     DEFAULT_PING_SLEEP,
     DEFAULT_PING_TARGET,
     DEFAULT_PING_TIMEOUT,
@@ -55,6 +60,7 @@ from .utils import (
     dev_only,
     format_size_from_bytes,
     format_song_duration,
+    format_time_to_seconds,
     instance_diff,
     is_empty_voice_channel,
     load_file,
@@ -117,10 +123,14 @@ class MusicBot(discord.Client):
         load_opus_lib()
 
         if config_file is None:
-            config_file = ConfigDefaults.options_file
+            self._config_file = ConfigDefaults.options_file
+        else:
+            self._config_file = config_file
 
         if perms_file is None:
-            perms_file = PermissionsDefaults.perms_file
+            self._perms_file = PermissionsDefaults.perms_file
+        else:
+            self._perms_file = perms_file
 
         if aliases_file is None:
             aliases_file = AliasesDefault.aliases_file
@@ -138,9 +148,11 @@ class MusicBot(discord.Client):
         self.players: Dict[int, MusicPlayer] = {}
         self.autojoinable_channels: Set[VoiceableChannel] = set()
 
-        self.config = Config(config_file)
+        self.config = Config(self._config_file)
 
-        self.permissions = Permissions(perms_file, grant_all=[self.config.owner_id])
+        self.permissions = Permissions(self._perms_file)
+        # Set the owner ID in case it wasn't auto...
+        self.permissions.set_owner_id(self.config.owner_id)
         self.str = Json(self.config.i18n_file)
 
         if self.config.usealias:
@@ -249,6 +261,10 @@ class MusicBot(discord.Client):
         A self looping method that tests network connectivity.
         This will call to the systems ping command and use its return status.
         """
+        if not self.config.enable_network_checker:
+            log.debug("Network ping test is disabled via config.")
+            return
+
         if self.logout_called:
             log.noise("Network ping test is closing down.")  # type: ignore[attr-defined]
             return
@@ -265,10 +281,14 @@ class MusicBot(discord.Client):
                 ping_target = DEFAULT_PING_TARGET
 
         # Make a ping call based on OS.
-        ping_path = shutil.which("ping")
-        if not ping_path:
-            log.warning("Could not locate path to `ping` system executable.")
-            ping_path = "ping"
+        if not hasattr(self, "_mb_ping_exe_path"):
+            ping_path = shutil.which("ping")
+            if not ping_path:
+                log.warning("Could not locate `ping` executable in your environment.")
+                ping_path = "ping"
+            setattr(self, "_mb_ping_exe_path", ping_path)
+        else:
+            ping_path = getattr(self, "_mb_ping_exe_path", "ping")
 
         ping_cmd: List[str] = []
         if os.name == "nt":
@@ -288,9 +308,25 @@ class MusicBot(discord.Client):
                 stderr=asyncio.subprocess.DEVNULL,
             )
             ping_status = await p.wait()
+        except FileNotFoundError:
+            log.error(
+                "MusicBot could not locate a `ping` command path.  Early network outage detection will not function."
+                "\nMusicBot tried the following command:   %s",
+                " ".join(ping_cmd),
+            )
+            return
+        except PermissionError:
+            log.error(
+                "MusicBot was not allowed to execute the `ping` command.  Early network outage detection will not function."
+                "\nMusicBot tried the following command:   %s",
+                " ".join(ping_cmd),
+            )
+            return
         except OSError:
             log.error(
-                "Your environment may not allow the `ping` system command.  Early network outage detection will not function.",
+                "Your environment may not allow the `ping` system command.  Early network outage detection will not function."
+                "\nMusicBot tried the following command:   %s",
+                " ".join(ping_cmd),
                 exc_info=self.config.debug_mode,
             )
             return
@@ -389,8 +425,6 @@ class MusicBot(discord.Client):
         # Check guilds for a resumable channel, conditionally override with owner summon.
         resuming = False
         for guild in self.guilds:
-            # TODO:  test that this, guild_unavailable hasn't fired in testing yet
-            # but that don't mean this wont break due to fragile API out-of-order packets...
             if guild.unavailable:
                 log.warning(
                     "Guild not available, cannot join:  %s/%s", guild.id, guild.name
@@ -1375,11 +1409,11 @@ class MusicBot(discord.Client):
         # if playing auto-playlist track and a user queues a track,
         # if we're configured to do so, auto skip the auto playlist track.
         if (
-            player.current_entry
+            self.config.auto_playlist_autoskip
+            and player.current_entry
             and player.current_entry.from_auto_playlist
             and playlist.peek() == entry
             and not entry.from_auto_playlist
-            # TODO:  and self.config.autoplaylist_autoskip
         ):
             log.debug("Automatically skipping auto-playlist entry for queued entry.")
             player.skip()
@@ -1505,9 +1539,7 @@ class MusicBot(discord.Client):
                 await self.change_presence(status=status, activity=activity)
                 self.last_status = activity
 
-    async def serialize_queue(
-        self, guild: discord.Guild, *, path: Optional[str] = None
-    ) -> None:
+    async def serialize_queue(self, guild: discord.Guild) -> None:
         """
         Serialize the current queue for a server's player to json.
         """
@@ -1518,8 +1550,7 @@ class MusicBot(discord.Client):
         if not player:
             return
 
-        if path is None:
-            path = f"data/{guild.id}/queue.json"
+        path = self.config.data_path.joinpath(str(guild.id), DEFAULT_DATA_NAME_QUEUE)
 
         async with self.aiolocks["queue_serialization" + ":" + str(guild.id)]:
             log.debug("Serializing queue for %s", guild.id)
@@ -1532,8 +1563,6 @@ class MusicBot(discord.Client):
         guild: discord.Guild,
         voice_client: discord.VoiceClient,
         playlist: Optional[Playlist] = None,
-        *,
-        directory: Optional[str] = None,
     ) -> Optional[MusicPlayer]:
         """
         Deserialize a saved queue for a server into a MusicPlayer.  If no queue is saved, returns None.
@@ -1544,23 +1573,20 @@ class MusicBot(discord.Client):
         if playlist is None:
             playlist = Playlist(self)
 
-        if directory is None:
-            directory = f"data/{guild.id}/queue.json"
+        path = self.config.data_path.joinpath(str(guild.id), DEFAULT_DATA_NAME_QUEUE)
 
         async with self.aiolocks["queue_serialization:" + str(guild.id)]:
-            if not os.path.isfile(directory):
+            if not path.is_file():
                 return None
 
             log.debug("Deserializing queue for %s", guild.id)
 
-            with open(directory, "r", encoding="utf8") as f:
+            with open(path, "r", encoding="utf8") as f:
                 data = f.read()
 
         return MusicPlayer.from_json(data, self, voice_client, playlist)
 
-    async def write_current_song(
-        self, guild: discord.Guild, entry: EntryTypes, *, path: Optional[str] = None
-    ) -> None:
+    async def write_current_song(self, guild: discord.Guild, entry: EntryTypes) -> None:
         """
         Writes the current song to file
         """
@@ -1568,8 +1594,7 @@ class MusicBot(discord.Client):
         if not player:
             return
 
-        if path is None:
-            path = f"data/{guild.id}/current.txt"
+        path = self.config.data_path.joinpath(str(guild.id), DEFAULT_DATA_NAME_CUR_SONG)
 
         async with self.aiolocks["current_song:" + str(guild.id)]:
             log.debug("Writing current song for %s", guild.id)
@@ -2068,11 +2093,6 @@ class MusicBot(discord.Client):
 
         print(flush=True)
 
-        # TODO: if on-demand loading is not good enough, we can load guild specifics here.
-        # if self.config.enable_options_per_guild:
-        #    for s in self.guilds:
-        #        await self._load_guild_options(s)
-
         # validate bound channels and log them.
         if self.config.bound_channels:
             # Get bound channels by ID, and validate that we can use them.
@@ -2172,17 +2192,30 @@ class MusicBot(discord.Client):
         if self.config.show_config_at_start:
             self._on_ready_log_configs()
 
-        # we do this after the config list because it's a lot easier to notice here
-        if self.config.missing_keys:
+        # we do this after the config stuff because it's a lot easier to notice here
+        if self.config.register.ini_missing_options:
+            missing_list = "\n".join(
+                str(o) for o in self.config.register.ini_missing_options
+            )
             conf_warn = exceptions.HelpfulError(
                 preface="Detected missing config options!",
-                issue="Your options.ini file is missing some options. Defaults will be used for this session.\n"
-                f"Here is a list of options we think are missing:\n    {', '.join(self.config.missing_keys)}",
+                issue=(
+                    "Your config file is missing some options. Defaults will be used for this session.\n"
+                    f"Here is a list of options we think are missing:\n{missing_list}"
+                ),
                 solution="Check the example_options.ini file for newly added options and copy them to your config.",
+                footnote="You can also use the `config` command to set the missing options.",
             )
             log.warning(str(conf_warn)[1:])
 
-        # self.loop.create_task(self._on_ready_call_later())
+        # Pre-load guild specific data / options.
+        # TODO:  probably change this later for better UI/UX.
+        if self.config.enable_options_per_guild:
+            for guild in self.guilds:
+                # Triggers on-demand task to load data from disk.
+                self.server_data[guild.id].is_ready()
+                # context switch to give scheduled task an execution window.
+                await asyncio.sleep(0)
 
     async def _on_ready_always(self) -> None:
         """
@@ -2225,9 +2258,10 @@ class MusicBot(discord.Client):
         """
         log.debug("Ensuring data folders exist")
         for guild in self.guilds:
-            pathlib.Path(f"data/{guild.id}/").mkdir(exist_ok=True)
+            self.config.data_path.joinpath(str(guild.id)).mkdir(exist_ok=True)
 
-        with open("data/server_names.txt", "w", encoding="utf8") as f:
+        names_path = self.config.data_path.joinpath(DEFAULT_DATA_NAME_SERVERS)
+        with open(names_path, "w", encoding="utf8") as f:
             for guild in sorted(self.guilds, key=lambda s: int(s.id)):
                 f.write(f"{guild.id}: {guild.name}\n")
 
@@ -2724,7 +2758,7 @@ class MusicBot(discord.Client):
 
     async def cmd_blocksong(
         self,
-        _player: MusicPlayer,
+        _player: Optional[MusicPlayer],
         option: str,
         leftover_args: List[str],
         song_subject: str = "",
@@ -2773,6 +2807,16 @@ class MusicBot(discord.Client):
                     f"Subject `{song_subject}` is already in the song block list.\n{status_msg}"
                 )
 
+            # remove song from auto-playlist if it is blocked
+            if (
+                self.config.auto_playlist_remove_on_block
+                and _player
+                and _player.current_entry
+                and song_subject == _player.current_entry.url
+                and _player.current_entry.from_auto_playlist
+            ):
+                await self.remove_url_from_autoplaylist(song_subject)
+
             async with self.aiolocks["song_blocklist"]:
                 self.config.song_blocklist.append_items([song_subject])
 
@@ -2783,17 +2827,13 @@ class MusicBot(discord.Client):
                 delete_after=10,
             )
 
+        # handle "remove" and "-"
         if not self.config.song_blocklist.is_blocked(song_subject):
             raise exceptions.CommandError(
                 "The subject is not in the song block list and cannot be removed.",
                 expire_in=10,
             )
 
-        # TODO:  add self.config.autoplaylist_remove_on_block
-        # if self.config.autoplaylist_remove_on_block
-        # and song_subject is current_entry.url
-        # and current_entry.from_auto_playlist
-        #   await self.remove_url_from_autoplaylist(song_subject)
         async with self.aiolocks["song_blocklist"]:
             self.config.song_blocklist.remove_items([song_subject])
 
@@ -4678,7 +4718,7 @@ class MusicBot(discord.Client):
         if permission_force_skip and (force_skip or self.config.legacy_skip):
             if (
                 not permission_force_skip
-                and not permissions.skiplooped
+                and not permissions.skip_looped
                 and player.repeatsong
             ):
                 raise exceptions.PermissionsError(
@@ -4740,7 +4780,7 @@ class MusicBot(discord.Client):
         )
 
         if skips_remaining <= 0:
-            if not permissions.skiplooped and player.repeatsong:
+            if not permissions.skip_looped and player.repeatsong:
                 raise exceptions.PermissionsError(
                     self.str.get(
                         "cmd-skip-vote-noperms-looped-song",
@@ -4773,7 +4813,7 @@ class MusicBot(discord.Client):
             )
 
         # TODO: When a song gets skipped, delete the old x needed to skip messages
-        if not permissions.skiplooped and player.repeatsong:
+        if not permissions.skip_looped and player.repeatsong:
             raise exceptions.PermissionsError(
                 self.str.get(
                     "cmd-skip-vote-noperms-looped-song",
@@ -4873,6 +4913,249 @@ class MusicBot(discord.Client):
             ).format(new_volume),
             expire_in=20,
         )
+
+    @owner_only
+    async def cmd_config(
+        self,
+        user_mentions: List[discord.Member],
+        channel_mentions: List[discord.abc.GuildChannel],
+        option: str,
+        leftover_args: List[str],
+    ) -> CommandResponse:
+        """
+        Usage:
+            {command_prefix}config missing
+                Shows help text about any missing config options.
+
+            {command_prefix}config diff
+                Lists the names of options which have been changed since loading config file.
+
+            {command_prefix}config list
+                List the available config options and their sections.
+
+            {command_prefix}config reload
+                Reload the options.ini file from disk.
+
+            {command_prefix}config help [Section] [Option]
+                Shows help text for a specific option.
+
+            {command_prefix}config show [Section] [Option]
+                Display the current value of the option.
+
+            {command_prefix}config save [Section] [Option]
+                Saves the current current value to the options file.
+
+            {command_prefix}config set [Section] [Option] [value]
+                Validates the option and sets the config for the session, but not to file.
+
+        This command allows management of MusicBot config options file.
+        """
+        if user_mentions and channel_mentions:
+            raise exceptions.CommandError(
+                "Config cannot use channel and user mentions at the same time.",
+                expire_in=30,
+            )
+
+        option = option.lower()
+        valid_options = [
+            "missing",
+            "diff",
+            "list",
+            "save",
+            "help",
+            "show",
+            "set",
+            "reload",
+        ]
+        if option not in valid_options:
+            raise exceptions.CommandError(
+                f"Invalid option for command: `{option}`",
+                expire_in=30,
+            )
+
+        # Show missing options with help text.
+        if option == "missing":
+            missing = ""
+            for opt in self.config.register.ini_missing_options:
+                missing += (
+                    f"**Missing Option:** `{opt}`\n"
+                    "```"
+                    f"{opt.comment}\n"
+                    f"Default is set to:  {opt.default}"
+                    "```\n"
+                )
+            if not missing:
+                missing = "*All config options are present and accounted for!*"
+
+            return Response(
+                missing,
+                delete_after=60,
+            )
+
+        # Show options names that have changed since loading.
+        if option == "diff":
+            changed = ""
+            for opt in self.config.register.get_updated_options():
+                changed += f"`{str(opt)}`\n"
+
+            if not changed:
+                changed = "No config options appear to be changed."
+            else:
+                changed = f"**Changed Options:**\n{changed}"
+
+            return Response(
+                changed,
+                delete_after=60,
+            )
+
+        # List all available options.
+        if option == "list":
+            non_edit_opts = ""
+            editable_opts = ""
+            for opt in self.config.register.option_list:
+                if opt.editable:
+                    editable_opts += f"`{opt}`\n"
+                else:
+                    non_edit_opts += f"`{opt}`\n"
+
+            opt_list = (
+                f"## Available Options:\n"
+                f"**Editable Options:**\n{editable_opts}\n"
+                f"**Manual Edit Only:**\n{non_edit_opts}"
+            )
+            return Response(
+                opt_list,
+                delete_after=60,
+            )
+
+        # Try to reload options.ini file from disk.
+        if option == "reload":
+            try:
+                new_conf = Config(self._config_file)
+                await new_conf.async_validate(self)
+
+                self.config = new_conf
+
+                return Response(
+                    "Config options reloaded from file successfully!",
+                    delete_after=30,
+                )
+            except Exception as e:
+                raise exceptions.CommandError(
+                    f"Unable to reload Config due to the following errror:\n{str(e)}",
+                    expire_in=30,
+                ) from e
+
+        # sub commands beyond here need 2 leftover_args
+        if option in ["help", "show", "save"]:
+            if len(leftover_args) < 2:
+                raise exceptions.CommandError(
+                    "You must provide a section name and option name for this command.",
+                    expire_in=30,
+                )
+
+        # Get the command args from leftovers and check them.
+        section_arg = leftover_args.pop(0)
+        option_arg = leftover_args.pop(0)
+        if user_mentions:
+            leftover_args += [str(m.id) for m in user_mentions]
+        if channel_mentions:
+            leftover_args += [str(ch.id) for ch in channel_mentions]
+        value_arg = " ".join(leftover_args)
+        p_opt = self.config.register.get_config_option(section_arg, option_arg)
+
+        if section_arg not in self.config.register.sections:
+            sects = ", ".join(self.config.register.sections)
+            raise exceptions.CommandError(
+                f"The section `{section_arg}` is not available.\n"
+                f"The available sections are:  {sects}",
+                expire_in=30,
+            )
+
+        if p_opt is None:
+            option_arg = f"[{section_arg}] > {option_arg}"
+            raise exceptions.CommandError(
+                f"The option `{option_arg}` is not available.",
+                expire_in=30,
+            )
+        opt = p_opt
+
+        # Display some commentary about the option and its default.
+        if option == "help":
+            default = "\nThis option can only be set by editing the config file."
+            if opt.editable:
+                default = f"\nBy default this option is set to: {opt.default}"
+            return Response(
+                f"**Option:** `{opt}`\n{opt.comment}{default}",
+                delete_after=60,
+            )
+
+        # Save the current config value to the INI file.
+        if option == "save":
+            if not opt.editable:
+                raise exceptions.CommandError(
+                    f"Option `{opt}` is not editable. Cannot save to disk.",
+                    expire_in=30,
+                )
+
+            async with self.aiolocks["config_edit"]:
+                saved = self.config.save_option(opt)
+
+            if not saved:
+                raise exceptions.CommandError(
+                    f"Failed to save the option:  `{opt}`",
+                    expire_in=30,
+                )
+            return Response(
+                f"Successfully saved the option:  `{opt}`",
+                delete_after=30,
+            )
+
+        # Display the current config and INI file values.
+        if option == "show":
+            if not opt.editable:
+                raise exceptions.CommandError(
+                    f"Option `{opt}` is not editable, value cannot be displayed.",
+                    expire_in=30,
+                )
+            # TODO: perhaps make use of currently unused display value for empty configs.
+            cur_val, ini_val, _disp_val = self.config.register.get_values(opt)
+            return Response(
+                f"**Option:** `{opt}`\n"
+                f"Current Value:  `{cur_val}`\n"
+                f"INI File Value:  `{ini_val}`",
+                delete_after=30,
+            )
+
+        # update a config variable, but don't save it.
+        if option == "set":
+            if not opt.editable:
+                raise exceptions.CommandError(
+                    f"Option `{opt}` is not editable. Cannot update setting.",
+                    expire_in=30,
+                )
+
+            if not value_arg:
+                raise exceptions.CommandError(
+                    "You must provide a section, option, and value for this sub command.",
+                    expire_in=30,
+                )
+
+            log.debug("Doing set with on %s == %s", opt, value_arg)
+            async with self.aiolocks["config_update"]:
+                updated = self.config.update_option(opt, value_arg)
+            if not updated:
+                raise exceptions.CommandError(
+                    f"Option `{opt}` was not updated!",
+                    expire_in=30,
+                )
+            return Response(
+                f"Option `{opt}` was updated for this session.\n"
+                f"To save the change use `config save {opt.section} {opt.option}`",
+                delete_after=30,
+            )
+
+        return None
 
     @owner_only
     async def cmd_option(self, option: str, value: str) -> CommandResponse:
@@ -5489,23 +5772,271 @@ class MusicBot(discord.Client):
         permissions = self.permissions.for_user(user)
 
         if user == author:
-            lines = [f"Command permissions in {guild.name}\n", "```", "```"]
+            perms = (
+                f"Your command permissions in {guild.name} are:\n"
+                f"```{permissions.format(for_user=True)}```"
+            )
         else:
-            lines = [
-                f"Command permissions for {user.name} in {guild.name}\n",
-                "```",
-                "```",
-            ]
+            perms = (
+                f"The command permissions for {user.name} in {guild.name} are:\n"
+                f"```{permissions.format()}```"
+            )
 
-        for perm in permissions.__dict__:
-            # TODO: double check this still works as desired.
-            if perm in ["user_list"] or permissions.__dict__[perm] == set():
-                continue
-            perm_data = permissions.__dict__[perm]
-            lines.insert(len(lines) - 1, f"{perm}: {perm_data}")
-
-        await self.safe_send_message(author, "\n".join(lines), fallback_channel=channel)
+        await self.safe_send_message(author, perms, fallback_channel=channel)
         return Response("\N{OPEN MAILBOX WITH RAISED FLAG}", delete_after=20)
+
+    @owner_only
+    async def cmd_setperms(
+        self,
+        user_mentions: List[discord.Member],
+        leftover_args: List[str],
+        option: str = "list",
+    ) -> CommandResponse:
+        """
+        Usage:
+            {command_prefix}setperms list
+                show loaded groups and list permission options.
+
+            {command_prefix}setperms reload
+                reloads permissions from the permissions.ini file
+
+            {command_prefix}setperms add [GroupName]
+                add new group with defaults
+
+            {command_prefix}setperms remove [GroupName]
+                remove existing group
+
+            {command_prefix}setperms help [PermName]
+                show help text for the permission option.
+
+            {command_prefix}setperms show [GroupName]
+                show permission value
+
+            {command_prefix}setperms save [GroupName]
+                save permissions group to file.
+
+            {command_prefix}setperms set [GroupName] [PermName] [Value]
+                set permission value
+        """
+        if user_mentions:
+            raise exceptions.CommandError(
+                "Permissions cannot use channel and user mentions at the same time.",
+                expire_in=30,
+            )
+
+        option = option.lower()
+        valid_options = [
+            "list",
+            "add",
+            "remove",
+            "save",
+            "help",
+            "show",
+            "set",
+            "reload",
+        ]
+        if option not in valid_options:
+            raise exceptions.CommandError(
+                f"Invalid option for command: `{option}`",
+                expire_in=30,
+            )
+
+        # Reload the permissions file from disk.
+        if option == "reload":
+            try:
+                new_permissions = Permissions(self._perms_file)
+                # Set the owner ID in case it wasn't auto...
+                new_permissions.set_owner_id(self.config.owner_id)
+                await new_permissions.async_validate(self)
+
+                self.permissions = new_permissions
+
+                return Response(
+                    "Permissions reloaded from file successfully!",
+                    delete_after=30,
+                )
+            except Exception as e:
+                raise exceptions.CommandError(
+                    f"Unable to reload Permissions due to the following errror:\n{str(e)}",
+                    expire_in=30,
+                ) from e
+
+        # List permission groups and available permission options.
+        if option == "list":
+            gl = []
+            for section in self.permissions.register.sections:
+                gl.append(f"`{section}`\n")
+
+            editable_opts = ""
+            for opt in self.permissions.register.option_list:
+                if opt.section != DEFAULT_PERMS_GROUP_NAME:
+                    continue
+
+                # if opt.editable:
+                editable_opts += f"`{opt.option}`\n"
+
+            groups = "".join(gl)
+            opt_list = (
+                f"## Available Groups:\n{groups}\n"
+                f"## Available Options:\n"
+                f"{editable_opts}\n"
+            )
+            return Response(
+                opt_list,
+                delete_after=60,
+            )
+
+        # sub commands beyond here need 2 leftover_args
+        if option in ["help", "show", "save", "add", "remove"]:
+            if len(leftover_args) < 1:
+                raise exceptions.CommandError(
+                    "You must provide a group or option name for this command.",
+                    expire_in=30,
+                )
+        if option == "set" and len(leftover_args) < 3:
+            raise exceptions.CommandError(
+                "You must provide a group, option, and value to set for this command.",
+                expire_in=30,
+            )
+
+        # Get the command args from leftovers and check them.
+        group_arg = ""
+        option_arg = ""
+        if option == "help":
+            group_arg = DEFAULT_PERMS_GROUP_NAME
+            option_arg = leftover_args.pop(0)
+        else:
+            group_arg = leftover_args.pop(0)
+        if option in ["set", "show"]:
+            option_arg = leftover_args.pop(0)
+
+        if user_mentions:
+            leftover_args += [str(m.id) for m in user_mentions]
+        value_arg = " ".join(leftover_args)
+
+        if group_arg not in self.permissions.register.sections and option != "add":
+            sects = ", ".join(self.permissions.register.sections)
+            raise exceptions.CommandError(
+                f"The group `{group_arg}` is not available.\n"
+                f"The available groups are:  {sects}",
+                expire_in=30,
+            )
+
+        # Make sure the option is set if the sub-command needs it.
+        if option in ["help", "set", "show"]:
+            p_opt = self.permissions.register.get_config_option(group_arg, option_arg)
+            if p_opt is None:
+                option_arg = f"[{group_arg}] > {option_arg}"
+                raise exceptions.CommandError(
+                    f"The option `{option_arg}` is not available.",
+                    expire_in=30,
+                )
+            opt = p_opt
+
+        # Display some commentary about the option and its default.
+        if option == "help":
+            default = (
+                "\nThis permission can only be set by editing the permissions file."
+            )
+            # TODO:  perhaps use empty display values here.
+            if opt.editable:
+                dval = self.permissions.register.to_ini(opt, use_default=True)
+                default = f"\nBy default this permission is set to: `{dval}`"
+            return Response(
+                f"**Permission:** `{opt.option}`\n{opt.comment}{default}",
+                delete_after=60,
+            )
+
+        if option == "add":
+            if group_arg in self.permissions.register.sections:
+                raise exceptions.CommandError(
+                    f"Cannot add group `{group_arg}` it already exists.",
+                    expire_in=30,
+                )
+            async with self.aiolocks["permission_edit"]:
+                self.permissions.add_group(group_arg)
+
+            return Response(
+                f"Successfully added new group:  `{group_arg}`",
+                delete_after=30,
+            )
+
+        if option == "remove":
+            if group_arg in [DEFAULT_OWNER_GROUP_NAME, DEFAULT_PERMS_GROUP_NAME]:
+                raise exceptions.CommandError(
+                    "Cannot remove built-in group.", expire_in=30
+                )
+
+            async with self.aiolocks["permission_edit"]:
+                self.permissions.remove_group(group_arg)
+
+            return Response(
+                f"Successfully removed group:  `{group_arg}`",
+                delete_after=30,
+            )
+
+        # Save the current config value to the INI file.
+        if option == "save":
+            if group_arg == DEFAULT_OWNER_GROUP_NAME:
+                raise exceptions.CommandError(
+                    "The owner group is not editable.",
+                    expire_in=30,
+                )
+
+            async with self.aiolocks["permission_edit"]:
+                saved = self.permissions.save_group(group_arg)
+
+            if not saved:
+                raise exceptions.CommandError(
+                    f"Failed to save the group:  `{group_arg}`",
+                    expire_in=30,
+                )
+            return Response(
+                f"Successfully saved the group:  `{group_arg}`",
+                delete_after=30,
+            )
+
+        # Display the current permissions group and INI file values.
+        if option == "show":
+            cur_val, ini_val, empty_display_val = self.permissions.register.get_values(
+                opt
+            )
+            return Response(
+                f"**Permission:** `{opt}`\n"
+                f"Current Value:  `{cur_val}` {empty_display_val}\n"
+                f"INI File Value:  `{ini_val}`",
+                delete_after=30,
+            )
+
+        # update a permission, but don't save it.
+        if option == "set":
+            if group_arg == DEFAULT_OWNER_GROUP_NAME:
+                raise exceptions.CommandError(
+                    "The owner group is not editable.",
+                    expire_in=30,
+                )
+
+            if not value_arg:
+                raise exceptions.CommandError(
+                    "You must provide a section, option, and value for this sub command.",
+                    expire_in=30,
+                )
+
+            log.debug("Doing set with on %s == %s", opt, value_arg)
+            async with self.aiolocks["permission_update"]:
+                updated = self.permissions.update_option(opt, value_arg)
+            if not updated:
+                raise exceptions.CommandError(
+                    f"Permission `{opt}` was not updated!",
+                    expire_in=30,
+                )
+            return Response(
+                f"Permission `{opt}` was updated for this session.\n"
+                f"To save the change use `perms save {opt.section} {opt.option}`",
+                delete_after=30,
+            )
+
+        return None
 
     @owner_only
     async def cmd_setname(self, leftover_args: List[str], name: str) -> CommandResponse:
@@ -6309,24 +6840,9 @@ class MusicBot(discord.Client):
                     handler_kwargs[key] = arg_value
                     params.pop(key)
 
+            # Test non-owners for command permissions.
             if message.author.id != self.config.owner_id:
-                if (
-                    user_permissions.command_whitelist
-                    and command not in user_permissions.command_whitelist
-                ):
-                    raise exceptions.PermissionsError(
-                        f"This command is not enabled for your group ({user_permissions.name}).",
-                        expire_in=20,
-                    )
-
-                if (
-                    user_permissions.command_blacklist
-                    and command in user_permissions.command_blacklist
-                ):
-                    raise exceptions.PermissionsError(
-                        f"This command is disabled for your group ({user_permissions.name}).",
-                        expire_in=20,
-                    )
+                user_permissions.can_use_command(command)
 
             # Invalid usage, return docstring
             if params:
@@ -6706,7 +7222,7 @@ class MusicBot(discord.Client):
                     )
 
         log.debug("Creating data folder for guild %s", guild.id)
-        pathlib.Path(f"data/{guild.id}/").mkdir(exist_ok=True)
+        self.config.data_path.joinpath(str(guild.id)).mkdir(exist_ok=True)
 
     async def on_guild_remove(self, guild: discord.Guild) -> None:
         """

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -15,6 +15,8 @@ except (subprocess.SubprocessError, OSError, ValueError) as e:
 DEFAULT_FOOTER_TEXT: str = f"Just-Some-Bots/MusicBot ({VERSION})"
 DEFAULT_BOT_NAME: str = "MusicBot"
 DEFAULT_BOT_ICON: str = "https://i.imgur.com/gFHBoZA.png"
+DEFAULT_OWNER_GROUP_NAME: str = "Owner (auto)"
+DEFAULT_PERMS_GROUP_NAME: str = "Default"
 
 
 # File path constants
@@ -28,6 +30,11 @@ DEPRECATED_USER_BLACKLIST: str = "config/blacklist.txt"
 DEFAULT_AUTOPLAYLIST_FILE: str = "config/autoplaylist.txt"
 BUNDLED_AUTOPLAYLIST_FILE: str = "config/_autoplaylist.txt"
 DEFAULT_AUDIO_CACHE_PATH: str = "audio_cache"
+DEFAULT_DATA_PATH: str = "data"
+DEFAULT_DATA_NAME_SERVERS: str = "server_names.txt"
+DEFAULT_DATA_NAME_QUEUE: str = "queue.json"
+DEFAULT_DATA_NAME_CUR_SONG: str = "current.txt"
+DEFAULT_DATA_NAME_OPTIONS: str = "options.json"
 
 EXAMPLE_OPTIONS_FILE: str = "config/example_options.ini"
 EXAMPLE_PERMS_FILE: str = "config/example_permissions.ini"

--- a/musicbot/constructs.py
+++ b/musicbot/constructs.py
@@ -2,7 +2,6 @@ import asyncio
 import inspect
 import json
 import logging
-import pathlib
 import pydoc
 from collections import defaultdict
 from typing import (
@@ -20,12 +19,20 @@ from typing import (
 
 import discord
 
+from .constants import (
+    DEFAULT_BOT_ICON,
+    DEFAULT_BOT_NAME,
+    DEFAULT_DATA_NAME_OPTIONS,
+    DEFAULT_FOOTER_TEXT,
+)
 from .json import Json
 from .utils import _get_variable
 
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from discord.types.embed import EmbedType
+
     from .bot import MusicBot
     from .config import Config
 
@@ -76,6 +83,7 @@ class GuildSpecificData:
         self._prefix_history: Set[str] = set()
         self._events: DefaultDict[str, GuildAsyncEvent] = defaultdict(GuildAsyncEvent)
         self._file_lock: asyncio.Lock = asyncio.Lock()
+        self._loading_lock: asyncio.Lock = asyncio.Lock()
         self._is_file_loaded: bool = False
 
         # Members below are available for public use.
@@ -86,6 +94,10 @@ class GuildSpecificData:
         # in theory, this should work out fine.
         if bot.loop:
             bot.loop.create_task(self.load_guild_options_file())
+
+    def is_ready(self) -> bool:
+        """A status indicator for fully loaded server data."""
+        return self._is_file_loaded and self._guild_id != 0
 
     def _lookup_guild_id(self) -> int:
         """
@@ -148,44 +160,51 @@ class GuildSpecificData:
         server-specific options intended to persist through shutdowns.
         This method only supports per-server command prefix currently.
         """
-        if self._guild_id == 0:
-            self._guild_id = self._lookup_guild_id()
-            if self._guild_id == 0:
-                log.error(
-                    "Cannot load data for guild with ID 0. This is likely a bug in the code!"
-                )
-                return
-
-        opt_file = pathlib.Path(f"data/{self._guild_id}/options.json")
-        if not opt_file.is_file():
-            log.debug("No file for guild %s/%s", self._guild_id, self._guild_name)
+        if self._loading_lock.locked():
             return
 
-        async with self._file_lock:
-            try:
-                log.debug(
-                    "Loading guild data for guild with ID:  %s/%s",
-                    self._guild_id,
-                    self._guild_name,
-                )
-                options = Json(opt_file)
+        async with self._loading_lock:
+            if self._guild_id == 0:
+                self._guild_id = self._lookup_guild_id()
+                if self._guild_id == 0:
+                    log.error(
+                        "Cannot load data for guild with ID 0. This is likely a bug in the code!"
+                    )
+                    return
+
+            opt_file = self._bot_config.data_path.joinpath(
+                str(self._guild_id), DEFAULT_DATA_NAME_OPTIONS
+            )
+            if not opt_file.is_file():
+                log.debug("No file for guild %s/%s", self._guild_id, self._guild_name)
                 self._is_file_loaded = True
-            except OSError:
-                log.exception(
-                    "An OS error prevented reading guild data file:  %s",
-                    opt_file,
-                )
                 return
 
-        guild_prefix = options.get("command_prefix", None)
-        if guild_prefix:
-            self._command_prefix = guild_prefix
-            log.info(
-                "Guild %s/%s has custom command prefix: %s",
-                self._guild_id,
-                self._guild_name,
-                self._command_prefix,
-            )
+            async with self._file_lock:
+                try:
+                    log.debug(
+                        "Loading guild data for guild with ID:  %s/%s",
+                        self._guild_id,
+                        self._guild_name,
+                    )
+                    options = Json(opt_file)
+                    self._is_file_loaded = True
+                except OSError:
+                    log.exception(
+                        "An OS error prevented reading guild data file:  %s",
+                        opt_file,
+                    )
+                    return
+
+            guild_prefix = options.get("command_prefix", None)
+            if guild_prefix:
+                self._command_prefix = guild_prefix
+                log.info(
+                    "Guild %s/%s has custom command prefix: %s",
+                    self._guild_id,
+                    self._guild_name,
+                    self._command_prefix,
+                )
 
     async def save_guild_options_file(self) -> None:
         """
@@ -198,7 +217,9 @@ class GuildSpecificData:
             )
             return
 
-        opt_file = pathlib.Path(f"data/{self._guild_id}/options.json")
+        opt_file = self._bot_config.data_path.joinpath(
+            str(self._guild_id), DEFAULT_DATA_NAME_OPTIONS
+        )
 
         # Prepare a dictionary to store our options.
         opt_dict = {"command_prefix": self._command_prefix}

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -623,7 +623,7 @@ class PermissionOptionRegistry(ConfigOptionRegistry):
         parser_value = parser_get(opt.section, opt.option, fallback=opt.default)
 
         display_config_value = ""
-        if not display_config_value and opt.empty_display_val:
+        if not config_value and opt.empty_display_val:
             display_config_value = opt.empty_display_val
 
         return (config_value, parser_value, display_config_value)

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -2,17 +2,25 @@ import configparser
 import logging
 import pathlib
 import shutil
-from typing import TYPE_CHECKING, Any, Dict, List, Set, Union
+from typing import TYPE_CHECKING, Dict, Set, Tuple, Type, Union
 
+import configupdater
 import discord
 
-from .config import ExtendedConfigParser
-from .constants import DEFAULT_PERMS_FILE, EXAMPLE_PERMS_FILE
+from .config import ConfigOption, ConfigOptionRegistry, ExtendedConfigParser, RegTypes
+from .constants import (
+    DEFAULT_OWNER_GROUP_NAME,
+    DEFAULT_PERMS_FILE,
+    DEFAULT_PERMS_GROUP_NAME,
+    EXAMPLE_PERMS_FILE,
+)
+from .exceptions import HelpfulError, PermissionsError
 
 if TYPE_CHECKING:
     from .bot import MusicBot
 
 log = logging.getLogger(__name__)
+
 
 # Permissive class define the permissive value of each permissions
 
@@ -23,32 +31,29 @@ class PermissionsDefaults:
     Most values restrict access by default.
     """
 
-    perms_file: pathlib.Path = pathlib.Path(DEFAULT_PERMS_FILE)
-    example_perms_file: pathlib.Path = pathlib.Path(EXAMPLE_PERMS_FILE)
+    command_whitelist: Set[str] = set()
+    command_blacklist: Set[str] = set()
+    ignore_non_voice: Set[str] = set()
+    grant_to_roles: Set[int] = set()
+    user_list: Set[int] = set()
 
-    CommandWhiteList: Set[str] = set()
-    CommandBlackList: Set[str] = set()
-    IgnoreNonVoice: Set[str] = set()
-    GrantToRoles: Set[int] = set()
-    UserList: Set[int] = set()
+    max_songs: int = 8
+    max_song_length: int = 210
+    max_playlist_length: int = 0
+    max_search_items: int = 10
 
-    MaxSongs: int = 8
-    MaxSongLength: int = 210
-    MaxPlaylistLength: int = 0
-    MaxSearchItems: int = 10
+    allow_playlists: bool = True
+    insta_skip: bool = False
+    skip_looped: bool = False
+    remove: bool = False
+    skip_when_absent: bool = True
+    bypass_karaoke_mode: bool = False
 
-    AllowPlaylists: bool = True
-    InstaSkip: bool = False
-    SkipLooped: bool = False
-    Remove: bool = False
-    SkipWhenAbsent: bool = True
-    BypassKaraokeMode: bool = False
-
-    SummonNoVoice: bool = False
+    summon_no_voice: bool = False
 
     # allow at least the extractors that the bot normally needs.
     # an empty set here allows all.
-    Extractors: Set[str] = {
+    extractors: Set[str] = {
         "generic",
         "youtube",
         "youtube:tab",
@@ -57,33 +62,43 @@ class PermissionsDefaults:
         "spotify:musicbot",
     }
 
+    # These defaults are not used per-group but rather for permissions system itself.
+    perms_file: pathlib.Path = pathlib.Path(DEFAULT_PERMS_FILE)
+    example_perms_file: pathlib.Path = pathlib.Path(EXAMPLE_PERMS_FILE)
 
-class Permissive:
-    CommandWhiteList: Set[str] = set()
-    CommandBlackList: Set[str] = set()
-    IgnoreNonVoice: Set[str] = set()
-    GrantToRoles: Set[int] = set()
-    UserList: Set[int] = set()
 
-    MaxSongs: int = 0
-    MaxSongLength: int = 0
-    MaxPlaylistLength: int = 0
-    MaxSearchItems: int = 10
+class PermissiveDefaults(PermissionsDefaults):
+    """
+    The maxiumum allowed version of defaults.
+    Most values grant access or remove limits by default.
+    """
 
-    AllowPlaylists: bool = True
-    InstaSkip: bool = True
-    SkipLooped: bool = True
-    Remove: bool = True
-    SkipWhenAbsent: bool = False
-    BypassKaraokeMode: bool = True
+    command_whitelist: Set[str] = set()
+    command_blacklist: Set[str] = set()
+    ignore_non_voice: Set[str] = set()
+    grant_to_roles: Set[int] = set()
+    user_list: Set[int] = set()
 
-    SummonNoVoice: bool = True
+    max_songs: int = 0
+    max_song_length: int = 0
+    max_playlist_length: int = 0
+    max_search_items: int = 10
 
-    Extractors: Set[str] = set()
+    allow_playlists: bool = True
+    insta_skip: bool = True
+    skip_looped: bool = True
+    remove: bool = True
+    skip_when_absent: bool = False
+    bypass_karaoke_mode: bool = True
+
+    summon_no_voice: bool = True
+
+    # an empty set here allows all.
+    extractors: Set[str] = set()
 
 
 class Permissions:
-    def __init__(self, perms_file: pathlib.Path, grant_all: List[int]) -> None:
+    def __init__(self, perms_file: pathlib.Path) -> None:
         """
         Handles locating, initializing defaults, loading, and validating
         permissions config from the given `perms_file` path.
@@ -92,6 +107,8 @@ class Permissions:
         """
         self.perms_file = perms_file
         self.config = ExtendedConfigParser()
+        self.register = PermissionOptionRegistry(self, self.config)
+        self.groups: Dict[str, "PermissionGroup"] = {}
 
         if not self.config.read(self.perms_file, encoding="utf-8"):
             example_file = PermissionsDefaults.example_perms_file
@@ -112,47 +129,58 @@ class Permissions:
                     f"Unable to copy {example_file} to {self.perms_file}:  {str(e)}"
                 ) from e
 
-        self.default_group = PermissionGroup("Default", self.config["Default"])
-        self.groups = set()
-
         for section in self.config.sections():
-            if section != "Owner (auto)":
-                self.groups.add(PermissionGroup(section, self.config[section]))
+            if section == DEFAULT_OWNER_GROUP_NAME:
+                self.groups[section] = self._generate_permissive_group(section)
+            else:
+                self.groups[section] = self._generate_default_group(section)
 
-        if self.config.has_section("Owner (auto)"):
-            owner_group = PermissionGroup(
-                "Owner (auto)", self.config["Owner (auto)"], fallback=Permissive
+        # in case the permissions don't have a default group, make one.
+        if not self.config.has_section(DEFAULT_PERMS_GROUP_NAME):
+            self.groups[DEFAULT_PERMS_GROUP_NAME] = self._generate_default_group(
+                DEFAULT_PERMS_GROUP_NAME
             )
 
-        else:
-            log.info(
-                "[Owner (auto)] section not found, falling back to permissive default"
-            )
-            # Create a fake section to fallback onto the default permissive values to grant to the owner
-            owner_group = PermissionGroup(
-                "Owner (auto)",
-                configparser.SectionProxy(self.config, "Owner (auto)"),
-                fallback=Permissive,
+        # in case the permissions don't have an owner group, create a virtual one.
+        if not self.config.has_section(DEFAULT_OWNER_GROUP_NAME):
+            self.groups[DEFAULT_OWNER_GROUP_NAME] = self._generate_permissive_group(
+                DEFAULT_OWNER_GROUP_NAME
             )
 
-        if hasattr(grant_all, "__iter__"):
-            owner_group.user_list = set(grant_all)
+        self.register.validate_register_destinations()
 
-        self.groups.add(owner_group)
+    def _generate_default_group(self, name: str) -> "PermissionGroup":
+        """Generate a group with `name` using PermissionDefaults."""
+        return PermissionGroup(name, self, PermissionsDefaults)
+
+    def _generate_permissive_group(self, name: str) -> "PermissionGroup":
+        """Generate a group with `name` using PermissiveDefaults. Typically owner group."""
+        return PermissionGroup(name, self, PermissiveDefaults)
+
+    def set_owner_id(self, owner_id: int) -> None:
+        """Sets the given id as the owner ID in the owner permission group."""
+        if owner_id == 0:
+            log.debug("OwnerID is set auto, will set correctly later.")
+        self.groups[DEFAULT_OWNER_GROUP_NAME].user_list = set([owner_id])
+
+    @property
+    def owner_group(self) -> "PermissionGroup":
+        """Always returns the owner group"""
+        return self.groups[DEFAULT_OWNER_GROUP_NAME]
+
+    @property
+    def default_group(self) -> "PermissionGroup":
+        """Always returns the default group"""
+        return self.groups[DEFAULT_PERMS_GROUP_NAME]
 
     async def async_validate(self, bot: "MusicBot") -> None:
         """
         Handle validation of permissions data that depends on async services.
         """
         log.debug("Validating permissions...")
-
-        og = discord.utils.get(self.groups, name="Owner (auto)")
-        if not og:
-            raise RuntimeError("Owner permissions group is missing!")
-
-        if 0 in og.user_list:
-            log.debug("Fixing automatic owner group")
-            og.user_list = {bot.config.owner_id}
+        if 0 in self.owner_group.user_list:
+            log.debug("Setting auto OwnerID for owner permissions group.")
+            self.owner_group.user_list = {bot.config.owner_id}
 
     def save(self) -> None:
         """
@@ -168,38 +196,122 @@ class Permissions:
         :param user: A discord User or Member object
         """
 
-        for group in self.groups:
+        # Search for the first group a member ID shows up in.
+        for group in self.groups.values():
             if user.id in group.user_list:
                 return group
 
-        # The only way I could search for roles is if I add a `server=None` param and pass that too
+        # In case this is not a Member and has no roles, use default.
         if isinstance(user, discord.User):
             return self.default_group
 
-        # We loop again so that we don't return a role based group before we find an assigned one
-        for group in self.groups:
+        # Search groups again and associate the member by role IDs.
+        for group in self.groups.values():
             for role in user.roles:
                 if role.id in group.granted_to_roles:
                     return group
 
+        # Or just assign default role.
         return self.default_group
 
-    def create_group(self, name: str, **kwargs: Dict[str, Any]) -> None:
+    def add_group(self, name: str) -> None:
         """
-        Currently unused, intended to create a permission group that could
-        then be saved back to the permissions config file.
+        Creates a permission group, but does nothing to the parser.
         """
-        # TODO: Test this.  and implement the rest of permissions editing...
-        self.config.read_dict({name: kwargs})
-        self.groups.add(PermissionGroup(name, self.config[name]))
+        self.groups[name] = self._generate_default_group(name)
+
+    def remove_group(self, name: str) -> None:
+        """Removes a permission group but does nothing to the parser."""
+        del self.groups[name]
+        self.register.unregister_group(name)
+
+    def save_group(self, group: str) -> bool:
+        """
+        Converts the current Permission Group value into an INI file value as needed.
+        Note: ConfigParser must not use multi-line values. This will break them.
+        Should multiline values be needed, maybe use ConfigUpdater package instead.
+        """
+        try:
+            cu = configupdater.ConfigUpdater()
+            cu.optionxform = str  # type: ignore
+            cu.read(self.perms_file, encoding="utf8")
+
+            opts = self.register.get_option_dict(group)
+            # update/delete existing
+            if group in set(cu.keys()):
+                # update
+                if group in self.groups:
+                    log.debug("Updating group in permssions file:  %s", group)
+                    for option in set(cu[group].keys()):
+                        cu[group][option].value = self.register.to_ini(opts[option])
+
+                # delete
+                else:
+                    log.debug("Deleting group from permissions file:  %s", group)
+                    cu.remove_section(group)
+
+            # add new
+            elif group in self.groups:
+                log.debug("Adding new group to permissions file:  %s", group)
+                options = ""
+                for _, opt in opts.items():
+                    c_bits = opt.comment.split("\n")
+                    if len(c_bits) > 1:
+                        comments = "".join([f"# {x}\n" for x in c_bits])
+                    else:
+                        comments = f"# {opt.comment.strip()}\n"
+                    ini_val = self.register.to_ini(opt)
+                    options += f"{comments}{opt.option} = {ini_val}\n\n"
+                new_section = configupdater.ConfigUpdater()
+                new_section.optionxform = str  # type: ignore
+                new_section.read_string(f"[{group}]\n{options}\n")
+                cu.add_section(new_section[group].detach())
+
+            log.debug("Saving permissions file now.")
+            cu.update_file()
+            return True
+
+        # except configparser.MissingSectionHeaderError:
+        except configparser.ParsingError:
+            log.exception("ConfigUpdater could not parse the permissions file!")
+        except configparser.DuplicateSectionError:
+            log.exception("You have a duplicate section, fix your Permissions file!")
+        except OSError:
+            log.exception("Failed to save permissions group:  %s", group)
+
+        return False
+
+    def update_option(self, option: ConfigOption, value: str) -> bool:
+        """
+        Uses option data to parse the given value and update its associated permission.
+        No data is saved to file however.
+        """
+        tparser = ExtendedConfigParser()
+        tparser.read_dict({option.section: {option.option: value}})
+
+        try:
+            get = getattr(tparser, option.getter, None)
+            if not get:
+                log.critical("Dev Bug! Permission has getter that is not available.")
+                return False
+            new_conf_val = get(option.section, option.option, fallback=option.default)
+            if not isinstance(new_conf_val, type(option.default)):
+                log.error(
+                    "Dev Bug! Permission has invalid type, getter and default must be the same type."
+                )
+                return False
+            setattr(self.groups[option.section], option.dest, new_conf_val)
+            return True
+        except (HelpfulError, ValueError, TypeError):
+            return False
 
 
 class PermissionGroup:
     def __init__(
         self,
         name: str,
-        section_data: configparser.SectionProxy,
-        fallback: Any = PermissionsDefaults,
+        manager: Permissions,
+        defaults: Type[PermissionsDefaults],
     ) -> None:
         """
         Create a PermissionGroup object from a ConfigParser section.
@@ -208,56 +320,172 @@ class PermissionGroup:
         :param: section_data:  a config SectionProxy that describes a group
         :param: fallback:  Typically a PermissionsDefaults class
         """
+        self._mgr = manager
+
         self.name = name
 
-        self.command_whitelist = section_data.getstrset(
-            "CommandWhiteList", fallback=fallback.CommandWhiteList
+        self.command_whitelist = self._mgr.register.init_option(
+            section=name,
+            option="CommandWhiteList",
+            dest="command_whitelist",
+            getter="getstrset",
+            default=defaults.command_whitelist,
+            comment="List of command names allowed for use, separated by spaces. Overrides CommandBlackList is set.",
+            empty_display_val="(All allowed)",
         )
-        self.command_blacklist = section_data.getstrset(
-            "CommandBlackList", fallback=fallback.CommandBlackList
+        self.command_blacklist = self._mgr.register.init_option(
+            section=name,
+            option="CommandBlackList",
+            dest="command_blacklist",
+            default=defaults.command_blacklist,
+            getter="getstrset",
+            comment="List of command names denied from use, separated by spaces. Will not work if CommandWhiteList is set!",
+            empty_display_val="(None denied)",
         )
-        self.ignore_non_voice = section_data.getstrset(
-            "IgnoreNonVoice", fallback=fallback.IgnoreNonVoice
+        self.ignore_non_voice = self._mgr.register.init_option(
+            section=name,
+            option="IgnoreNonVoice",
+            dest="ignore_non_voice",
+            getter="getstrset",
+            default=defaults.ignore_non_voice,
+            comment=(
+                "List of command names that can only be used while in the same voice channel as MusicBot.\n"
+                "Some commands will always require the user to be in voice, regardless of this list.\n"
+                "Command names should be separated by spaces."
+            ),
+            empty_display_val="(No commands listed)",
         )
-        self.granted_to_roles = section_data.getidset(
-            "GrantToRoles", fallback=fallback.GrantToRoles
+        self.granted_to_roles = self._mgr.register.init_option(
+            section=name,
+            option="GrantToRoles",
+            dest="granted_to_roles",
+            getter="getidset",
+            default=defaults.grant_to_roles,
+            comment="List of Discord server role IDs that are granted this permission group. This option is ignored if UserList is set.",
+            invisible=True,
         )
-        self.user_list = section_data.getidset("UserList", fallback=fallback.UserList)
-
-        self.max_songs = section_data.getint("MaxSongs", fallback=fallback.MaxSongs)
-        self.max_song_length = section_data.getint(
-            "MaxSongLength", fallback=fallback.MaxSongLength
+        self.user_list = self._mgr.register.init_option(
+            section=name,
+            option="UserList",
+            dest="user_list",
+            getter="getidset",
+            default=defaults.user_list,
+            comment="List of Discord member IDs that are granted permissions in this group. This option overrides GrantToRoles.",
+            invisible=True,
         )
-        self.max_playlist_length = section_data.getint(
-            "MaxPlaylistLength", fallback=fallback.MaxPlaylistLength
+        self.max_songs = self._mgr.register.init_option(
+            section=name,
+            option="MaxSongs",
+            dest="max_songs",
+            getter="getint",
+            default=defaults.max_songs,
+            comment="Maximum number of songs a user is allowed to queue. A value of 0 means unlimited.",
+            empty_display_val="(Unlimited)",
         )
-        self.max_search_items = section_data.getint(
-            "MaxSearchItems", fallback=fallback.MaxSearchItems
+        self.max_song_length = self._mgr.register.init_option(
+            section=name,
+            option="MaxSongLength",
+            dest="max_song_length",
+            getter="getint",
+            default=defaults.max_song_length,
+            comment=(
+                "Maximum length of a song in seconds. A value of 0 means unlimited.\n"
+                "This permission may not be enforced if song duration is not available."
+            ),
+            empty_display_val="(Unlimited)",
         )
-
-        self.allow_playlists = section_data.getboolean(
-            "AllowPlaylists", fallback=fallback.AllowPlaylists
+        self.max_playlist_length = self._mgr.register.init_option(
+            section=name,
+            option="MaxPlaylistLength",
+            dest="max_playlist_length",
+            getter="getint",
+            default=defaults.max_playlist_length,
+            comment="Maximum number of songs a playlist is allowed to have to be queued. A value of 0 means unlimited.",
+            empty_display_val="(Unlimited)",
         )
-        self.instaskip = section_data.getboolean(
-            "InstaSkip", fallback=fallback.InstaSkip
+        self.max_search_items = self._mgr.register.init_option(
+            section=name,
+            option="MaxSearchItems",
+            dest="max_search_items",
+            getter="getint",
+            default=defaults.max_search_items,
+            comment="The maximum number of items that can be returned in a search.",
         )
-        self.skiplooped = section_data.getboolean(
-            "SkipLooped", fallback=fallback.SkipLooped
+        self.allow_playlists = self._mgr.register.init_option(
+            section=name,
+            option="AllowPlaylists",
+            dest="allow_playlists",
+            getter="getboolean",
+            default=defaults.allow_playlists,
+            comment="Allow users to queue playlists, or multiple songs at once.",
         )
-        self.remove = section_data.getboolean("Remove", fallback=fallback.Remove)
-        self.skip_when_absent = section_data.getboolean(
-            "SkipWhenAbsent", fallback=fallback.SkipWhenAbsent
+        self.instaskip = self._mgr.register.init_option(
+            section=name,
+            option="InstaSkip",
+            dest="instaskip",
+            getter="getboolean",
+            default=defaults.insta_skip,
+            comment="Allow users to skip without voting, if LegacySkip config option is enabled.",
         )
-        self.bypass_karaoke_mode = section_data.getboolean(
-            "BypassKaraokeMode", fallback=fallback.BypassKaraokeMode
+        self.skip_looped = self._mgr.register.init_option(
+            section=name,
+            option="SkipLooped",
+            dest="skip_looped",
+            getter="getboolean",
+            default=defaults.skip_looped,
+            comment="Allows the user to skip a looped song.",
         )
-
-        self.summonplay = section_data.getboolean(
-            "SummonNoVoice", fallback=fallback.SummonNoVoice
+        self.remove = self._mgr.register.init_option(
+            section=name,
+            option="Remove",
+            dest="remove",
+            getter="getboolean",
+            default=defaults.remove,
+            comment=(
+                "Allows the user to remove any song from the queue.\n"
+                "Does not remove or skip currently playing songs."
+            ),
         )
-
-        self.extractors = section_data.getstrset(
-            "Extractors", fallback=fallback.Extractors
+        self.skip_when_absent = self._mgr.register.init_option(
+            section=name,
+            option="SkipWhenAbsent",
+            dest="skip_when_absent",
+            getter="getboolean",
+            default=defaults.skip_when_absent,
+            comment="Skip songs added by users who are not in voice when their song is played.",
+        )
+        self.bypass_karaoke_mode = self._mgr.register.init_option(
+            section=name,
+            option="BypassKaraokeMode",
+            dest="bypass_karaoke_mode",
+            getter="getboolean",
+            default=defaults.bypass_karaoke_mode,
+            comment="Allows the user to add songs to the queue when Karaoke Mode is enabled.",
+        )
+        self.summonplay = self._mgr.register.init_option(
+            section=name,
+            option="SummonNoVoice",
+            dest="summonplay",
+            getter="getboolean",
+            default=defaults.summon_no_voice,
+            comment=(
+                "Auto summon to user voice channel when using play commands, if bot isn't in voice already.\n"
+                "The summon command must still be allowed for this group!"
+            ),
+        )
+        self.extractors = self._mgr.register.init_option(
+            section=name,
+            option="Extractors",
+            dest="extractors",
+            getter="getstrset",
+            default=defaults.extractors,
+            comment=(
+                "List of yt_dlp extractor keys, separated by spaces, that are allowed to be used.\n"
+                "Services supported by yt_dlp shown here:  https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md \n"
+                "MusicBot also provides one custom service `spotify:musicbot` to enable or disable spotify API extraction.\n"
+                "NOTICE: MusicBot might not support all services available to yt_dlp!\n"
+            ),
+            empty_display_val="(All allowed)",
         )
 
         self.validate()
@@ -277,8 +505,165 @@ class PermissionGroup:
         if uid in self.user_list:
             self.user_list.remove(uid)
 
+    def can_use_command(self, command: str) -> None:
+        """
+        Test if command is enabled in this permission group.
+
+        :raises:  PermissionsError  if command is denied from use.
+        """
+        if self.command_whitelist and command not in self.command_whitelist:
+            raise PermissionsError(
+                f"This command is not enabled for your group ({self.name}).",
+                expire_in=20,
+            )
+
+        if self.command_blacklist and command in self.command_blacklist:
+            raise PermissionsError(
+                f"This command is disabled for your group ({self.name}).",
+                expire_in=20,
+            )
+
+    def format(self, for_user: bool = False) -> str:
+        """
+        Format the current group values into INI-like text.
+
+        :param: for_user:  Present values for display, instead of literal values.
+        """
+        perms = f"Permission group name:  {self.name}\n"
+        for opt in self._mgr.register.option_list:
+            if opt.section != self.name:
+                continue
+            if opt.invisible and for_user:
+                continue
+            val = self._mgr.register.to_ini(opt)
+            if not val and opt.empty_display_val:
+                val = opt.empty_display_val
+            perms += f"{opt.option} = {val}\n"
+        return perms
+
     def __repr__(self) -> str:
         return f"<PermissionGroup: {self.name}>"
 
     def __str__(self) -> str:
         return f"<PermissionGroup: {self.name}: {self.__dict__}>"
+
+
+class PermissionOptionRegistry(ConfigOptionRegistry):
+    def __init__(self, config: Permissions, parser: ExtendedConfigParser) -> None:
+        super().__init__(config, parser)
+
+    def validate_register_destinations(self) -> None:
+        """Check all configured options for matching destination definitions."""
+        if not isinstance(self._config, Permissions):
+            raise RuntimeError(
+                "Dev Bug! Somehow this is Config when it should be Permissions."
+            )
+
+        errors = []
+        for opt in self._option_list:
+            if not hasattr(self._config.groups[opt.section], opt.dest):
+                errors.append(
+                    f"Permission `{opt}` has an missing destination named:  {opt.dest}"
+                )
+        if errors:
+            msg = "Dev Bug!  Some permissions failed validation.\n"
+            msg += "\n".join(errors)
+            raise RuntimeError(msg)
+
+    @property
+    def distinct_options(self) -> Set[str]:
+        """Unique Permission names for Permission groups."""
+        return self._distinct_options
+
+    def get_option_dict(self, group: str) -> Dict[str, ConfigOption]:
+        """Get only ConfigOptions for the group, in a dict by option name."""
+        return {opt.option: opt for opt in self.option_list if opt.section == group}
+
+    def unregister_group(self, group: str) -> None:
+        """Removes all registered options for group."""
+        new_opts = []
+        for opt in self.option_list:
+            if opt.section == group:
+                continue
+            new_opts.append(opt)
+        self._option_list = new_opts
+
+    def get_values(self, opt: ConfigOption) -> Tuple[RegTypes, str, str]:
+        """
+        Get the values in PermissionGroup and *ConfigParser for this option.
+        Returned tuple contains parsed value, ini-string, and a display string
+        for the parsed config value if applicable.
+        Display string may be empty if not used.
+        """
+        if not isinstance(self._config, Permissions):
+            raise RuntimeError(
+                "Dev Bug! Somehow this is Config when it should be Permissions."
+            )
+
+        if not opt.editable:
+            return ("", "", "")
+
+        if opt.section not in self._config.groups:
+            raise ValueError(
+                f"Dev Bug! PermissionGroup named `{opt.section}` does not exist."
+            )
+
+        if not hasattr(self._config.groups[opt.section], opt.dest):
+            raise AttributeError(
+                f"Dev Bug! Attribute `PermissionGroup.{opt.dest}` does not exist."
+            )
+
+        if not hasattr(self._parser, opt.getter):
+            raise AttributeError(
+                f"Dev Bug! Method `*ConfigParser.{opt.getter}` does not exist."
+            )
+
+        parser_get = getattr(self._parser, opt.getter)
+        config_value = getattr(self._config.groups[opt.section], opt.dest)
+        parser_value = parser_get(opt.section, opt.option, fallback=opt.default)
+
+        display_config_value = ""
+        if not display_config_value and opt.empty_display_val:
+            display_config_value = opt.empty_display_val
+
+        return (config_value, parser_value, display_config_value)
+
+    def get_parser_value(self, opt: ConfigOption) -> RegTypes:
+        """returns the parser's parsed value for the given option."""
+        getter = getattr(self._parser, opt.getter, None)
+        if getter is None:
+            raise AttributeError(
+                f"Dev Bug! Attribute *ConfigParser.{opt.getter} does not exist."
+            )
+
+        val: RegTypes = getter(opt.section, opt.option, fallback=opt.default)
+        if not isinstance(val, type(opt.default)):
+            raise TypeError("Dev Bug!  Type from parser does not match default type.")
+        return val
+
+    def to_ini(self, option: ConfigOption, use_default: bool = False) -> str:
+        """
+        Convert the parsed permission value into an INI value.
+        This method does not perform validation, simply converts the value.
+
+        :param: use_default:  return the default value instead of current config.
+        """
+        if not isinstance(self._config, Permissions):
+            raise RuntimeError(
+                "Dev Bug! Registry does not have Permissions config object."
+            )
+
+        if use_default:
+            conf_value = option.default
+        else:
+            if option.section not in self._config.groups:
+                raise ValueError(f"No PermissionGroup by the name `{option.section}`")
+
+            group = self._config.groups[option.section]
+            if not hasattr(group, option.dest):
+                raise AttributeError(
+                    f"Dev Bug! Attribute `PermissionGroup.{option.dest}` does not exist."
+                )
+
+            conf_value = getattr(group, option.dest)
+        return self._value_to_ini(conf_value, option.getter)

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -247,13 +247,11 @@ def set_logging_level(level: int, override: bool = False) -> None:
         dlogger.setLevel(level)
 
 
-# TODO: perhaps add config file option for max logs kept.
 def set_logging_max_kept_logs(number: int) -> None:
     """Inform the logger how many logs it should keep."""
     setattr(logging, "mb_max_logs_kept", number)
 
 
-# TODO: perhaps add a config file option for date format.
 def set_logging_rotate_date_format(sftime: str) -> None:
     """Inform the logger how it should format rotated file date strings."""
     setattr(logging, "mb_rot_date_fmt", sftime)
@@ -663,10 +661,13 @@ def format_song_duration(seconds: Union[int, float, datetime.timedelta]) -> str:
 
     # Simply remove any microseconds from the delta.
     time_delta = str(seconds).split(".", maxsplit=1)[0]
+    t_hours = seconds.seconds / 3600
 
-    # Check the hours portion for empty 0 and remove it.
-    duration_array = time_delta.split(":")
-    return time_delta if int(duration_array[0]) > 0 else ":".join(duration_array[1:])
+    # if hours is 0 remove it.
+    if seconds.days == 0 and t_hours < 1:
+        duration_array = time_delta.split(":")
+        return ":".join(duration_array[1:])
+    return time_delta
 
 
 def format_size_from_bytes(size_bytes: int) -> str:
@@ -759,6 +760,33 @@ def format_time_to_seconds(time_str: Union[str, int]) -> int:
     if isinstance(time_str, int):
         return time_str
 
+    # support HH:MM:SS notations like those from timedelta.__str__
+    hms_total = 0
+    if ":" in time_str:
+        parts = time_str.split()
+        for part in parts:
+            bits = part.split(":")
+            part_sec = 0
+            try:
+                # format is MM:SS
+                if len(bits) == 2:
+                    m = int(bits[0])
+                    s = int(bits[1])
+                    part_sec += (m * 60) + s
+                # format is HH:MM:SS
+                elif len(bits) == 3:
+                    h = int(bits[0] or 0)
+                    m = int(bits[1])
+                    s = int(bits[2] or 0)
+                    part_sec += (h * 3600) + (m * 60) + s
+                # format is not supported.
+                else:
+                    continue
+                hms_total += part_sec
+                time_str = time_str.replace(part, "")
+            except (ValueError, TypeError):
+                continue
+
     # TODO: find a good way to make this i18n friendly.
     time_lex = re.compile(r"(\d*\.?\d+)\s*(y|d|h|m|s)?", re.I)
     unit_seconds = {
@@ -768,7 +796,7 @@ def format_time_to_seconds(time_str: Union[str, int]) -> int:
         "m": 60,
         "s": 1,
     }
-    total_sec = 0
+    total_sec = hms_total
     for value, unit in time_lex.findall(time_str):
         if not unit:
             unit = "s"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ yt-dlp
 colorlog
 cffi --only-binary all; sys_platform == 'win32'
 certifi
+configupdater


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR adds a new dependency on the `configupdater` package. 
The new package enables updating the config and permissions ini files without destroying comments and other modifications made by users in these files.
There are two new commands:
- `config` allows interacting with the options.ini file settings, with some limits to prevent abuse or risk to tokens.
- `setperms` allows interacting with the permissions.ini file, with limits on built-in owner group.

Additionally, this PR converts the remaining file paths and some other hard-coded strings in permissions into definitions in the `constants.py` file. 


### Related issues 

Should close #730 and #362

