### PR TITLE
Add latency and botlatency commands.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -6925,6 +6925,59 @@ class MusicBot(discord.Client):
             delete_after=60,
         )
 
+    @owner_only
+    async def cmd_botlatency(self) -> CommandResponse:
+        """
+        Usage:
+            {command_prefix}botlatency
+
+        Prints latency info for all voice clients.
+        """
+        vclats = ""
+        for vc in self.voice_clients:
+            if not isinstance(vc, discord.VoiceClient) or not hasattr(
+                vc.channel, "rtc_region"
+            ):
+                log.debug("Got a strange voice client entry.")
+                continue
+
+            vl = vc.latency * 1000
+            vla = vc.average_latency * 1000
+            # Display Auto for region instead of None
+            region = vc.channel.rtc_region or "auto"
+            vclats += f"- `{vl:.0f} ms` (`{vla:.0f} ms` Avg.) in region: `{region}`\n"
+
+        if not vclats:
+            vclats = "No voice clients connected.\n"
+
+        sl = self.latency * 1000
+        return Response(
+            f"**API Latency:** `{sl:.0f} ms`\n**VoiceClient Latency:**\n{vclats}",
+            delete_after=30,
+        )
+
+    async def cmd_latency(self, guild: discord.Guild) -> CommandResponse:
+        """
+        Usage:
+            {command_prefix}latency
+
+        Prints the latency info available to MusicBot.
+        If connected to a voice channel, voice latency is also returned.
+        """
+
+        voice_lat = ""
+        if guild.id in self.players:
+            vc = self.players[guild.id].voice_client
+            if vc:
+                vl = vc.latency * 1000
+                vla = vc.average_latency * 1000
+                voice_lat = f"\n**Voice Latency:** `{vl:.0f} ms` (`{vla:.0f} ms` Avg.)"
+        sl = self.latency * 1000
+        return Response(
+            f"**API Latency:** `{sl:.0f} ms`{voice_lat}",
+            delete_after=30,
+        )
+
     async def cmd_botversion(self) -> CommandResponse:
         """
         Usage:


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

Adds two new commands to print latency info from the bot.  The `latency` command is intended for users, and only lists the current guild / Voice latency.  While `botlatency` will show info for all connected voice clients regardless of calling guild.