### PR TITLE
Windows patches 2024-08-05

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -45,6 +45,15 @@ if (-Not (Get-Command winget -ErrorAction SilentlyContinue) )
     ""
     Return
 }
+else
+{
+    ""
+    "Checking WinGet can be used..."
+    "If prompted, you must agree to the MS terms to continue installing."
+    ""
+    winget list -q Git.Git
+    ""
+}
 
 # -----------------------------------------------------CONSTANTS-------------------------------------------------------
 
@@ -69,7 +78,7 @@ else
 ""
 
 # Check if Any python 3 is installed
-"Checking if python is already installed..."
+"Checking if python 3 is already installed..."
 Invoke-Expression "winget list -q Python.Python.3" | Out-Null
 if (!($LastExitCode -eq 0))
 {
@@ -80,7 +89,7 @@ if (!($LastExitCode -eq 0))
 }
 else
 {
-    "Python already installed."
+    "Python 3 already installed."
 }
 ""
 
@@ -119,7 +128,7 @@ if((Test-Path $MB_Reqs_File) -and (Test-Path $MB_Module_Dir) -and (Test-Path $MB
 } else {
     ""
     "MusicBot currently has three branches available."
-    "  master - An older MusicBot, for older discord.py. May not work without tweaks!"
+    "  master - Stable MusicBot, least updates and may at times be out-of-date."
     "  review - Newer MusicBot, usually stable with less updates than the dev branch."
     "  dev    - The newest MusicBot, latest features and changes which may need testing."
     ""
@@ -160,7 +169,7 @@ $versionArray = "3.8", "3.9", "3.10", "3.11", "3.12"
 
 foreach ($version in $versionArray)
 {
-    Invoke-Expression "py -$version -c 'exit()'" 2>$null
+    Invoke-Expression "py -$version -c 'exit()'" | Out-Null
     if($LastExitCode -eq 0)
     {
         $PYTHON = "py -$version"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pynacl
-discord.py [voice, speed] @ git+https://github.com/Rapptz/discord.py
+discord.py [voice, speed] @ git+https://github.com/Rapptz/discord.py ; sys_platform != 'win32'
+discord.py [voice] @ git+https://github.com/Rapptz/discord.py ; sys_platform == 'win32'
+# Windows users may want to install orjson and pycares for speed, but avoid aiodns for now.
 pip
 yt-dlp
 colorlog


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This change set addresses the recent bug with `discord.py[speed]` on windows (`aiodns` breaks with ProactorEventLoop, which is required for async process IO on windows, iirc)   
Some users may need to remove the `aiodns` package if it is installed, this will not be done automatically.  
Further, windows users may install `pycares` and `orjson` packages manually if needed.  

Windows `installer.ps1`  will now display the terms agreement prompt if terms are not already agreed to.  This prevents a hang when terms are not previously accepted and the installer checks for packages using winget.  