### PR TITLE
Installer updates

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -2,7 +2,15 @@
 
 CHCP 65001 > NUL
 
-REM --> This script only exists to easily launch the PowerShell script.
+REM --> The install.bat script only exists to easily launch the PowerShell script.
 REM --> By default powershell might error about running unsigned scripts...
 
-powershell.exe -noprofile -executionpolicy bypass -file install.ps1
+CD "%~dp0"
+
+SET InstFile="%~dp0%\install.ps1"
+IF exist %InstFile% (
+    powershell.exe -noprofile -executionpolicy bypass -file "%InstFile%"
+) ELSE (
+    echo Could not locate install.ps1
+    echo Please ensure it is available to continue the automatic install.
+)

--- a/install.ps1
+++ b/install.ps1
@@ -100,9 +100,10 @@ else
 }
 ""
 
-# TODO: fix this, it fails due to some missing addition to powershell environment.
-# idk if it is even needed, but was here before so whatever I guess...
-Invoke-Expression "refreshenv" 2>$null
+# NOTE: if we need to refresh the environment vars (Path, etc.) after installing
+# the above packages, we may need to add some other dependency which provides
+# RefreshEnv.bat or manually manage paths to newly installed exes.
+# Users should be able to get around this by restarting the powershell script.
 
 # --------------------------------------------------PULLING THE BOT----------------------------------------------------
 

--- a/musicbot/exceptions.py
+++ b/musicbot/exceptions.py
@@ -37,7 +37,6 @@ class InvalidDataError(MusicbotException):
 
 
 # The no processing entry type failed and an entry was a playlist/vice versa
-# TODO: Add typing options instead of is_playlist
 class WrongEntryTypeError(ExtractionError):
     def __init__(self, message: str, is_playlist: bool, use_url: str) -> None:
         super().__init__(message)
@@ -168,4 +167,5 @@ class RestartSignal(Signal):
 
 # signal to end the bot "gracefully"
 class TerminateSignal(Signal):
-    exit_code: int = 0
+    def __init__(self, exit_code: int = 0):
+        self.exit_code: int = exit_code

--- a/run.py
+++ b/run.py
@@ -650,7 +650,7 @@ def parse_cli_args() -> argparse.Namespace:
         help="Skip all optional startup checks, including the update check.",
     )
 
-    # Skip update checks option.
+    # Skip disk checks option.
     ap.add_argument(
         "--no-disk-check",
         dest="no_disk_check",

--- a/update.py
+++ b/update.py
@@ -232,7 +232,6 @@ def update_ffmpeg() -> None:
         print(f"Found FFmpeg EXE at:  {ffmpeg_bin}")
         print(f"Current {localver}")
 
-    # TODO: query winget for updates if winget is detected.
     # only query remote version if we are updating bundled exe.
     if ffmpeg_bin.lower() == bundle_ffmpeg_bin.lower():
         remotever = get_remote_ffmpeg_version()
@@ -241,6 +240,7 @@ def update_ffmpeg() -> None:
 
     print("")
 
+    # If ffmpeg was installed via winget, query it for upgrades instead.
     if (
         ffmpeg_bin.lower() != bundle_ffmpeg_bin.lower()
         and "winget" in ffmpeg_bin.lower()


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

These enable the install scripts to detect when they are run from a repo clone and continue installation without prompting for a new branch / clone to be made.
Some minor changes to output in the windows ps1 script to make it a tad less verbose and clear to see what is going on. 
This also fixes an edge case with startup when discord.py is missing but an extension package is installed.