### PR TITLE
Provide option for auto-unpause, default off.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -252,6 +252,9 @@ SavePlayedHistoryGuilds = no
 # to play files from the local MediaFileDirectory path.
 EnableLocalMedia = no
 
+# Allow MusicBot to automatically unpause when play commands are used.
+UnpausePlayerOnPlay = no
+
 
 [Files]
 # Configure automatic log file rotation at restart, and limit the number of files kept.

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3230,6 +3230,9 @@ class MusicBot(discord.Client):
 
         This function should not be called from _cmd_play().
         """
+        if not self.config.auto_unpause_on_play:
+            return
+
         if not player or not player.voice_client or not player.voice_client.channel:
             return
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -655,6 +655,15 @@ class Config:
             ),
         )
 
+        self.auto_unpause_on_play: bool = self.register.init_option(
+            section="MusicBot",
+            option="UnpausePlayerOnPlay",
+            dest="auto_unpause_on_play",
+            default=ConfigDefaults.auto_unpause_on_play,
+            getter="getboolean",
+            comment="Allow MusicBot to automatically unpause when play commands are used.",
+        )
+
         self.user_blocklist_enabled: bool = self.register.init_option(
             section="MusicBot",
             option="EnableUserBlocklist",
@@ -1164,6 +1173,7 @@ class ConfigDefaults:
     enable_local_media: bool = False
     enable_queue_history_global: bool = False
     enable_queue_history_guilds: bool = False
+    auto_unpause_on_play: bool = False
 
     song_blocklist: Set[str] = set()
     user_blocklist: Set[int] = set()


### PR DESCRIPTION
- [ ] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

Adds a config option `UnpausePlayerOnPlay` to control automatic playback resume when play commands are used.
Default is off to return MusicBot to its previous behavior.

This has not been tested, more changes might be needed. 