### PR TITLE
Bug-fixes and more options.

### DIFF
--- a/config/example_aliases.json
+++ b/config/example_aliases.json
@@ -5,13 +5,19 @@
         "The keys must be valid commands, and can have simple, space separated arguments.   ",
         "Arguments passed by the user will be appended to any command arguments set here.   ",
         "                                                                                   ",
-        "For Example:                                                                       ",
+        "For example, (replace _cmd_name_ with the command of your choice):                 ",
+        "This will map _cmd_name_ to multiple aliases, alias1 & a_long_alias           ",
         {
-            "_command_name_":  ["alias1", "a_long_alias"],
-            "_cmd_ arg1 arg2 argN": ["short"],
-
-            "config set MusicBot": ["setcfg"]
-        }
+            "_cmd_name_":  ["alias1", "a_long_alias"]
+        },
+        "                                                                                   ",
+        "To alias a command with arguments, use something like the following:               ",
+        {
+            "_cmd_name_ arg1 arg2 argN": ["macro_alias"]
+        },
+        "Lets say you have the following alias: ",
+        {"config set MusicBot": ["setcfg"]},
+        "Users can use `setcfg DefaultVolume 0.40` to set default playback volume to 40%.   "
     ],
     
     "play": ["p"],

--- a/config/example_aliases.json
+++ b/config/example_aliases.json
@@ -1,4 +1,19 @@
 {
+    "--comment": [
+        "Aliases allow you to rename or shorten existing commands.                          ",
+        "Alias names may contain anything, except for spaces.                               ",
+        "The keys must be valid commands, and can have simple, space separated arguments.   ",
+        "Arguments passed by the user will be appended to any command arguments set here.   ",
+        "                                                                                   ",
+        "For Example:                                                                       ",
+        {
+            "_command_name_":  ["alias1", "a_long_alias"],
+            "_cmd_ arg1 arg2 argN": ["short"],
+
+            "config set MusicBot": ["setcfg"]
+        }
+    ],
+    
     "play": ["p"],
     "skip": ["s"],
     "queue": ["q"],

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -258,6 +258,11 @@ EnableLocalMedia = no
 # Allow MusicBot to automatically unpause when play commands are used.
 UnpausePlayerOnPlay = no
 
+# Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.
+# The value set here is passed to `ytdlp --proxy` and aiohttp header checking.
+# Leave blank to disable.
+YtdlpProxy = 
+
 
 [Files]
 # Configure automatic log file rotation at restart, and limit the number of files kept.

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -263,6 +263,11 @@ UnpausePlayerOnPlay = no
 # Leave blank to disable.
 YtdlpProxy = 
 
+# Experimental option to set a static User-Agent header in yt-dlp.
+# It is not typically recommended by yt-dlp to change the UA string.
+# Leave blank to use default, dynamically generated UA strings.
+YtdlpUserAgent = 
+
 
 [Files]
 # Configure automatic log file rotation at restart, and limit the number of files kept.

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -152,8 +152,7 @@ DebugLevel = INFO
 #  {p0_url}      = The track url for the currently playing track.
 StatusMessage = 
 
-# If enabled, status messages will count and report paused players.
-# When disabled, the {n_paused} variable in StatusMessage option will always report 0.
+# If enabled, status message updates will count and report paused players.
 StatusIncludePaused = no
 
 # Write what the bot is currently playing to the data/<server id>/current.txt FILE.

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -152,6 +152,10 @@ DebugLevel = INFO
 #  {p0_url}      = The track url for the currently playing track.
 StatusMessage = 
 
+# If enabled, status messages will count and report paused players.
+# When disabled, the {n_paused} variable in StatusMessage option will always report 0.
+StatusIncludePaused = no
+
 # Write what the bot is currently playing to the data/<server id>/current.txt FILE.
 # This can then be used with OBS and anything else that takes a dynamic input.
 WriteCurrentSong = no

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -132,6 +132,10 @@ DeleteInvoking = no
 # resume from where it left off.
 PersistentQueue = yes
 
+# Enable MusicBot to download the next song in the queue while a song is playing.
+# Currently this option does not apply to auto-playlist or songs added to an empty queue.
+PreDownloadNextSong = yes
+
 # Determines what messages are logged to the console. The default level is INFO, which is
 # everything an average user would need. Other levels include CRITICAL, ERROR, WARNING,
 # DEBUG, VOICEDEBUG, FFMPEG, NOISY, and EVERYTHING. You should only change this if you
@@ -265,6 +269,9 @@ YtdlpProxy =
 
 # Experimental option to set a static User-Agent header in yt-dlp.
 # It is not typically recommended by yt-dlp to change the UA string.
+# For examples of what you might put here, check the following two links:
+#   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+#   https://www.useragents.me/
 # Leave blank to use default, dynamically generated UA strings.
 YtdlpUserAgent = 
 

--- a/musicbot/aliases.py
+++ b/musicbot/aliases.py
@@ -20,6 +20,7 @@ class Aliases:
     Command alias with conflicting names will overload each other, it is up to
     the user to avoid configuring aliases with conflicts.
     """
+
     # TODO: add a method to query aliases a natural command has.
 
     def __init__(self, aliases_file: Path, nat_cmds: List[str]) -> None:
@@ -65,15 +66,17 @@ class Aliases:
                 self.aliases_seed = json.load(f)
         except OSError as e:
             log.error(
-                f"Failed to load aliases file:  {str(self.aliases_file)}",
+                "Failed to load aliases file:  %s",
+                self.aliases_file,
                 exc_info=e,
             )
             self.aliases_seed = AliasesDefault.aliases_seed
             return
         except json.JSONDecodeError as e:
             log.error(
-                f"Failed to parse aliases file:  {str(self.aliases_file)}\n"
+                "Failed to parse aliases file:  %s\n"
                 "Ensure the file contains valid JSON and restart the bot.",
+                self.aliases_file,
                 exc_info=e,
             )
             self.aliases_seed = AliasesDefault.aliases_seed

--- a/musicbot/aliases.py
+++ b/musicbot/aliases.py
@@ -123,7 +123,6 @@ class Aliases:
                     )
                     continue
 
-                
                 self.aliases.update({alias: (cmd, cmd_args)})
 
     def get(self, alias_name: str) -> Tuple[str, str]:

--- a/musicbot/aliases.py
+++ b/musicbot/aliases.py
@@ -2,16 +2,27 @@ import json
 import logging
 import shutil
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 from .constants import DEFAULT_COMMAND_ALIAS_FILE, EXAMPLE_COMMAND_ALIAS_FILE
 from .exceptions import HelpfulError
 
 log = logging.getLogger(__name__)
 
+RawAliasJSON = Dict[str, Any]
+ComplexAliases = Dict[str, Tuple[str, str]]
+
 
 class Aliases:
-    def __init__(self, aliases_file: Path) -> None:
+    """
+    Aliases class provides a method of duplicating commands under different names or
+    providing reduction in keystrokes for multi-argument commands.
+    Command alias with conflicting names will overload each other, it is up to
+    the user to avoid configuring aliases with conflicts.
+    """
+    # TODO: add a method to query aliases a natural command has.
+
+    def __init__(self, aliases_file: Path, nat_cmds: List[str]) -> None:
         """
         Handle locating, initializing, loading, and validation of command aliases.
         If given `aliases_file` is not found, examples will be copied to the location.
@@ -19,9 +30,14 @@ class Aliases:
         :raises: musicbot.exceptions.HelpfulError
             if loading fails in some known way.
         """
-        self.aliases_file = aliases_file
-        self.aliases_seed = AliasesDefault.aliases_seed
-        self.aliases = AliasesDefault.aliases
+        # List of "natural" commands to allow.
+        self.nat_cmds: List[str] = nat_cmds
+        # File Path used to locate and load the alias json.
+        self.aliases_file: Path = aliases_file
+        # "raw" dict from json file.
+        self.aliases_seed: RawAliasJSON = AliasesDefault.aliases_seed
+        # Simple aliases
+        self.aliases: ComplexAliases = AliasesDefault.complex_aliases
 
         # find aliases file
         if not self.aliases_file.is_file():
@@ -37,32 +53,95 @@ class Aliases:
                 )
 
         # parse json
-        with self.aliases_file.open() as f:
-            try:
+        self.load()
+
+    def load(self) -> None:
+        """
+        Attempt to load/decode JSON and determine which version of aliases we have.
+        """
+        # parse json
+        try:
+            with self.aliases_file.open() as f:
                 self.aliases_seed = json.load(f)
-            except json.JSONDecodeError as e:
-                raise HelpfulError(
-                    f"Failed to parse aliases file:  {str(self.aliases_file)}",
-                    "Ensure your alias file contains valid JSON and restart the bot.",
-                ) from e
+        except OSError as e:
+            log.error(
+                f"Failed to load aliases file:  {str(self.aliases_file)}",
+                exc_info=e,
+            )
+            self.aliases_seed = AliasesDefault.aliases_seed
+            return
+        except json.JSONDecodeError as e:
+            log.error(
+                f"Failed to parse aliases file:  {str(self.aliases_file)}\n"
+                "Ensure the file contains valid JSON and restart the bot.",
+                exc_info=e,
+            )
+            self.aliases_seed = AliasesDefault.aliases_seed
+            return
 
-        # construct
+        # Create an alias-to-command map from the JSON.
         for cmd, aliases in self.aliases_seed.items():
-            if not isinstance(cmd, str) or not isinstance(aliases, list):
-                raise HelpfulError(
-                    "Failed to load aliases file due to invalid format.",
-                    "Make sure your aliases conform to the format given in the example file.",
-                )
-            self.aliases.update({alias.lower(): cmd.lower() for alias in aliases})
+            # ignore comments
+            if cmd.lower() in ["--comment", "--comments"]:
+                continue
 
-    def get(self, alias: str) -> str:
+            # check for spaces, and handle args in cmd alias if they exist.
+            cmd_args = ""
+            if " " in cmd:
+                cmd_bits = cmd.split(" ", maxsplit=1)
+                if len(cmd_bits) > 1:
+                    cmd = cmd_bits[0]
+                    cmd_args = cmd_bits[1].strip()
+                cmd = cmd.strip()
+
+            # ensure command name is valid.
+            if cmd not in self.nat_cmds:
+                log.error(
+                    "Aliases skipped for non-existent command:  %s  ->  %s",
+                    cmd,
+                    aliases,
+                )
+                continue
+
+            # ensure alias data uses valid types.
+            if not isinstance(cmd, str) or not isinstance(aliases, list):
+                log.error(
+                    "Alias(es) skipped for invalid alias data:  %s  ->  %s",
+                    cmd,
+                    aliases,
+                )
+                continue
+
+            # Loop over given aliases and associate them.
+            for alias in aliases:
+                alias = alias.lower()
+                if alias in self.aliases:
+                    log.error(
+                        "Alias `%s` skipped as already exists on command:  %s",
+                        alias,
+                        self.aliases[alias],
+                    )
+                    continue
+
+                
+                self.aliases.update({alias: (cmd, cmd_args)})
+
+    def get(self, alias_name: str) -> Tuple[str, str]:
         """
-        Return cmd name that given `alias` points to or an empty string.
+        Get the command name the given `aliase_name` refers to.
+        Returns a two-member tuple containing the command name and any args for
+        the command alias in the case of complex aliases.
         """
-        return self.aliases.get(alias, "")
+        cmd_name, cmd_args = self.aliases.get(alias_name, ("", ""))
+
+        # If no alias at all, return nothing.
+        if not cmd_name:
+            return ("", "")
+
+        return (cmd_name, cmd_args)
 
 
 class AliasesDefault:
     aliases_file: Path = Path(DEFAULT_COMMAND_ALIAS_FILE)
-    aliases_seed: Dict[str, Any] = {}
-    aliases: Dict[str, str] = {}
+    aliases_seed: RawAliasJSON = {}
+    complex_aliases: ComplexAliases = {}

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -247,6 +247,12 @@ class MusicBot(discord.Client):
         if self.config.enable_queue_history_global:
             await self.playlist_mgr.global_history.load()
 
+        # TODO: testing is needed to see if this would be required.
+        # See also:  https://github.com/aio-libs/aiohttp/discussions/6044
+        # aiohttp version must be at least 3.8.0 for the following to potentially work.
+        # Python 3.11+ might also be a requirement if CPython does not support start_tls.
+        # setattr(asyncio.sslproto._SSLProtocolTransport, "_start_tls_compatible", True)
+
         self.http.user_agent = MUSICBOT_USER_AGENT_AIOHTTP
         if self.use_certifi:
             ssl_ctx = ssl.create_default_context(cafile=certifi.where())

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -47,6 +47,7 @@ from .constants import (
     EMOJI_STOP_SIGN,
     FALLBACK_PING_SLEEP,
     FALLBACK_PING_TIMEOUT,
+    MUSICBOT_USER_AGENT_AIOHTTP,
 )
 from .constants import VERSION as BOTVERSION
 from .constants import VOICE_CLIENT_MAX_RETRY_CONNECT, VOICE_CLIENT_RECONNECT_TIMEOUT
@@ -248,7 +249,7 @@ class MusicBot(discord.Client):
         if self.config.enable_queue_history_global:
             await self.playlist_mgr.global_history.load()
 
-        self.http.user_agent = f"MusicBot/{BOTVERSION}"
+        self.http.user_agent = MUSICBOT_USER_AGENT_AIOHTTP
         if self.use_certifi:
             ssl_ctx = ssl.create_default_context(cafile=certifi.where())
             tcp_connector = aiohttp.TCPConnector(ssl_context=ssl_ctx)

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1569,13 +1569,20 @@ class MusicBot(discord.Client):
             return
 
         playing = sum(1 for p in self.players.values() if p.is_playing)
-        paused = sum(1 for p in self.players.values() if p.is_paused)
+        if self.config.status_include_paused:
+            paused = sum(1 for p in self.players.values() if p.is_paused)
+        else:
+            paused = 0
         total = len(self.players)
 
         def format_status_msg(player: Optional[MusicPlayer]) -> str:
+            if not self.config.status_include_paused:
+                p = sum(1 for p in self.players.values() if p.is_paused)
+            else:
+                p = paused
             msg = self.config.status_message
             msg = msg.replace("{n_playing}", str(playing))
-            msg = msg.replace("{n_paused}", str(paused))
+            msg = msg.replace("{n_paused}", str(p))
             msg = msg.replace("{n_connected}", str(total))
             if player and player.current_entry:
                 msg = msg.replace("{p0_title}", player.current_entry.title)

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -7049,15 +7049,14 @@ class MusicBot(discord.Client):
             try:
                 run_type = "exec"
                 # exec needs a fake locals so we can get `result` from it.
-                lscope = {}
+                lscope: Dict[str, Any] = {}
                 # exec also needs locals() to be in globals() for access to work.
                 gscope = globals().copy()
                 gscope.update(locals().copy())
                 exec(code, gscope, lscope)  # pylint: disable=exec-used
                 log.debug("Debug code ran with exec().")
-                if "result" in lscope:
-                    result = lscope["result"]
-            except Exception as e:  # pylint: disable=broad-exception-caught
+                result = lscope.get("result", result)
+            except Exception as e:
                 log.exception("Debug code failed to execute.")
                 raise exceptions.CommandError(
                     f"Failed to execute debug code.\n{codeblock.format(code)}\n"

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -123,8 +123,6 @@ CommandResponse = Union[Response, None]
 
 log = logging.getLogger(__name__)
 
-# TODO:  add an aliases command to manage command aliases.
-
 
 class MusicBot(discord.Client):
     def __init__(

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -1653,9 +1653,14 @@ class ConfigOptionRegistry:
         if getter == "getpathlike":
             return str(conf_value)
 
-        # NOTE: Added for completeness but unused as debug_level is not editable.
-        if getter == "getdebuglevel" and isinstance(conf_value, int):
-            return str(logging.getLevelName(conf_value))
+        # NOTE: debug_level is not editable, but can be displayed.
+        if (
+            getter == "getdebuglevel"
+            and isinstance(conf_value, tuple)
+            and isinstance(conf_value[0], str)
+            and isinstance(conf_value[1], int)
+        ):
+            return str(logging.getLevelName(conf_value[1]))
 
         return str(conf_value)
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -20,6 +20,7 @@ from typing import (
 import configupdater
 
 from .constants import (
+    DATA_FILE_COOKIES,
     DATA_FILE_SERVERS,
     DEFAULT_AUDIO_CACHE_DIR,
     DEFAULT_DATA_DIR,
@@ -780,6 +781,7 @@ class Config:
         # Convert all path constants into config as pathlib.Path objects.
         self.data_path = pathlib.Path(DEFAULT_DATA_DIR).resolve()
         self.server_names_path = self.data_path.joinpath(DATA_FILE_SERVERS)
+        self.cookies_path = self.data_path.joinpath(DATA_FILE_COOKIES)
 
         # Validate the config settings match destination values.
         self.register.validate_register_destinations()
@@ -917,6 +919,14 @@ class Config:
 
         if self.enable_local_media and not self.media_file_dir.is_dir():
             self.media_file_dir.mkdir(exist_ok=True)
+
+        if self.cookies_path.is_file():
+            log.warning(
+                "Cookies TXT file detected. MusicBot will pass them to yt-dlp.\n"
+                "Enabling cookies is not recommended, and could be risky.\n"
+                "Make sure you understand how yt-dlp will be using the cookies.\n"
+                "Good Luck!  \U0001F596"
+            )
 
     async def async_validate(self, bot: "MusicBot") -> None:
         """

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import shutil
 import sys
+import time
 from typing import (
     TYPE_CHECKING,
     Dict,
@@ -426,6 +427,17 @@ class Config:
             getter="getboolean",
             comment="Allow MusicBot to save the song queue, so they will survive restarts.",
         )
+        self.pre_download_next_song: bool = self.register.init_option(
+            section="MusicBot",
+            option="PreDownloadNextSong",
+            dest="pre_download_next_song",
+            default=ConfigDefaults.pre_download_next_song,
+            getter="getboolean",
+            comment=(
+                "Enable MusicBot to download the next song in the queue while a song is playing.\n"
+                "Currently this option does not apply to auto-playlist or songs added to an empty queue."
+            ),
+        )
         self.status_message: str = self.register.init_option(
             section="MusicBot",
             option="StatusMessage",
@@ -693,7 +705,6 @@ class Config:
                 "Leave blank to disable."
             ),
         )
-
         self.ytdlp_user_agent: str = self.register.init_option(
             section="MusicBot",
             option="YtdlpUserAgent",
@@ -702,6 +713,9 @@ class Config:
             comment=(
                 "Experimental option to set a static User-Agent header in yt-dlp.\n"
                 "It is not typically recommended by yt-dlp to change the UA string.\n"
+                "For examples of what you might put here, check the following two links:\n"
+                "   https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent \n"
+                "   https://www.useragents.me/ \n"
                 "Leave blank to use default, dynamically generated UA strings."
             ),
         )
@@ -964,10 +978,13 @@ class Config:
         if self.cookies_path.is_file():
             log.warning(
                 "Cookies TXT file detected. MusicBot will pass them to yt-dlp.\n"
-                "Enabling cookies is not recommended, and could be risky.\n"
-                "Make sure you understand how yt-dlp will be using the cookies.\n"
-                "Good Luck!  \U0001F596"
+                "Cookies are not recommended, may not be supported, and may totally break.\n"
+                "Copying cookies from your web-browser risks exposing personal data and \n"
+                "in the best case can result in your accounts being banned!\n\n"
+                "You have been warned!  Good Luck!  \U0001F596\n"
             )
+            # make sure the user sees this.
+            time.sleep(3)
 
     async def async_validate(self, bot: "MusicBot") -> None:
         """
@@ -1228,6 +1245,7 @@ class ConfigDefaults:
     auto_unpause_on_play: bool = False
     ytdlp_proxy: str = ""
     ytdlp_user_agent: str = ""
+    pre_download_next_song: bool = True
 
     song_blocklist: Set[str] = set()
     user_blocklist: Set[int] = set()

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -446,6 +446,14 @@ class Config:
                 " {p0_url}      = The track url for the currently playing track."
             ),
         )
+        self.status_include_paused: bool = self.register.init_option(
+            section="MusicBot",
+            option="StatusIncludePaused",
+            dest="status_include_paused",
+            default=ConfigDefaults.status_include_paused,
+            getter="getboolean",
+            comment="If enabled, status messages will report info on paused players.",
+        )
         self.write_current_song: bool = self.register.init_option(
             section="MusicBot",
             option="WriteCurrentSong",
@@ -1159,6 +1167,7 @@ class ConfigDefaults:
     delete_invoking: bool = False
     persistent_queue: bool = True
     status_message: str = ""
+    status_include_paused: bool = False
     write_current_song: bool = False
     allow_author_skip: bool = True
     use_experimental_equalization: bool = False

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -694,6 +694,18 @@ class Config:
             ),
         )
 
+        self.ytdlp_user_agent: str = self.register.init_option(
+            section="MusicBot",
+            option="YtdlpUserAgent",
+            dest="ytdlp_user_agent",
+            default=ConfigDefaults.ytdlp_user_agent,
+            comment=(
+                "Experimental option to set a static User-Agent header in yt-dlp.\n"
+                "It is not typically recommended by yt-dlp to change the UA string.\n"
+                "Leave blank to use default, dynamically generated UA strings."
+            ),
+        )
+
         self.user_blocklist_enabled: bool = self.register.init_option(
             section="MusicBot",
             option="EnableUserBlocklist",
@@ -1215,6 +1227,7 @@ class ConfigDefaults:
     enable_queue_history_guilds: bool = False
     auto_unpause_on_play: bool = False
     ytdlp_proxy: str = ""
+    ytdlp_user_agent: str = ""
 
     song_blocklist: Set[str] = set()
     user_blocklist: Set[int] = set()

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -673,6 +673,27 @@ class Config:
             comment="Allow MusicBot to automatically unpause when play commands are used.",
         )
 
+        # This is likely to turn into one option for each separate part.
+        # Due to how the support for protocols differs from part to part.
+        # ytdlp has its own option that uses requests.
+        # aiohttp requires per-call proxy parameter be set.
+        # and ffmpeg with stream mode also makes its own direct connections.
+        # top it off with proxy for the API. Once we tip the proxy iceberg...
+        # In some cases, users might get away with setting environment variables,
+        # HTTP_PROXY, HTTPS_PROXY, and others for ytdlp and ffmpeg.
+        # While aiohttp would require some other param or config file for that.
+        self.ytdlp_proxy: str = self.register.init_option(
+            section="MusicBot",
+            option="YtdlpProxy",
+            dest="ytdlp_proxy",
+            default=ConfigDefaults.ytdlp_proxy,
+            comment=(
+                "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
+                "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
+                "Leave blank to disable."
+            ),
+        )
+
         self.user_blocklist_enabled: bool = self.register.init_option(
             section="MusicBot",
             option="EnableUserBlocklist",
@@ -1193,6 +1214,7 @@ class ConfigDefaults:
     enable_queue_history_global: bool = False
     enable_queue_history_guilds: bool = False
     auto_unpause_on_play: bool = False
+    ytdlp_proxy: str = ""
 
     song_blocklist: Set[str] = set()
     user_blocklist: Set[int] = set()

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -37,6 +37,7 @@ DEFAULT_DATA_DIR: str = "data/"
 # File names within the DEFAULT_DATA_DIR or guild folders.
 DATA_FILE_SERVERS: str = "server_names.txt"
 DATA_FILE_CACHEMAP: str = "playlist_cachemap.json"
+DATA_FILE_COOKIES: str = "cookies.txt"  # No support for this, go read yt-dlp docs.
 DATA_GUILD_FILE_QUEUE: str = "queue.json"
 DATA_GUILD_FILE_CUR_SONG: str = "current.txt"
 DATA_GUILD_FILE_OPTIONS: str = "options.json"

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -114,6 +114,13 @@ DEFAULT_MAX_INFO_DL_THREADS: int = 2
 # Maximum number of seconds to wait for HEAD request on media files.
 DEFAULT_MAX_INFO_REQUEST_TIMEOUT: int = 10
 
+# MusicBot can pre-download the track up-next, while the current plays.
+# Typically not an issue, but makes more requests over all to the same media.
+# If it is an issue for some, this constant can disable the pre-downloads.
+PRE_DOWNLOAD_NEXT_TRACK: bool = True
+# Time to wait before starting pre-download when a new song is playing.
+DEFAULT_PRE_DOWNLOAD_DELAY: float = 4.0
+
 # Discord and other API constants
 DISCORD_MSG_CHAR_LIMIT: int = 2000
 

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -35,6 +35,13 @@ DEFAULT_BOT_NAME: str = "MusicBot"
 DEFAULT_BOT_ICON: str = "https://i.imgur.com/gFHBoZA.png"
 DEFAULT_OWNER_GROUP_NAME: str = "Owner (auto)"
 DEFAULT_PERMS_GROUP_NAME: str = "Default"
+# This UA string is used by MusicBot only for the aiohttp session.
+# Meaning discord API and spotify API communications.
+# NOT used by ytdlp, they have a dynamic UA selection feature.
+MUSICBOT_USER_AGENT_AIOHTTP: str = f"MusicBot/{VERSION}"
+# Intentionally left empty, for dynamic selection.
+# Not recommended to change this, unless you understand how ytdlp uses it.
+MUSICBOT_USER_AGENT_YTDLP: str = ""
 
 
 # File path constants

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -39,9 +39,6 @@ DEFAULT_PERMS_GROUP_NAME: str = "Default"
 # Meaning discord API and spotify API communications.
 # NOT used by ytdlp, they have a dynamic UA selection feature.
 MUSICBOT_USER_AGENT_AIOHTTP: str = f"MusicBot/{VERSION}"
-# Intentionally left empty, for dynamic selection.
-# Not recommended to change this, unless you understand how ytdlp uses it.
-MUSICBOT_USER_AGENT_YTDLP: str = ""
 
 
 # File path constants

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -111,10 +111,6 @@ DEFAULT_MAX_INFO_DL_THREADS: int = 2
 # Maximum number of seconds to wait for HEAD request on media files.
 DEFAULT_MAX_INFO_REQUEST_TIMEOUT: int = 10
 
-# MusicBot can pre-download the track up-next, while the current plays.
-# Typically not an issue, but makes more requests over all to the same media.
-# If it is an issue for some, this constant can disable the pre-downloads.
-PRE_DOWNLOAD_NEXT_TRACK: bool = True
 # Time to wait before starting pre-download when a new song is playing.
 DEFAULT_PRE_DOWNLOAD_DELAY: float = 4.0
 

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -92,6 +92,14 @@ class Downloader:
         ytdl_format_options = ytdl_format_options_immutable.copy()
         ytdl_format_options["http_headers"] = self.http_req_headers
 
+        # check if we should apply a cookies file to ytdlp.
+        if bot.config.cookies_path.is_file():
+            log.info(
+                "MusicBot will use cookies for yt-dlp from:  %s",
+                bot.config.cookies_path,
+            )
+            ytdl_format_options["cookiefile"] = bot.config.cookies_path
+
         if self.download_folder:
             # print("setting template to " + os.path.join(download_folder, otmpl))
             otmpl = ytdl_format_options["outtmpl"]

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -19,7 +19,11 @@ from yt_dlp.networking.exceptions import (  # type: ignore[import-untyped]
 from yt_dlp.utils import DownloadError  # type: ignore[import-untyped]
 from yt_dlp.utils import UnsupportedError
 
-from .constants import DEFAULT_MAX_INFO_DL_THREADS, DEFAULT_MAX_INFO_REQUEST_TIMEOUT
+from .constants import (
+    DEFAULT_MAX_INFO_DL_THREADS,
+    DEFAULT_MAX_INFO_REQUEST_TIMEOUT,
+    MUSICBOT_USER_AGENT_YTDLP,
+)
 from .exceptions import ExtractionError, MusicbotException
 from .spotify import Spotify
 
@@ -85,9 +89,13 @@ class Downloader:
         )
 
         # force ytdlp and HEAD requests to use the same UA string.
-        self.http_req_headers = {
-            "User-Agent": youtube_dl.utils.networking.random_user_agent()
-        }
+        # If the constant is set, use that, otherwise use dynamic selection.
+        if MUSICBOT_USER_AGENT_YTDLP:
+            ua = MUSICBOT_USER_AGENT_YTDLP
+            log.warning("Forcing YTDLP to use User Agent:  %s", ua)
+        else:
+            ua = youtube_dl.utils.networking.random_user_agent()
+        self.http_req_headers = {"User-Agent": ua}
         # Copy immutable dict and use the mutable copy for everything else.
         ytdl_format_options = ytdl_format_options_immutable.copy()
         ytdl_format_options["http_headers"] = self.http_req_headers

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -108,6 +108,10 @@ class Downloader:
             )
             ytdl_format_options["cookiefile"] = bot.config.cookies_path
 
+        if bot.config.ytdlp_proxy:
+            log.info("Yt-dlp will use your configured proxy server.")
+            ytdl_format_options["proxy"] = bot.config.ytdlp_proxy
+
         if self.download_folder:
             # print("setting template to " + os.path.join(download_folder, otmpl))
             otmpl = ytdl_format_options["outtmpl"]
@@ -207,6 +211,7 @@ class Downloader:
             timeout=req_timeout,
             allow_redirects=allow_redirects,
             headers=req_headers,
+            proxy=self.bot.config.ytdlp_proxy,
         ) as response:
             return response.headers
 

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -19,11 +19,7 @@ from yt_dlp.networking.exceptions import (  # type: ignore[import-untyped]
 from yt_dlp.utils import DownloadError  # type: ignore[import-untyped]
 from yt_dlp.utils import UnsupportedError
 
-from .constants import (
-    DEFAULT_MAX_INFO_DL_THREADS,
-    DEFAULT_MAX_INFO_REQUEST_TIMEOUT,
-    MUSICBOT_USER_AGENT_YTDLP,
-)
+from .constants import DEFAULT_MAX_INFO_DL_THREADS, DEFAULT_MAX_INFO_REQUEST_TIMEOUT
 from .exceptions import ExtractionError, MusicbotException
 from .spotify import Spotify
 
@@ -90,8 +86,8 @@ class Downloader:
 
         # force ytdlp and HEAD requests to use the same UA string.
         # If the constant is set, use that, otherwise use dynamic selection.
-        if MUSICBOT_USER_AGENT_YTDLP:
-            ua = MUSICBOT_USER_AGENT_YTDLP
+        if bot.config.ytdlp_user_agent:
+            ua = bot.config.ytdlp_user_agent
             log.warning("Forcing YTDLP to use User Agent:  %s", ua)
         else:
             ua = youtube_dl.utils.networking.random_user_agent()

--- a/musicbot/permissions.py
+++ b/musicbot/permissions.py
@@ -182,14 +182,6 @@ class Permissions:
             log.debug("Setting auto OwnerID for owner permissions group.")
             self.owner_group.user_list = {bot.config.owner_id}
 
-    def save(self) -> None:
-        """
-        Currently unused function intended to write permissions back to
-        its configuration file.
-        """
-        with open(self.perms_file, "w", encoding="utf8") as f:
-            self.config.write(f)
-
     def for_user(self, user: Union[discord.Member, discord.User]) -> "PermissionGroup":
         """
         Returns the first PermissionGroup a user belongs to

--- a/musicbot/player.py
+++ b/musicbot/player.py
@@ -56,6 +56,8 @@ class SourcePlaybackCounter(AudioSource):
 
         :param: start_time:  A time in seconds that was used in ffmpeg -ss flag.
         """
+        # NOTE: PCMVolumeTransformer will let you set any crazy value.
+        # But internally it limits between 0 and 2.0.
         self._source = source
         self._num_reads: int = 0
         self._start_time: float = start_time

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -441,8 +441,11 @@ class Playlist(EventEmitter, Serializable):
             return None
 
         entry = self.entries.popleft()
-        # TODO:  Add the pre-download for song-after-next back, later...
-
+        next_entry = self.peek()
+        if next_entry and next_entry != entry:
+            log.everything("Pre-downloading next track:  %r", next_entry)
+            entry.get_ready_future()
+        
         return await entry.get_ready_future()
 
     def peek(self) -> Optional[EntryTypes]:

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -443,7 +443,9 @@ class Playlist(EventEmitter, Serializable):
         entry = self.entries.popleft()
         next_entry = self.peek()
         if next_entry and next_entry != entry:
-            log.everything("Pre-downloading next track:  %r", next_entry)
+            log.everything(  # type: ignore[attr-defined]
+                "Pre-downloading next track:  %r", next_entry
+            )
             entry.get_ready_future()
 
         return await entry.get_ready_future()

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -445,7 +445,7 @@ class Playlist(EventEmitter, Serializable):
         if next_entry and next_entry != entry:
             log.everything("Pre-downloading next track:  %r", next_entry)
             entry.get_ready_future()
-        
+
         return await entry.get_ready_future()
 
     def peek(self) -> Optional[EntryTypes]:

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -18,7 +18,7 @@ from typing import (
 
 import discord
 
-from .constants import DEFAULT_PRE_DOWNLOAD_DELAY, PRE_DOWNLOAD_NEXT_TRACK
+from .constants import DEFAULT_PRE_DOWNLOAD_DELAY
 from .constructs import Serializable
 from .entry import LocalFilePlaylistEntry, StreamPlaylistEntry, URLPlaylistEntry
 from .exceptions import ExtractionError, InvalidDataError, WrongEntryTypeError
@@ -454,7 +454,7 @@ class Playlist(EventEmitter, Serializable):
         Enforces a delay before doing pre-download of the "next" song.
         Should only be called from get_next_entry() after pop.
         """
-        if not PRE_DOWNLOAD_NEXT_TRACK:
+        if not self.bot.config.pre_download_next_song:
             return
 
         if not self.entries:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ discord.py [voice, speed] @ git+https://github.com/Rapptz/discord.py
 pip
 yt-dlp
 colorlog
+colorama >= 0.4.6; sys_platform == 'win32'
 cffi --only-binary all; sys_platform == 'win32'
 certifi
 configupdater

--- a/run.py
+++ b/run.py
@@ -990,7 +990,7 @@ def main() -> None:
                 continue
 
         except SyntaxError:
-            if "-dirty" in BOTVERSION:
+            if "-modded" in BOTVERSION:
                 log.exception("Syntax error (version is dirty, did you edit the code?)")
             else:
                 log.exception("Syntax error (this is a bug, not your fault)")

--- a/run.py
+++ b/run.py
@@ -844,7 +844,6 @@ def set_console_title() -> None:
 
             # this is only available in colorama version 0.4.6+
             # which as it happens isn't required by colorlog.
-            # TODO: maybe add colorama>=0.4.6 to requirements.txt
             colorama.just_fix_windows_console()
         except (ImportError, AttributeError):
             # This might only work for Win 10+

--- a/run.py
+++ b/run.py
@@ -809,9 +809,11 @@ def set_console_title() -> None:
             # if colorama fails to import we can assume setup_logs didn't load it.
             import colorama  # type: ignore[import-untyped]
 
-            # if it works, then great, one less thing to worry about right???
+            # this is only available in colorama version 0.4.6+
+            # which as it happens isn't required by colorlog.
+            # TODO: maybe add colorama>=0.4.6 to requirements.txt
             colorama.just_fix_windows_console()
-        except ImportError:
+        except (ImportError, AttributeError):
             # This might only work for Win 10+
             from ctypes import windll  # type: ignore[attr-defined]
 

--- a/run.py
+++ b/run.py
@@ -40,9 +40,13 @@ from musicbot.utils import (
 
 # protect dependency import from stopping the launcher
 try:
+    # This has been available for 7+ years. So it should be OK to do this...
     from aiohttp.client_exceptions import ClientConnectorCertificateError
 except ImportError:
-    pass
+    # prevent NameError while handling exceptions later, if import fails.
+    class ClientConnectorCertificateError(Exception):  # type: ignore[no-redef]
+        pass
+
 
 log = logging.getLogger("musicbot.launcher")
 
@@ -963,7 +967,7 @@ def main() -> None:
                 log.exception("Syntax error (this is a bug, not your fault)")
             break
 
-        except (AttributeError, ImportError) as e:
+        except (AttributeError, ImportError, ModuleNotFoundError) as e:
             # In case a discord extension is installed but discord.py isn't.
             if isinstance(e, AttributeError):
                 if "module 'discord'" not in str(e):

--- a/update.py
+++ b/update.py
@@ -47,13 +47,24 @@ def get_bot_version(git_bin: str) -> str:
     Gets the bot current version as reported by git, without loading constants.
     """
     try:
-        ver = (
-            subprocess.check_output(
-                [git_bin, "describe", "--tags", "--always", "--dirty"]
-            )
+        # Get the last release tag, number of commits since, and g{commit_id} as string.
+        ver_p1 = (
+            subprocess.check_output([git_bin, "describe", "--tags", "--always"])
             .decode("ascii")
             .strip()
         )
+        # Check status of file modifications.
+        ver_p2 = (
+            subprocess.check_output([git_bin, "status", "-suno", "--porcelain"])
+            .decode("ascii")
+            .strip()
+        )
+        if ver_p2:
+            ver_p2 = "-modded"
+        else:
+            ver_p2 = ""
+
+        ver = f"{ver_p1}{ver_p2}"
 
     except (subprocess.SubprocessError, OSError, ValueError) as e:
         print(f"Failed getting version due to:  {str(e)}")
@@ -343,20 +354,29 @@ def main() -> None:
     print("Checking for current bot version and local changes...")
     get_bot_version(git_bin)
 
-    # Check that the current working directory is clean
+    # Check that the current working directory is clean.
+    # -suno is --short with --untracked-files=no
     status_unclean = subprocess.check_output(
-        [git_bin, "status", "--porcelain"], universal_newlines=True
+        [git_bin, "status", "-suno", "--porcelain"], universal_newlines=True
     )
-    if status_unclean:
+    if status_unclean.strip():
+        # TODO: Maybe offering a stash option here would not be so bad...
+        print(
+            "Detected the following files have been modified:\n"
+            f"{status_unclean}\n"
+            "To update MusicBot source code, you must first remove modifications made to the above source files.\n"
+            "If you want to keep your changes, consider using `git stash` or otherwise back them up before you continue.\n"
+            "This script can automatically revert your modifications, but cannot automatically save them.\n"
+        )
         hard_reset = yes_or_no_input(
-            "You have modified files that are tracked by Git (e.g the bot's source files).\n"
-            "Should we try to hard reset the repo? You will lose local modifications."
+            "WARNING:  All changed files listed above will be reset!\n"
+            "Would you like to reset the Source code, to allow MusicBot to update?"
         )
         if hard_reset:
             run_or_raise_error(
                 [git_bin, "reset", "--hard"],
                 "Could not hard reset the directory to a clean state.\n"
-                "You will need to run `git pull` manually.",
+                "You will need to manually reset the local git repository, or make a new clone of MusicBot.",
             )
         else:
             do_deps = yes_or_no_input(
@@ -394,6 +414,8 @@ def main() -> None:
     update_deps()
     update_ffmpeg()
     finalize()
+
+# TODO: make sure pip update runs again after any git pull is done.
 
 
 if __name__ == "__main__":

--- a/update.py
+++ b/update.py
@@ -415,8 +415,6 @@ def main() -> None:
     update_ffmpeg()
     finalize()
 
-# TODO: make sure pip update runs again after any git pull is done.
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher (3.8.10 on Win 10 & 3.10.12 on PopOS 22.04)
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR contains a few patches for stability, some corrections to features, and also adds new config options to tweak some of ytdlp's network related settings.   
Some of these patches will need some extra testing on windows or with python 3.8 to be sure they work.  As always, feel free to deny this PR and cherry-pick the parts that are most useful.  

A summary list of changes:  
- Add support for `cookies.txt` by adding the file `MusicBot/data/cookies.txt` to enable cookies.  Must not be empty!
- Add option to allow changing yt-dlp UA strings from dynamic to static / custom UA.
- Add option to enable HTTP/HTTPS proxy for yt-dlp and media checking only.  (APIs and ffmpeg will not use this proxy.)
- Add option to count paused players, off by default to restore historic behavior of status message.
- Add support for complex aliases, with arguments.  
- Re-enables pre-download for next track in the queue. (still no support for auto playlist tracks and the new-song edge case.)
- Better handling of player inactivity checks to prevent premature disconnects.
- Better handling of start-up failures to trigger installing dependencies.
- Adds a check for ffmpeg being executable to start-up.
- Windows will now prefer system-installed ffmpeg over using bundled `bin/` exes.
- Improved debug command flexibility.
- Added dev-only command to generate markdown from config and permissions code.  A step to generating documentations from the source.


### Related issues (if applicable)

Alias support was expanded on, potentially closing issue #2413 

