### PR TITLE
Multiple playlists and local media files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ config/whitelist.txt
 config/blacklist.txt
 config/blocklist_users.txt
 config/blocklist_songs.txt
+config/playlists/
+media/
 
 docker-compose.yml

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -230,6 +230,17 @@ EnableSongBlocklist = no
 # By default this is disabled.
 EnableNetworkChecker = no
 
+# Enable saving all songs played by MusicBot to a global playlist, history.txt
+SavePlayedHistoryGlobal = no
+
+# Enable saving songs played by MusicBot to a per-guild playlist, history-{Guild_ID}.txt
+SavePlayedHistoryGuilds = no
+
+# Enable playback of local media files using the play command.
+# When enabled, users can use:  `play file://path/to/file.ext`
+# to play files from the local MediaFileDirectory path.
+EnableLocalMedia = no
+
 
 [Files]
 # Configure automatic log file rotation at restart, and limit the number of files kept.
@@ -243,11 +254,6 @@ LogsMaxKept = 0
 #    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
 # Default value is:  ".ended-%Y-%j-%H%m%S"
 LogsDateFormat = .ended-%Y-%j-%H%m%S
-
-# An optional file path to an auto playlist text file.
-# Each line of the file will be treated similarly to using the play command.
-# Default value is:  config/autoplaylist.txt
-AutoPlaylistFile =
 
 # Path to your i18n file. Do not set this if you do not know what it does.
 i18nFile = 
@@ -272,3 +278,13 @@ UserBlocklistFile =
 # MusicBot will create it if it does not exist.
 # Default file:  config/blocklist_songs.txt
 SongBlocklistFile = 
+
+# A directory path where playlists and related files can be stored.
+# Default path is:  config/playlists/
+AutoPlaylistDirectory =
+
+# An optional directory path where playable media files can be stored.
+# All files and sub-directories can then be accessed by using 'file://' as a protocol.
+#  Example:  file://some/folder/name/file.ext
+#  Maps to:  ./media/some/folder/name/file.ext
+MediaFileDirectory =

--- a/musicbot/autoplaylist.py
+++ b/musicbot/autoplaylist.py
@@ -1,0 +1,349 @@
+import asyncio
+import logging
+import pathlib
+import shutil
+import time
+from collections import UserList
+from typing import TYPE_CHECKING, Dict, List, Optional, Set
+
+from .constants import (
+    APL_FILE_APLCOPY,
+    APL_FILE_DEFAULT,
+    APL_FILE_HISTORY,
+    OLD_BUNDLED_AUTOPLAYLIST_FILE,
+    OLD_DEFAULT_AUTOPLAYLIST_FILE,
+)
+
+if TYPE_CHECKING:
+    from .bot import MusicBot
+
+    StrUserList = UserList[str]
+else:
+    StrUserList = UserList
+
+log = logging.getLogger(__name__)
+
+
+class AutoPlaylist(StrUserList):
+    def __init__(self, filename: pathlib.Path, bot: "MusicBot") -> None:
+        super().__init__()
+
+        self._bot: "MusicBot" = bot
+        self._file: pathlib.Path = filename
+        self._removed_file = filename.with_name(f"{filename.stem}.removed.log")
+
+        self._update_lock: asyncio.Lock = asyncio.Lock()
+        self._file_lock: asyncio.Lock = asyncio.Lock()
+        self._is_loaded: bool = False
+
+    @property
+    def filename(self) -> str:
+        """The base file name of this playlist."""
+        return self._file.name
+
+    @property
+    def loaded(self) -> bool:
+        """
+        Returns the load status of this playlist.
+        When False, no playlist data will be available.
+        """
+        return self._is_loaded
+
+    @property
+    def rmlog_file(self) -> pathlib.Path:
+        """Returns the generated removal log file name."""
+        return self._removed_file
+
+    def create_file(self) -> None:
+        """Creates the playlist file if it does not exist."""
+        if not self._file.is_file():
+            self._file.touch(exist_ok=True)
+
+    async def load(self, force: bool = False) -> None:
+        """
+        Loads the playlist file if it has not been loaded.
+        """
+        # ignore loaded lists unless forced.
+        if (self._is_loaded or self._file_lock.locked()) and not force:
+            return
+
+        # Load the actual playlist file.
+        async with self._file_lock:
+            try:
+                self.data = self._read_playlist()
+            except OSError:
+                log.warning("Error loading auto playlist file:  %s", self._file)
+                self.data = []
+                self._is_loaded = False
+                return
+            self._is_loaded = True
+
+    def _read_playlist(self) -> List[str]:
+        """
+        Read and parse the playlist file for track entries.
+        """
+        # Comments in apl files are only handled based on start-of-line.
+        # Inline comments are not supported due to supporting non-URL entries.
+        comment_char = "#"
+
+        # Read in the file and add non-comments to the playlist.
+        playlist: List[str] = []
+        with open(self._file, "r", encoding="utf8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith(comment_char):
+                    continue
+                playlist.append(line)
+        return playlist
+
+    async def remove_track(
+        self,
+        song_subject: str,
+        *,
+        ex: Optional[Exception] = None,
+        delete_from_ap: bool = False,
+    ) -> None:
+        """
+        Handle clearing the given `song_subject` from the autoplaylist queue,
+        and optionally from the configured autoplaylist file.
+
+        :param: ex:  an exception that is given as the reason for removal.
+        :param: delete_from_ap:  should the configured list file be updated?
+        """
+        if song_subject not in self.data:
+            return
+
+        async with self._update_lock:
+            self.data.remove(song_subject)
+            log.info(
+                "Removing%s song from playlist, %s: %s",
+                " unplayable" if ex and not isinstance(ex, UserWarning) else "",
+                self._file.name,
+                song_subject,
+            )
+
+            if not self._removed_file.is_file():
+                self._removed_file.touch(exist_ok=True)
+
+            try:
+                with open(self._removed_file, "a", encoding="utf8") as f:
+                    ctime = time.ctime()
+                    # add 10 spaces to line up with # Reason:
+                    e_str = str(ex).replace("\n", "\n#" + " " * 10)
+                    sep = "#" * 32
+                    f.write(
+                        f"# Entry removed {ctime}\n"
+                        f"# Track:  {song_subject}\n"
+                        f"# Reason: {e_str}\n"
+                        f"\n{sep}\n\n"
+                    )
+            except (OSError, PermissionError, FileNotFoundError, IsADirectoryError):
+                log.exception(
+                    "Could not log information about the playlist URL removal."
+                )
+
+            if delete_from_ap:
+                log.info("Updating playlist file...")
+
+                def _filter_replace(line: str, url: str) -> str:
+                    target = line.strip()
+                    if target == url:
+                        return f"# Removed # {url}"
+                    return line
+
+                # read the original file in and update lines with the URL.
+                # this is done to preserve the comments and formatting.
+                try:
+                    data = self._file.read_text(encoding="utf8").split("\n")
+                    data = [_filter_replace(x, song_subject) for x in data]
+                    text = "\n".join(data)
+                    self._file.write_text(text, encoding="utf8")
+                except (OSError, PermissionError, FileNotFoundError):
+                    log.exception("Failed to save playlist file:  %s", self._file)
+                self._bot.filecache.remove_autoplay_cachemap_entry_by_url(song_subject)
+
+    async def add_track(self, song_subject: str) -> None:
+        """
+        Add the given `song_subject` to the auto playlist file and in-memory
+        list.  Does not update the player's current autoplaylist queue.
+        """
+        if song_subject in self.data:
+            log.debug("URL already in playlist %s, ignoring", self._file.name)
+            return
+
+        async with self._update_lock:
+            # Note, this does not update the player's copy of the list.
+            self.data.append(song_subject)
+            log.info(
+                "Adding new URL to playlist, %s: %s",
+                self._file.name,
+                song_subject,
+            )
+
+            try:
+                # make sure the file exists.
+                if not self._file.is_file():
+                    self._file.touch(exist_ok=True)
+
+                # append to the file to preserve its formatting.
+                with open(self._file, "r+", encoding="utf8") as fh:
+                    lines = fh.readlines()
+                    if not lines:
+                        lines.append("# MusicBot Auto Playlist\n")
+                    if lines[-1].endswith("\n"):
+                        lines.append(f"{song_subject}\n")
+                    else:
+                        lines.append(f"\n{song_subject}\n")
+                    fh.seek(0)
+                    fh.writelines(lines)
+            except (OSError, PermissionError, FileNotFoundError):
+                log.exception("Failed to save playlist file:  %s", self._file)
+
+
+class AutoPlaylistManager:
+    """Manager class that facilitates multiple playlists."""
+
+    def __init__(self, bot: "MusicBot") -> None:
+        """
+        Initialize the manager, checking the file system for usable playlists.
+        """
+        self._bot: "MusicBot" = bot
+        self._apl_dir: pathlib.Path = bot.config.auto_playlist_dir
+        self._apl_file_default = self._apl_dir.joinpath(APL_FILE_DEFAULT)
+        self._apl_file_history = self._apl_dir.joinpath(APL_FILE_HISTORY)
+        self._apl_file_usercopy = self._apl_dir.joinpath(APL_FILE_APLCOPY)
+
+        self._playlists: Dict[str, AutoPlaylist] = {}
+
+        self.setup_autoplaylist()
+
+    def setup_autoplaylist(self) -> None:
+        """
+        Ensure directories for auto playlists are available and that historic
+        playlist files are copied.
+        """
+        if not self._apl_dir.is_dir():
+            self._apl_dir.mkdir(parents=True, exist_ok=True)
+
+        # Files from previous versions of MusicBot
+        old_usercopy = pathlib.Path(OLD_DEFAULT_AUTOPLAYLIST_FILE)
+        old_bundle = pathlib.Path(OLD_BUNDLED_AUTOPLAYLIST_FILE)
+
+        # Copy or rename the old auto-playlist files if new files don't exist yet.
+        if old_usercopy.is_file() and not self._apl_file_usercopy.is_file():
+            # rename the old autoplaylist.txt into the new playlist directory.
+            old_usercopy.rename(self._apl_file_usercopy)
+        if old_bundle.is_file() and not self._apl_file_default.is_file():
+            # copy the bundled playlist into the default, shared playlist.
+            shutil.copy(old_bundle, self._apl_file_default)
+
+        if (
+            not self._apl_file_history.is_file()
+            and self._bot.config.enable_queue_history_global
+        ):
+            self._apl_file_history.touch(exist_ok=True)
+
+        self.discover_playlists()
+
+    @property
+    def _default_pl(self) -> AutoPlaylist:
+        """Returns the default playlist, even if the file is deleted."""
+        if self._apl_file_default.stem in self._playlists:
+            return self._playlists[self._apl_file_default.stem]
+
+        self._playlists[self._apl_file_default.stem] = AutoPlaylist(
+            filename=self._apl_file_default,
+            bot=self._bot,
+        )
+        return self._playlists[self._apl_file_default.stem]
+
+    @property
+    def _usercopy_pl(self) -> Optional[AutoPlaylist]:
+        """Returns the copied autoplaylist.txt playlist if it exists."""
+        # return mapped copy if possible.
+        if self._apl_file_usercopy.stem in self._playlists:
+            return self._playlists[self._apl_file_usercopy.stem]
+
+        # if no mapped copy, check if file exists and map it.
+        if self._apl_file_usercopy.is_file():
+            self._playlists[self._apl_file_usercopy.stem] = AutoPlaylist(
+                filename=self._apl_file_usercopy,
+                bot=self._bot,
+            )
+
+        return self._playlists.get(self._apl_file_usercopy.stem, None)
+
+    @property
+    def global_history(self) -> AutoPlaylist:
+        """Returns the MusicBot global history file."""
+        if self._apl_file_history.stem in self._playlists:
+            return self._playlists[self._apl_file_history.stem]
+
+        self._playlists[self._apl_file_history.stem] = AutoPlaylist(
+            filename=self._apl_file_history,
+            bot=self._bot,
+        )
+        return self._playlists[self._apl_file_history.stem]
+
+    @property
+    def playlist_names(self) -> List[str]:
+        """Returns all discovered playlist names."""
+        return list(self._playlists.keys())
+
+    @property
+    def loaded_playlists(self) -> List[AutoPlaylist]:
+        """Returns all loaded AutoPlaylist objects."""
+        return [pl for pl in self._playlists.values() if pl.loaded]
+
+    @property
+    def loaded_tracks(self) -> List[str]:
+        """
+        Contains a list of all unique playlist entries, from each loaded playlist.
+        """
+        tracks: Set[str] = set()
+        for pl in self._playlists.values():
+            if pl.loaded:
+                tracks = tracks.union(set(pl))
+        return list(tracks)
+
+    def discover_playlists(self) -> None:
+        """
+        Look for available playlist files but do not load them into memory yet.
+        This method makes playlists available for display or selection.
+        """
+        for pfile in self._apl_dir.iterdir():
+            # only process .txt files
+            if pfile.suffix.lower() == ".txt":
+                # ignore already discovered playlists.
+                if pfile.stem in self._playlists:
+                    continue
+
+                pl = AutoPlaylist(pfile, self._bot)
+                self._playlists[pfile.stem] = pl
+
+    def get_default(self) -> AutoPlaylist:
+        """
+        Gets the appropriate default playlist based on which files exist.
+        """
+        # If the old autoplaylist.txt was copied, use it.
+        if self._usercopy_pl is not None:
+            return self._usercopy_pl
+        return self._default_pl
+
+    def get_playlist(self, filename: str) -> AutoPlaylist:
+        """Get or create a playlist with the given filename."""
+        # using pathlib .name here prevents directory traversal attack.
+        pl_file = self._apl_dir.joinpath(pathlib.Path(filename).name)
+
+        # Return the existing instance if we have one.
+        if pl_file.stem in self._playlists:
+            return self._playlists[pl_file.stem]
+
+        # otherwise, make a new instance with this filename
+        self._playlists[pl_file.stem] = AutoPlaylist(pl_file, self._bot)
+        return self._playlists[pl_file.stem]
+
+    def playlist_exists(self, filename: str) -> bool:
+        """Check for the existence of the given playlist file."""
+        # using pathlib .name prevents directory traversal attack.
+        return self._apl_dir.joinpath(pathlib.Path(filename).name).is_file()

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -27,19 +27,29 @@ DEFAULT_COMMAND_ALIAS_FILE: str = "config/aliases.json"
 DEFAULT_USER_BLOCKLIST_FILE: str = "config/blocklist_users.txt"
 DEFAULT_SONG_BLOCKLIST_FILE: str = "config/blocklist_songs.txt"
 DEPRECATED_USER_BLACKLIST: str = "config/blacklist.txt"
-DEFAULT_AUTOPLAYLIST_FILE: str = "config/autoplaylist.txt"
-BUNDLED_AUTOPLAYLIST_FILE: str = "config/_autoplaylist.txt"
-DEFAULT_AUDIO_CACHE_PATH: str = "audio_cache"
-DEFAULT_DATA_PATH: str = "data"
-DEFAULT_DATA_NAME_SERVERS: str = "server_names.txt"
-DEFAULT_DATA_NAME_QUEUE: str = "queue.json"
-DEFAULT_DATA_NAME_CUR_SONG: str = "current.txt"
-DEFAULT_DATA_NAME_OPTIONS: str = "options.json"
+OLD_DEFAULT_AUTOPLAYLIST_FILE: str = "config/autoplaylist.txt"
+OLD_BUNDLED_AUTOPLAYLIST_FILE: str = "config/_autoplaylist.txt"
+DEFAULT_PLAYLIST_DIR: str = "config/playlists/"
+DEFAULT_MEDIA_FILE_DIR: str = "media/"
+DEFAULT_AUDIO_CACHE_DIR: str = "audio_cache/"
+DEFAULT_DATA_DIR: str = "data/"
 
+# File names within the DEFAULT_DATA_DIR or guild folders.
+DATA_FILE_SERVERS: str = "server_names.txt"
+DATA_FILE_CACHEMAP: str = "playlist_cachemap.json"
+DATA_GUILD_FILE_QUEUE: str = "queue.json"
+DATA_GUILD_FILE_CUR_SONG: str = "current.txt"
+DATA_GUILD_FILE_OPTIONS: str = "options.json"
+
+# Example config files.
 EXAMPLE_OPTIONS_FILE: str = "config/example_options.ini"
 EXAMPLE_PERMS_FILE: str = "config/example_permissions.ini"
 EXAMPLE_COMMAND_ALIAS_FILE: str = "config/example_aliases.json"
 
+# Playlist related settings.
+APL_FILE_DEFAULT: str = "default.txt"
+APL_FILE_HISTORY: str = "history.txt"
+APL_FILE_APLCOPY: str = "autoplaylist.txt"
 
 # Logging related constants
 DEFAULT_MUSICBOT_LOG_FILE: str = "logs/musicbot.log"

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from discord import AudioSource, FFmpegPCMAudio, PCMVolumeTransformer, VoiceClient
 
 from .constructs import Serializable, Serializer, SkipState
-from .entry import StreamPlaylistEntry, URLPlaylistEntry
+from .entry import LocalFilePlaylistEntry, StreamPlaylistEntry, URLPlaylistEntry
 from .exceptions import FFmpegError, FFmpegWarning
 from .lib.event_emitter import EventEmitter
 
@@ -24,7 +24,7 @@ else:
     AsyncFuture = asyncio.Future
 
 # Type alias
-EntryTypes = Union[URLPlaylistEntry, StreamPlaylistEntry]
+EntryTypes = Union[URLPlaylistEntry, StreamPlaylistEntry, LocalFilePlaylistEntry]
 
 log = logging.getLogger(__name__)
 
@@ -376,7 +376,7 @@ class MusicPlayer(EventEmitter, Serializable):
 
                 boptions = "-nostdin"
                 # aoptions = "-vn -b:a 192k"
-                if isinstance(entry, URLPlaylistEntry):
+                if isinstance(entry, (URLPlaylistEntry, LocalFilePlaylistEntry)):
                     aoptions = entry.aoptions
                     # check for before options, currently just -ss here.
                     if entry.boptions:


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

Adding multi-playlist features and the ability to play local media.
All new playlist features are managed by the `autoplaylist` command.

This PR enables guild-specific playlists by setting separate playlist names for each guild.  
MusicBot can now save a list of played songs per-guild and/or globally. 

Local media is identified by the use of `file://` as a URI scheme when using play commands.  These file 'URL' can be included in playlists to enable playing local media files between files sourced remotely. 
Local media is disabled by default and the source directory can be configured via `MediaFileDirectory` config option.

As a side note. These last few PRs have probably left `dev` in a broken state.  The last PR in the series will contain mostly bug fixes that should leave it working again. 

### Related issues (if applicable)

Could close these issues:  
#1842 #1004 #921 #443 #44 #43 
#168  -- now possible via file:// scheme and playlists.