### PR TITLE
Potentially fix high-cpu deadlock bug.

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1820,6 +1820,9 @@ class MusicBot(discord.Client):
                     "Got HTTPException trying to send message to %s: %s", dest, content
                 )
 
+        except aiohttp.client_exceptions.ClientError:
+            lfunc("Failed to send due to an HTTP error.")
+
         finally:
             if not retry_after and self.config.delete_messages:
                 if msg and expire_in:
@@ -1882,6 +1885,9 @@ class MusicBot(discord.Client):
                 log.noise(  # type: ignore[attr-defined]
                     "Got HTTPException trying to delete message: %s", message
                 )
+
+        except aiohttp.client_exceptions.ClientError:
+            lfunc("Failed to send due to an HTTP error.")
 
         return None
 
@@ -1950,6 +1956,9 @@ class MusicBot(discord.Client):
                 log.noise(  # type: ignore[attr-defined]
                     "Got HTTPException trying to edit message %s to: %s", message, new
                 )
+
+        except aiohttp.client_exceptions.ClientError:
+            lfunc("Failed to send due to an HTTP error.")
 
         return None
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -2029,10 +2029,10 @@ class MusicBot(discord.Client):
             # We can't kill the threads in ThreadPoolExecutor.  User can Ctrl+C though.
             # We can pass `wait=False` and carry on with "shutdown" but threads
             # will stay until they're done.  We wait to keep it clean...
-            if sys.version_info < (3, 9):
-                self.downloader.thread_pool.shutdown()
-            else:
-                self.downloader.thread_pool.shutdown(cancel_futures=True)
+            tps_args: Dict[str, Any] = {}
+            if sys.version_info >= (3, 9):
+                tps_args["cancel_futures"] = True
+            self.downloader.thread_pool.shutdown(**tps_args)
 
             # Inspect all waiting tasks and either cancel them or let them finish.
             pending_tasks = []

--- a/musicbot/constructs.py
+++ b/musicbot/constructs.py
@@ -90,9 +90,8 @@ class GuildSpecificData:
 
         # create a task to load any persistent guild options.
         # in theory, this should work out fine.
-        if bot.loop:
-            bot.loop.create_task(self.load_guild_options_file())
-            bot.loop.create_task(self.autoplaylist.load())
+        bot.create_task(self.load_guild_options_file(), name="MB_LoadGuildOptions")
+        bot.create_task(self.autoplaylist.load(), name="MB_LoadAPL")
 
     def is_ready(self) -> bool:
         """A status indicator for fully loaded server data."""

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -79,7 +79,10 @@ class Downloader:
         self.bot: "MusicBot" = bot
         self.download_folder: pathlib.Path = bot.config.audio_cache_path
         # NOTE: this executor may not be good for long-running downloads...
-        self.thread_pool = ThreadPoolExecutor(max_workers=DEFAULT_MAX_INFO_DL_THREADS)
+        self.thread_pool = ThreadPoolExecutor(
+            max_workers=DEFAULT_MAX_INFO_DL_THREADS,
+            thread_name_prefix="MB_Downloader",
+        )
 
         # force ytdlp and HEAD requests to use the same UA string.
         self.http_req_headers = {
@@ -570,6 +573,14 @@ class YtdlpResponseDict(YUserDict):
                 default,
             )
         return default
+
+    @property
+    def input_subject(self) -> str:
+        """Get the input subject used to create this data."""
+        subject = self.data.get("__input_subject", "")
+        if isinstance(subject, str):
+            return subject
+        return ""
 
     @property
     def expected_filename(self) -> Optional[str]:

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import shutil
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
 
 import discord
 from yt_dlp.utils import (  # type: ignore[import-untyped]
@@ -24,8 +24,10 @@ if TYPE_CHECKING:
 
     # Explicit compat with python 3.8
     AsyncFuture = asyncio.Future[Any]
+    AsyncTask = asyncio.Task[Any]
 else:
     AsyncFuture = asyncio.Future
+    AsyncTask = asyncio.Task
 
 GuildMessageableChannels = Union[
     discord.Thread,
@@ -56,6 +58,7 @@ class BasePlaylistEntry(Serializable):
         self._is_downloading: bool = False
         self._is_downloaded: bool = False
         self._waiting_futures: List[AsyncFuture] = []
+        self._task_pool: Set[AsyncTask] = set()
 
     @property
     def start_time(self) -> float:
@@ -116,7 +119,7 @@ class BasePlaylistEntry(Serializable):
         The future will either fire with the result (being the entry) or an exception
         as to why the song download failed.
         """
-        future = asyncio.Future()  # type: AsyncFuture
+        future: AsyncFuture = asyncio.Future()
         if self.is_downloaded:
             # In the event that we're downloaded, we're already ready for playback.
             future.set_result(self)
@@ -124,10 +127,12 @@ class BasePlaylistEntry(Serializable):
         else:
             # If we request a ready future, let's ensure that it'll actually resolve at one point.
             self._waiting_futures.append(future)
-            asyncio.ensure_future(self._download())
+            task = asyncio.create_task(self._download(), name="MB_EntryReadyTask")
+            # Make sure garbage collection does not delete the task early...
+            self._task_pool.add(task)
+            task.add_done_callback(self._task_pool.discard)
 
-        name = self.title or self.filename or self.url
-        log.debug("Created future for %s", name)
+        log.debug("Created future for %r", self)
         return future
 
     def _for_each_future(self, cb: Callable[..., Any]) -> None:
@@ -138,13 +143,15 @@ class BasePlaylistEntry(Serializable):
         futures = self._waiting_futures
         self._waiting_futures = []
 
+        log.everything(  # type: ignore[attr-defined]
+            "Completed futures for %r with %r", self, cb
+        )
         for future in futures:
             if future.cancelled():
                 continue
 
             try:
                 cb(future)
-
             except Exception:  # pylint: disable=broad-exception-caught
                 log.exception("Unhandled exception in _for_each_future callback.")
 
@@ -153,6 +160,9 @@ class BasePlaylistEntry(Serializable):
 
     def __hash__(self) -> int:
         return id(self)
+
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__}(url='{self.url}', title='{self.title}' file='{self.filename}')>"
 
 
 async def run_command(command: List[str]) -> bytes:
@@ -445,7 +455,7 @@ class URLPlaylistEntry(BasePlaylistEntry):
     async def _download(self) -> None:
         if self._is_downloading:
             return
-        log.debug("URLPlaylistEntry is now checking download status.")
+        log.debug("Getting ready for entry:  %r", self)
 
         self._is_downloading = True
         try:
@@ -525,7 +535,8 @@ class URLPlaylistEntry(BasePlaylistEntry):
         # Flake8 thinks 'e' is never used, and later undefined. Maybe the lambda is too much.
         except Exception as e:  # pylint: disable=broad-exception-caught
             ex = e
-            log.exception("Exception while checking entry data.")
+            if log.getEffectiveLevel() <= logging.DEBUG:
+                log.error("Exception while checking entry data.")
             self._for_each_future(lambda future: future.set_exception(ex))
 
         finally:
@@ -664,11 +675,13 @@ class URLPlaylistEntry(BasePlaylistEntry):
         """
         Actually download the media in this entry into cache.
         """
-        log.info("Download started:  %s", self.url)
+        log.info("Download started:  %r", self)
 
-        retry = 2
         info = None
-        while True:
+        for attempt in range(1, 4):
+            log.everything(  # type: ignore[attr-defined]
+                "Download attempt %s of 3...", attempt
+            )
             try:
                 info = await self.downloader.extract_info(self.url, download=True)
                 break
@@ -676,12 +689,14 @@ class URLPlaylistEntry(BasePlaylistEntry):
                 # this typically means connection was interrupted, any
                 # download is probably partial. we should definitely do
                 # something about it to prevent broken cached files.
-                if retry > 0:
+                if attempt < 3:
+                    wait_for = 1.5 * attempt
                     log.warning(
-                        "Download may have failed, retrying.  Reason: %s", str(e)
+                        "Download incomplete, retrying in %.1f seconds.  Reason: %s",
+                        wait_for,
+                        str(e),
                     )
-                    retry -= 1
-                    await asyncio.sleep(1.5)  # TODO: backoff timer maybe?
+                    await asyncio.sleep(wait_for)  # TODO: backoff timer maybe?
                     continue
 
                 # Mark the file I guess, and maintain the default of raising ExtractionError.
@@ -693,15 +708,14 @@ class URLPlaylistEntry(BasePlaylistEntry):
                 raise ExtractionError(str(e)) from e
 
             except Exception as e:
-                log.exception("Extraction encountered an unhandled exception.")
+                log.error("Extraction encountered an unhandled exception.")
                 raise MusicbotException(str(e)) from e
 
-        log.info("Download complete:  %s", self.url)
-
         if info is None:
-            log.critical("YTDL has failed, everyone panic")
-            raise ExtractionError("ytdl broke and hell if I know why")
-            # What the fuck do I do now?
+            log.error("Download failed:  %r", self)
+            raise ExtractionError("Failed to extract data for the requested media.")
+
+        log.info("Download complete:  %r", self)
 
         self._is_downloaded = True
         self.filename = info.expected_filename or ""
@@ -751,7 +765,7 @@ class StreamPlaylistEntry(BasePlaylistEntry):
         """get extracted url if available or otherwise return the input subject"""
         if self.info.extractor and self.info.url:
             return self.info.url
-        return self.info.get("__input_subject", "")
+        return self.info.input_subject
 
     @property
     def title(self) -> str:
@@ -886,10 +900,13 @@ class StreamPlaylistEntry(BasePlaylistEntry):
         return None
 
     async def _download(self) -> None:
+        log.debug("Getting ready for entry:  %r", self)
         self._is_downloading = True
         self._is_downloaded = True
         self.filename = self.url
         self._is_downloading = False
+
+        self._for_each_future(lambda future: future.set_result(self))
 
 
 class LocalFilePlaylistEntry(BasePlaylistEntry):
@@ -1133,7 +1150,8 @@ class LocalFilePlaylistEntry(BasePlaylistEntry):
         """
         if self._is_downloading:
             return
-        log.debug("LocalFilePlaylistEntry is now extracting media information.")
+
+        log.debug("Getting ready for entry:  %r", self)
 
         self._is_downloading = True
         try:
@@ -1180,7 +1198,8 @@ class LocalFilePlaylistEntry(BasePlaylistEntry):
         # Flake8 thinks 'e' is never used, and later undefined. Maybe the lambda is too much.
         except Exception as e:  # pylint: disable=broad-exception-caught
             ex = e
-            log.exception("Exception while checking entry data.")
+            if log.getEffectiveLevel() <= logging.DEBUG:
+                log.error("Exception while checking entry data.")
             self._for_each_future(lambda future: future.set_exception(ex))
 
         finally:

--- a/musicbot/filecache.py
+++ b/musicbot/filecache.py
@@ -358,7 +358,9 @@ class AudioFileCache:
             change_made = True
 
         if change_made:
-            self.bot.loop.create_task(self.save_autoplay_cachemap())
+            self.bot.create_task(
+                self.save_autoplay_cachemap(), name="MB_SaveAutoPlayCachemap"
+            )
 
     def remove_autoplay_cachemap_entry(self, entry: "BasePlaylistEntry") -> None:
         """
@@ -374,7 +376,9 @@ class AudioFileCache:
         filename = pathlib.Path(entry.filename).stem
         if filename in self.auto_playlist_cachemap:
             del self.auto_playlist_cachemap[filename]
-            self.bot.loop.create_task(self.save_autoplay_cachemap())
+            self.bot.create_task(
+                self.save_autoplay_cachemap(), name="MB_SaveAutoPlayCachemap"
+            )
 
     def remove_autoplay_cachemap_entry_by_url(self, url: str) -> None:
         """
@@ -396,7 +400,9 @@ class AudioFileCache:
             del self.auto_playlist_cachemap[key]
 
         if len(to_remove) != 0:
-            self.bot.loop.create_task(self.save_autoplay_cachemap())
+            self.bot.create_task(
+                self.save_autoplay_cachemap(), name="MB_SaveAutoPlayCachemap"
+            )
 
     def _check_autoplay_cachemap(self, filename: pathlib.Path) -> bool:
         """

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -270,6 +270,7 @@ class MusicPlayer(EventEmitter, Serializable):
         elif self.loopqueue:
             self.playlist.entries.append(entry)
 
+        # TODO: investigate if this is cruft code or not.
         if self._current_player:
             if hasattr(self._current_player, "after"):
                 self._current_player.after = None
@@ -277,9 +278,9 @@ class MusicPlayer(EventEmitter, Serializable):
 
         self._current_entry = None
         self._source = None
+        self.stop()
 
         if error:
-            self.stop()
             self.emit("error", player=self, entry=entry, ex=error)
             return
 
@@ -290,7 +291,6 @@ class MusicPlayer(EventEmitter, Serializable):
         ):
             # I'm not sure that this would ever not be done if it gets to this point
             # unless ffmpeg is doing something highly questionable
-            self.stop()
             self.emit(
                 "error", player=self, entry=entry, ex=self._stderr_future.exception()
             )

--- a/musicbot/utils.py
+++ b/musicbot/utils.py
@@ -297,6 +297,8 @@ def rotate_log_files(max_kept: int = -1, date_fmt: str = "") -> None:
     :param: date_fmt:  format compatible with datetime.strftime() for rotated filename.
     """
     if hasattr(logging, "_mb_logs_rotated"):
+        if log.getEffectiveLevel() <= logging.DEBUG:
+            print("Logs already rotated.")
         return
 
     # Use the input arguments or fall back to settings or defaults.
@@ -312,6 +314,8 @@ def rotate_log_files(max_kept: int = -1, date_fmt: str = "") -> None:
 
     # Rotation can be disabled by setting 0.
     if not max_kept:
+        if log.getEffectiveLevel() <= logging.DEBUG:
+            print("No logs rotated.")
         return
 
     # Format a date that will be used for files rotated now.


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR makes further changes to playback processing to avoid the infinite loop / deadlock issue created by too many concurrent playback calls waiting for the async player lock.  

- Some changes have been made to how player errors are handled, to better ensure proper handling of those errors and continue playback where needed.  This includes a minor change to YtdlResponseDict objects to provide an `input_subject` property which can reliably be used for managing autoplaylist entry removal in the player error handling function. 

- All tasks spawned through `asyncio.create_task()` in MusicBot now use a method provided by `MusicBot.create_task()` so MusicBot can manage the reference to said task and ensure it does not get garbage collected before it is finished.  This should increase overall stability, though early deletion of tasks may be rare and/or depend on python version.   A few exceptions are made for functions outside of MusicBot, such as those related to signal handling.

- Processing of shutdown has also been changed.  The downloader thread pool executor is now sent a `shutdown()` which will cancel all pending tasks that have not yet started, but wait for all running threads to finish before moving on with the rest of shutdown.   This allows those threads and their system resources to be properly cleaned up, but may cause delays in shutdown or restart when large media files have begun downloading.  (Due to how we use ytdlp, we cannot actually cancel or cleanly interrupt the downloads that are running.)

- Additionally, the stderr reader for FFmpeg will now read stderr stream for the duration of playback.  Reader loop is cancelled by the `done()` state of the associated `asyncio.Future()` which is ultimately closed by the _playback_finished callback if no exception was set by the stream reader.   This should enable catching and logging errors and warnings from ffmpeg (assuming they are placed in stderr io stream) for the duration of playback, not just the very start.

- Finally, minor changes to logging (mostly debug output) have been made to provide more information about the various entry types and their primary data points.  Some handling was added to `safe_*_message` functions to handle aiohttp client errors more gracefully. 


Lets hope this PR contains minimal regressions... Only more testing will tell!