### PR TITLE
Bug fixes, QOL tweaks, and code clean up.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -30,6 +30,10 @@ BotExceptionIDs =
 # e.g if you set this to *, the play command would be triggered using *play.
 CommandPrefix = !
 
+# Enable using commands with @[YourBotNameHere]
+# The CommandPrefix is still available, but can be replaced with @ mention.
+CommandsByMention = yes
+
 # Restricts the bot to only listening to certain text channels.
 # Space-separated list of text channel IDs.
 BindToChannels =
@@ -136,6 +140,16 @@ DebugLevel = INFO
 
 # Specify a custom message to use as the bot's status. If left empty, the bot
 # will display dynamic info about music currently being played in its status instead.
+# Status messages may also use the following variables in custom status messages:
+#  {n_playing}   = Number of currently Playing music players.
+#  {n_paused}    = Number of currently Paused music players.
+#  {n_connected} = Number of connected music players, in any player state.
+#
+# The following variables give access to information about the player and track.
+# These variables may not be accurate in multi-guild bots:
+#  {p0_length}   = The total duration of the track, if available. Ex: [2:34]
+#  {p0_title}    = The track title for the currently playing track.
+#  {p0_url}      = The track url for the currently playing track.
 StatusMessage = 
 
 # Write what the bot is currently playing to the data/<server id>/current.txt FILE.
@@ -202,8 +216,7 @@ LeaveInactiveVC = no
 # Default value is 300 seconds.
 LeaveInactiveVCTimeOut = 300
 
-# If enabled, MusicBot will leave the channel immediately when the song queue is empty.
-# Default is set to:  no
+# Sets if if the bot should leave immediately once all songs have finished playing.
 LeaveAfterQueueEmpty = no
 
 # Set a period of seconds that a player can be paused or not playing before it will disconnect.
@@ -216,12 +229,10 @@ LeavePlayerInactiveFor = 0
 # When enabled the bot will automatically rotate between user requested songs.
 RoundRobinQueue = no
 
-# Enable the user block list feature, without emptying the block list.
-# Default is set to:  yes
+# This setting allows you to quickly enable or disable use of User Blocklist. 
 EnableUserBlocklist = yes
 
 # This setting allows you to quickly enable or disable the use of Song Blocklist.
-# Default is set to:  no
 EnableSongBlocklist = no
 
 # Allow MusicBot to use system ping command to detect network outage and availability.

--- a/config/example_permissions.ini
+++ b/config/example_permissions.ini
@@ -73,11 +73,14 @@
 ;    that the bot is already joined in the server. It is also expected that the user have ability to invoke summon command to
 ;    use this option.
 ;
-;    Extractors = example1 example2
-;    Specify the name of youtube-dl extractors that people will be able to play using the bot. Seperated by spaces.
-;    This is to allow restriction of playing porn videos through the bot, as these are supported by yt-dl. Leave blank to allow all.
-;    For a list of possible extractors, see https://github.com/rg3/youtube-dl/tree/master/youtube_dl/extractor
-;    The generic extractor is used by the bot to query the song when the query text is given via the play command.
+;    Extractors = spotify:musicbot youtube youtube:playlist youtube:tab youtube:search
+;    Specify yt-dlp extractor names that MusicBot will allow users to play media from.
+;    Each extractor name should be separated by spaces.
+;    If left empty, all services will be allowed.  Including porn services.
+;    The yt-dlp project has a list of supported services here:  
+;      https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md
+;
+;    The extractor `spotify:musicbot` is provided by MusicBot, not yt-dlp.
 ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -66,11 +66,16 @@ DEFAULT_LOG_LEVEL: str = "INFO"
 
 # Default target FQDN or IP to ping with network tester.
 DEFAULT_PING_TARGET: str = "discord.com"
+# Default file location URI used by fallback HTTP network testing.
+# This URI must be available via standard HTTP on the above domain/IP target.
+DEFAULT_PING_HTTP_URI: str = "/robots.txt"
 # Max time in seconds that ping should wait for response.
-DEFAULT_PING_TIMEOUT: int = 2
+DEFAULT_PING_TIMEOUT: int = 5
 # Time in seconds to wait between pings.
-DEFAULT_PING_SLEEP: float = 0.8
-
+DEFAULT_PING_SLEEP: float = 2
+# Ping time settings for HTTP fallback.
+FALLBACK_PING_TIMEOUT: int = 15
+FALLBACK_PING_SLEEP: float = 4
 
 # Minimum number of seconds to wait for a VoiceClient to connect.
 VOICE_CLIENT_RECONNECT_TIMEOUT: int = 5
@@ -89,6 +94,7 @@ DISCORD_MSG_CHAR_LIMIT: int = 2000
 
 EMOJI_CHECK_MARK_BUTTON: str = "\u2705"
 EMOJI_CROSS_MARK_BUTTON: str = "\u274E"
+EMOJI_STOP_SIGN: str = "\U0001F6D1"
 EMOJI_IDLE_ICON: str = "\U0001f634"  # same as \N{SLEEPING FACE}
 EMOJI_PLAY_ICON: str = "\u25B6"  # add \uFE0F to make button
 EMOJI_PAUSE_ICON: str = "\u23F8\uFE0F"  # add \uFE0F to make button

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -69,7 +69,7 @@ class PermissionsDefaults:
 
 class PermissiveDefaults(PermissionsDefaults):
     """
-    The maxiumum allowed version of defaults.
+    The maximum allowed version of defaults.
     Most values grant access or remove limits by default.
     """
 
@@ -229,7 +229,7 @@ class Permissions:
         """
         Converts the current Permission Group value into an INI file value as needed.
         Note: ConfigParser must not use multi-line values. This will break them.
-        Should multiline values be needed, maybe use ConfigUpdater package instead.
+        Should multi-line values be needed, maybe use ConfigUpdater package instead.
         """
         try:
             cu = configupdater.ConfigUpdater()
@@ -326,20 +326,26 @@ class PermissionGroup:
 
         self.command_whitelist = self._mgr.register.init_option(
             section=name,
-            option="CommandWhiteList",
+            option="CommandWhitelist",
             dest="command_whitelist",
             getter="getstrset",
             default=defaults.command_whitelist,
-            comment="List of command names allowed for use, separated by spaces. Overrides CommandBlackList is set.",
+            comment=(
+                "List of command names allowed for use, separated by spaces.\n"
+                "This option overrides CommandBlacklist if set."
+            ),
             empty_display_val="(All allowed)",
         )
         self.command_blacklist = self._mgr.register.init_option(
             section=name,
-            option="CommandBlackList",
+            option="CommandBlacklist",
             dest="command_blacklist",
             default=defaults.command_blacklist,
             getter="getstrset",
-            comment="List of command names denied from use, separated by spaces. Will not work if CommandWhiteList is set!",
+            comment=(
+                "List of command names denied from use, separated by spaces.\n"
+                "Will not work if CommandWhitelist is set!"
+            ),
             empty_display_val="(None denied)",
         )
         self.ignore_non_voice = self._mgr.register.init_option(

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -129,6 +129,7 @@ class MusicPlayer(EventEmitter, Serializable):
         self._stderr_future: Optional[AsyncFuture] = None
 
         self._source: Optional[SourcePlaybackCounter] = None
+        self._pending_call_later: Optional[EntryTypes] = None
 
         self.playlist.on("entry-added", self.on_entry_added)
         self.playlist.on("entry-failed", self.on_entry_failed)
@@ -154,8 +155,9 @@ class MusicPlayer(EventEmitter, Serializable):
         """
         Event dispatched by Playlist when an entry is added to the queue.
         """
-        if self.is_stopped:
+        if self.is_stopped and not self.current_entry and not self._pending_call_later:
             log.noise("calling-later, self.play from player.")  # type: ignore[attr-defined]
+            self._pending_call_later = entry
             self.loop.call_later(2, self.play)
 
         self.emit(
@@ -357,19 +359,27 @@ class MusicPlayer(EventEmitter, Serializable):
             )
             return self.resume()
 
+        if self._play_lock.locked():
+            log.voicedebug(  # type: ignore[attr-defined]
+                "MusicPlayer already locked for playback, this call is ignored."
+            )
+            return
+
         async with self._play_lock:
             if self.is_stopped or _continue:
                 try:
                     entry = await self.playlist.get_next_entry()
                 except IndexError:
-                    log.warning("Failed to get entry, retrying", exc_info=True)
-                    self.loop.call_later(0.1, self.play)
-                    return
+                    log.warning("Failed to get entry.", exc_info=True)
+                    entry = None
 
                 # If nothing left to play, transition to the stopped state.
                 if not entry:
                     self.stop()
                     return
+
+                if self._pending_call_later == entry:
+                    self._pending_call_later = None
 
                 # In-case there was a player, kill it. RIP.
                 self._kill_current_player()

--- a/musicbot/spotify.py
+++ b/musicbot/spotify.py
@@ -285,11 +285,12 @@ class SpotifyPlaylist(SpotifyObject):
             raise ValueError("Invalid playlist_data, missing items key in tracks")
 
         for item in items:
+            if "track" not in item:
+                raise ValueError("Invalid playlist_data, missing track key in items")
+
             track_data = item.get("track", None)
             if track_data:
                 self._track_objects.append(SpotifyTrack(track_data))
-            else:
-                raise ValueError("Invalid playlist_data, missing track key in items")
 
     @property
     def track_objects(self) -> List[SpotifyTrack]:

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -8,7 +8,7 @@ import re
 import sys
 import unicodedata
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Set, Union
 
 # protected imports to keep run.py from breaking on missing packages.
 try:
@@ -212,7 +212,7 @@ def mute_discord_console_log() -> None:
     for h in dlogger.handlers:
         if getattr(h, "terminator", None) == "":
             dlogger.removeHandler(h)
-    # for console output cariage return post muffled log string.
+    # for console output carriage return post muffled log string.
     print()
 
 
@@ -447,39 +447,6 @@ def paginate(
         chunks.append(currentchunk)
 
     return chunks
-
-
-def instance_diff(obj1: Any, obj2: Any) -> Dict[str, Tuple[Any, Any]]:
-    """
-    Compute a dict showing which attributes have changed between two given objects.
-    Objects must be of the same type and have __slots__ or __dict__.
-    """
-    if type(obj1) is not type(obj2):
-        raise ValueError("Objects must be of the same type to get differences.")
-
-    changes: Dict[str, Tuple[Any, Any]] = {}
-    keys = set()
-    if hasattr(obj1, "__slots__") and hasattr(obj2, "__slots__"):
-        vars1 = getattr(obj1, "__slots__", [])
-        vars2 = getattr(obj2, "__slots__", [])
-        if isinstance(vars1, list) and isinstance(vars2, list):
-            keys = set(vars1 + vars2)
-    elif hasattr(obj1, "__dict__") and hasattr(obj2, "__dict__"):
-        vars1 = getattr(obj1, "__dict__", {})
-        vars2 = getattr(obj2, "__dict__", {})
-        if isinstance(vars1, dict) and isinstance(vars2, dict):
-            keys = set(list(vars1.keys()) + list(vars2.keys()))
-    else:
-        raise ValueError(
-            f"Objects don't have __slots__ or __dict__ attribute: ({type(obj1)}, {type(obj2)})"
-        )
-
-    for key in keys:
-        val1 = getattr(obj1, key, None)
-        val2 = getattr(obj2, key, None)
-        if val1 != val2:
-            changes[key] = (val1, val2)
-    return changes
 
 
 def _func_() -> str:


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR will leave `dev` in a working state! :tada:  
It contains the following note worthy changes and fixes:  
- Adds support for commands by mention, E.g.: `@MusicBot search` instead of command prefix only.
  - See the `CommandsByMention` option to enable. 
- Adds support for dynamic variables in custom status messages.
  - See the updated help text in `example_options.ini` for usage details.
- Adds http based network testing as a fall back for systems without access to ping when network testing is desired.
- Command `config` no longer requires the section argument. (as long as duplicate options don't happen in the future)
- Command `blockuser` can work on non-guild member mentions as well as ID strings to avoid mentions.
  - Additional command argument `?` or `status` will show a users blocked status.
- Fix typo in permissions that broke the `CommandWhitelist`/`CommandBlacklist` options.
- Possible fix for high CPU bug caused by race condition that resulted in an infinite loop.
- Fix for disconnect handling while auto-join is configured.
- A hand full of stuff that didn't make it into the last PR, which left it broken.
- Various comment updates and removal of old code.


### Related issues (if applicable)

Could close #2399 