### PR TITLE
Add uptime command

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -144,6 +144,7 @@ class MusicBot(discord.Client):
 
         self.use_certifi: bool = use_certifi
         self.exit_signal: ExitSignals = None
+        self._init_time: float = time.time()
         self._os_signal: Optional[signal.Signals] = None
         self._ping_peer_addr: str = ""
         self._ping_use_http: bool = False
@@ -6923,6 +6924,20 @@ class MusicBot(discord.Client):
             f"**Source Code Updates:**\n{git_status}\n\n"
             f"**Dependency Updates:**\n{pip_status}",
             delete_after=60,
+        )
+
+    async def cmd_uptime(self) -> CommandResponse:
+        """
+        Usage:
+            {command_prefix}uptime
+
+        Displays the MusicBot uptime, since last start/restart.
+        """
+        uptime = time.time() - self._init_time
+        delta = format_song_duration(uptime)
+        return Response(
+            f"MusicBot has been up for `{delta}`",
+            delete_after=30,
         )
 
     async def cmd_botversion(self) -> CommandResponse:


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

Adds user-requested `uptime` command for displaying bot uptime remotely.  As the bot measures its uptime by storing a starting time stamp, the time given by `uptime` may not match the time shown by a system-level service / process manager. 