### PR TITLE
Seek and speed features

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -60,6 +60,11 @@ DeleteNowPlaying = no
 # The volume of the bot's audio output, between 0.01 and 1.0.
 DefaultVolume = 0.25
 
+# The playback speed used by default for every song played by MusicBot.
+# Must be a value between 0.5 and 100.0, inclusive.
+# Default is 1.0, for normal playback speed.
+DefaultSpeed = 1.0
+
 # The number of people voting to skip in order for a song to be skipped successfully,
 # whichever value is lower will be used. Ratio refers to the percentage of undefeaned, non-
 # owner users in the channel. 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3315,6 +3315,7 @@ class MusicBot(discord.Client):
             {command_prefix}seek [time]
 
         Restarts the current song at the given time.
+        If time starts with + or - seek will be relative to current playback time.
         Time should be given in seconds, fractional seconds are accepted.
         Due to codec specifics in ffmpeg, this may not be accurate.
         """
@@ -3344,9 +3345,15 @@ class MusicBot(discord.Client):
                 expire_in=30,
             )
 
+        relative_seek: int = 0
         f_seek_time: float = 0
         if "." in seek_time:
             try:
+                if seek_time.startswith("-"):
+                    relative_seek = -1
+                if seek_time.startswith("+"):
+                    relative_seek = 1
+
                 p1, p2 = seek_time.rsplit(".", maxsplit=1)
                 i_seek_time = format_time_to_seconds(p1)
                 f_seek_time = float(f"0.{p2}")
@@ -3359,7 +3366,10 @@ class MusicBot(discord.Client):
         else:
             f_seek_time = 0.0 + format_time_to_seconds(seek_time)
 
-        if f_seek_time > _player.current_entry.duration:
+        if relative_seek != 0:
+            f_seek_time = _player.progress + (relative_seek * f_seek_time)
+
+        if f_seek_time > _player.current_entry.duration or f_seek_time < 0:
             td = format_song_duration(_player.current_entry.duration_td)
             raise exceptions.CommandError(
                 f"Cannot seek to `{seek_time}` in the current track with a length of `{td}`",

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -265,6 +265,17 @@ class Config:
                 "Must be a value from 0 to 1 inclusive."
             ),
         )
+        self.default_speed: float = self.register.init_option(
+            section="MusicBot",
+            option="DefaultSpeed",
+            dest="default_speed",
+            default=ConfigDefaults.default_speed,
+            getter="getfloat",
+            comment=(
+                "Sets the default speed MusicBot will play songs at.\n"
+                "Must be a value from 0.5 to 100.0 for ffmpeg to use it."
+            ),
+        )
         self.skips_required: int = self.register.init_option(
             section="MusicBot",
             option="SkipsRequired",
@@ -817,6 +828,16 @@ class Config:
         if not self.footer_text:
             self.footer_text = ConfigDefaults.footer_text
 
+        if self.default_speed < 0.5 or self.default_speed > 100.0:
+            log.warning(
+                "The default playback speed must be between 0.5 and 100.0. "
+                "The option value of %.3f will be limited instead."
+            )
+            self.default_speed = max(min(self.default_speed, 100.0), 0.5)
+
+        if self.enable_local_media and not self.media_file_dir.is_dir():
+            self.media_file_dir.mkdir(exist_ok=True)
+
     async def async_validate(self, bot: "MusicBot") -> None:
         """
         Validation logic for bot settings that depends on data from async services.
@@ -1060,6 +1081,7 @@ class ConfigDefaults:
     delete_nowplaying: bool = True
 
     default_volume: float = 0.15
+    default_speed: float = 1.0
     skips_required: int = 4
     skip_ratio_required: float = 0.5
     save_videos: bool = True

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -46,30 +46,52 @@ class SourcePlaybackCounter(AudioSource):
     def __init__(
         self,
         source: PCMVolumeTransformer[FFmpegPCMAudio],
-        progress: int = 0,
+        start_time: float = 0,
+        playback_speed: float = 1.0,
     ) -> None:
         """
         Manage playback source and attempt to count progress frames used
         to measure playback progress.
+
+        :param: start_time:  A time in seconds that was used in ffmpeg -ss flag.
         """
         self._source = source
-        self.progress = progress
+        self._num_reads: int = 0
+        self._start_time: float = start_time
+        self._playback_speed: float = playback_speed
 
     def read(self) -> bytes:
         res = self._source.read()
         if res:
-            self.progress += 1
+            self._num_reads += 1
         return res
-
-    def get_progress(self) -> float:
-        """Get an approximate playback progress."""
-        return self.progress * 0.02
 
     def cleanup(self) -> None:
         log.noise(  # type: ignore[attr-defined]
-            "Cleanup got called on the audio source:  %s", repr(self)
+            "Cleanup got called on the audio source:  %r", self
         )
         self._source.cleanup()
+
+    @property
+    def frames(self) -> int:
+        """
+        Number of read frames since this source was opened.
+        This is not the total playback time.
+        """
+        return self._num_reads
+
+    @property
+    def session_progress(self) -> float:
+        """
+        Like progress but only counts frames from this session.
+        Adjusts the estimated time by playback speed.
+        """
+        return (self._num_reads * 0.02) * self._playback_speed
+
+    @property
+    def progress(self) -> float:
+        """Get an approximate playback progress time."""
+        return self._start_time + self.session_progress
 
 
 class MusicPlayer(EventEmitter, Serializable):
@@ -356,6 +378,9 @@ class MusicPlayer(EventEmitter, Serializable):
                 # aoptions = "-vn -b:a 192k"
                 if isinstance(entry, URLPlaylistEntry):
                     aoptions = entry.aoptions
+                    # check for before options, currently just -ss here.
+                    if entry.boptions:
+                        boptions += f" {entry.boptions}"
                 else:
                     aoptions = "-vn"
 
@@ -377,7 +402,9 @@ class MusicPlayer(EventEmitter, Serializable):
                             stderr=stderr_io,
                         ),
                         self.volume,
-                    )
+                    ),
+                    start_time=entry.start_time,
+                    playback_speed=entry.playback_speed,
                 )
                 log.voicedebug(  # type: ignore[attr-defined]
                     "Playing %r using %r", self._source, self.voice_client
@@ -447,22 +474,11 @@ class MusicPlayer(EventEmitter, Serializable):
                     )
 
     def __json__(self) -> Dict[str, Any]:
-        progress_frames = None
-        if (
-            self._current_player
-            and self._current_player._player  # pylint: disable=protected-access
-        ):
-            if self.progress is not None:
-                progress_frames = (
-                    self._current_player._player.loops  # pylint: disable=protected-access
-                )
-
         return self._enclose_json(
             {
                 "current_entry": {
                     "entry": self.current_entry,
-                    "progress": self.progress,
-                    "progress_frames": progress_frames,
+                    "progress": self.progress if self.progress > 1 else None,
                 },
                 "entries": self.playlist,
             }
@@ -489,12 +505,13 @@ class MusicPlayer(EventEmitter, Serializable):
 
         current_entry_data = raw_json["current_entry"]
         if current_entry_data["entry"]:
+            entry = current_entry_data["entry"]
+            progress = current_entry_data["progress"]
+            if progress and isinstance(
+                entry, (URLPlaylistEntry, LocalFilePlaylistEntry)
+            ):
+                entry.set_start_time(progress)
             player.playlist.entries.appendleft(current_entry_data["entry"])
-            # TODO: progress stuff
-            # how do I even do this
-            # this would have to be in the entry class right?
-            # some sort of progress indicator to skip ahead with ffmpeg (however that works, reading and ignoring frames?)
-
         return player
 
     @classmethod
@@ -554,11 +571,17 @@ class MusicPlayer(EventEmitter, Serializable):
         Return a progress value for the media playback.
         """
         if self._source:
-            return self._source.get_progress()
-            # TODO: Properly implement this
-            #       Correct calculation should be bytes_read/192k
-            #       192k AKA sampleRate * (bitDepth / 8) * channelCount
-            #       Change frame_count to bytes_read in the PatchedBuff
+            return self._source.progress
+        return 0
+
+    @property
+    def session_progress(self) -> float:
+        """
+        Return the estimated playback time of the current playback source.
+        Like progress, but does not include any start-time if one was used.
+        """
+        if self._source:
+            return self._source.session_progress
         return 0
 
 


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR adds seeking and playback speed features.    Two new commands `seek` and `speed` which work on the current playing track. 
This PR also enables serialization to keep track of song progress so songs can be paused and resumed from their last known progress point when reconnecting or restarting the bot/music player.

### Related issues (if applicable)

could close #2192  and  #452 