### PR TITLE
Cookie management command & bug fix

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -7354,6 +7354,12 @@ class MusicBot(discord.Client):
           When updating cookies, you must upload a file named cookies.txt
           If cookies are disabled, uploading will enable the feature.
           Uploads will delete existing cookies, including disabled cookies file.
+
+        WARNING:
+          Copying cookies can risk exposing your personal information or accounts,
+          and may result in account bans or theft if you are not careful.
+          It is not recommended due to these risks, and you should not use this
+          feature if you do not understand how to avoid the risks.
         """
         opt = opt.lower()
         if opt == "on":

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -7268,7 +7268,7 @@ class MusicBot(discord.Client):
         uptime = time.time() - self._init_time
         delta = format_song_duration(uptime)
         return Response(
-            f"MusicBot has been up for `{delta}`",
+            f"{self.user.name} has been up for `{delta}`",
             delete_after=30,
         )
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -7413,9 +7413,7 @@ class MusicBot(discord.Client):
             try:
                 self.config.disabled_cookies_path.unlink()
             except OSError as e:
-                log.warning(
-                    "Could not remove old, disabled cookies file:  %s", str(e)
-                )
+                log.warning("Could not remove old, disabled cookies file:  %s", str(e))
 
         # simply save the uploaded file in attachment 1 as cookies.txt.
         try:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -7402,7 +7402,7 @@ class MusicBot(discord.Client):
                 except OSError as e:
                     raise exceptions.CommandError(
                         f"Could not rename cookies file due to error:  {str(e)}\n"
-                        "Cookies temporarilly disabled and will be re-enabled on next restart."
+                        "Cookies temporarily disabled and will be re-enabled on next restart."
                     ) from e
             return Response("Cookies have been disabled.")
 

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -32,6 +32,7 @@ from .constants import (
     DATA_FILE_SERVERS,
     DATA_GUILD_FILE_CUR_SONG,
     DATA_GUILD_FILE_QUEUE,
+    DEFAULT_BOT_NAME,
     DEFAULT_OWNER_GROUP_NAME,
     DEFAULT_PERMS_GROUP_NAME,
     DEFAULT_PING_HTTP_URI,
@@ -7267,8 +7268,11 @@ class MusicBot(discord.Client):
         """
         uptime = time.time() - self._init_time
         delta = format_song_duration(uptime)
+        name = DEFAULT_BOT_NAME
+        if self.user:
+            name = self.user.name
         return Response(
-            f"{self.user.name} has been up for `{delta}`",
+            f"{name} has been up for `{delta}`",
             delete_after=30,
         )
 

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -837,6 +837,9 @@ class Config:
         self.data_path = pathlib.Path(DEFAULT_DATA_DIR).resolve()
         self.server_names_path = self.data_path.joinpath(DATA_FILE_SERVERS)
         self.cookies_path = self.data_path.joinpath(DATA_FILE_COOKIES)
+        self.disabled_cookies_path = self.cookies_path.parent.joinpath(
+            f"_{self.cookies_path.name}"
+        )
 
         # Validate the config settings match destination values.
         self.register.validate_register_destinations()

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -148,6 +148,20 @@ class Downloader:
         del self.safe_ytdl.params["cookiefile"]
         del self.unsafe_ytdl.params["cookiefile"]
 
+    def randomize_user_agent_string(self) -> None:
+        """
+        Uses ytdlp utils functions to re-randomize UA strings in YoutubeDL
+        objects and header check requests.
+        """
+        # ignore this call if static UA is configured.
+        if not self.bot.config.ytdlp_user_agent:
+            return
+
+        new_ua = youtube_dl.utils.networking.random_user_agent()
+        self.unsafe_ytdl.params["http_headers"]["User-Agent"] = new_ua
+        self.safe_ytdl.params["http_headers"]["User-Agent"] = new_ua
+        self.http_req_headers["User-Agent"] = new_ua
+
     def get_url_or_none(self, url: str) -> Optional[str]:
         """
         Uses ytdl.utils.url_or_none() to validate a playable URL.
@@ -336,6 +350,9 @@ class Downloader:
         data["__input_subject"] = song_subject
         data["__header_data"] = headers or None
         data["__expected_filename"] = self.ytdl.prepare_filename(data)
+
+        # ensure the UA is randomized with each new request if not set static.
+        self.randomize_user_agent_string()
 
         """
         # disabled since it is only needed for working on extractions.

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import datetime
 import functools
@@ -205,6 +206,9 @@ class Downloader:
                         headers[new_key] = values
                     else:
                         headers[new_key] = values.pop()
+            except asyncio.exceptions.TimeoutError:
+                log.warning("Checking media headers failed due to timeout.")
+                headers = headers = {"X-HEAD-REQ-FAILED": "1"}
             except (ExtractionError, OSError, aiohttp.ClientError):
                 log.warning("Failed HEAD request for:  %s", test_url)
                 log.exception("HEAD Request exception: ")

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -125,6 +125,29 @@ class Downloader:
         """Get the Safe (errors ignored) instance of YoutubeDL."""
         return self.safe_ytdl
 
+    @property
+    def cookies_enabled(self) -> bool:
+        """
+        Get status of cookiefile option in ytdlp objects.
+        """
+        return all(
+            ["cookiefile" in ytdl.params for ytdl in [self.safe_ytdl, self.unsafe_ytdl]]
+        )
+
+    def enable_ytdl_cookies(self) -> None:
+        """
+        Set the cookiefile option on the ytdl objects.
+        """
+        self.safe_ytdl.params["cookiefile"] = self.bot.config.cookies_path
+        self.unsafe_ytdl.params["cookiefile"] = self.bot.config.cookies_path
+
+    def disable_ytdl_cookies(self) -> None:
+        """
+        Remove the cookiefile option on the ytdl objects.
+        """
+        del self.safe_ytdl.params["cookiefile"]
+        del self.unsafe_ytdl.params["cookiefile"]
+
     def get_url_or_none(self, url: str) -> Optional[str]:
         """
         Uses ytdl.utils.url_or_none() to validate a playable URL.

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -132,7 +132,7 @@ class Downloader:
         Get status of cookiefile option in ytdlp objects.
         """
         return all(
-            ["cookiefile" in ytdl.params for ytdl in [self.safe_ytdl, self.unsafe_ytdl]]
+            "cookiefile" in ytdl.params for ytdl in [self.safe_ytdl, self.unsafe_ytdl]
         )
 
     def enable_ytdl_cookies(self) -> None:

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -208,7 +208,7 @@ class Downloader:
                         headers[new_key] = values.pop()
             except asyncio.exceptions.TimeoutError:
                 log.warning("Checking media headers failed due to timeout.")
-                headers = headers = {"X-HEAD-REQ-FAILED": "1"}
+                headers = {"X-HEAD-REQ-FAILED": "1"}
             except (ExtractionError, OSError, aiohttp.ClientError):
                 log.warning("Failed HEAD request for:  %s", test_url)
                 log.exception("HEAD Request exception: ")


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [ ] I have tested my changes on Python 3.8 or higher (only tested 3.10, but 3.8 should still work)
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

- Adds an owner-only command `setcookies` to allow managing cookies remotely.   
- Continue to download songs when the mostly optional header check request hits a timeout.
- Changes downloader to randomize UA strings for each extraction when UA is not static. (Fixes possible regression that may be causing more frequent sign-in errors.)  

