### PR TITLE
Ytdlp oauth2 plugin integration

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -12,6 +12,15 @@ Token = bot_token
 Spotify_ClientID =
 Spotify_ClientSecret =
 
+# Sets the YouTube API Client ID, used by Yt-dlp OAuth2 plugin.
+# Optional, unless built-in credentials are not working.
+YtdlpOAuth2ClientID = 
+
+# Sets the YouTube API Client Secret key, used by Yt-dlp OAuth2 plugin.
+# Optional, unless YtdlpOAuth2ClientID is set.
+YtdlpOAuth2ClientSecret = 
+
+
 [Permissions]
 # This option determines which user has full permissions and control of the bot.
 # Only one user can be the bot's owner. You can generally leave this as "auto".
@@ -274,6 +283,18 @@ YtdlpProxy =
 #   https://www.useragents.me/
 # Leave blank to use default, dynamically generated UA strings.
 YtdlpUserAgent = 
+
+# Experimental option to enable yt-dlp to use a YouTube account via OAuth2.
+# When enabled, you must use the generated URL and code to authorize an account.
+# The authorization token is then stored in the `data/auth.token` file.
+# This option should not be used when cookies are enabled.
+# Using a personal account may not be recommended.
+YtdlpUseOAuth2 = 
+
+# Optional youtube URL used at start-up for triggering OAuth2 authorization.
+# This starts the OAuth2 prompt early, rather than waiting for a song request.
+# Authorization must be completed before start-up will continue when this is set.
+YtdlpOAuth2URL = 
 
 
 [Files]

--- a/config/example_permissions.ini
+++ b/config/example_permissions.ini
@@ -73,14 +73,18 @@
 ;    that the bot is already joined in the server. It is also expected that the user have ability to invoke summon command to
 ;    use this option.
 ;
-;    Extractors = spotify:musicbot youtube youtube:playlist youtube:tab youtube:search
+;    Extractors = spotify:musicbot youtube generic soundcloud Bandcamp
 ;    Specify yt-dlp extractor names that MusicBot will allow users to play media from.
-;    Each extractor name should be separated by spaces.
-;    If left empty, all services will be allowed.  Including porn services.
-;    The yt-dlp project has a list of supported services here:  
+;    Each extractor name should be separated by spaces or commas.
+;    If left empty, hard-coded defaults will be allowed.
+;    The yt-dlp project has a list of supported services / extractor names here:  
 ;      https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md
 ;
-;    The extractor `spotify:musicbot` is provided by MusicBot, not yt-dlp.
+;    The extractor `spotify:musicbot` is provided by MusicBot, not by yt-dlp.
+;    To allow ALL services, including porn services, add "__" to the list, without quotes.
+;    Example to allow all:
+;
+;    Extractors = __
 ;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -130,7 +134,7 @@ SkipWhenAbsent = no
 BypassKaraokeMode = no
 SummonNoVoice = no
 SkipLooped = no
-Extractors = generic youtube youtube:playlist youtube:tab youtube:search spotify:musicbot
+Extractors = generic youtube spotify:musicbot Bandcamp soundcloud
 
 ; This group has full permissions.
 [MusicMaster]

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -4097,14 +4097,7 @@ class MusicBot(discord.Client):
                 )
 
             # ensure the extractor has been allowed via permissions.
-            if info.extractor not in permissions.extractors and permissions.extractors:
-                raise exceptions.PermissionsError(
-                    self.str.get(
-                        "cmd-play-badextractor",
-                        "You do not have permission to play the requested media. Service `{}` is not permitted.",
-                    ).format(info.extractor),
-                    expire_in=30,
-                )
+            permissions.can_use_extractor(info.extractor)
 
             # if the result has "entries" but it's empty, it might be a failed search.
             if "entries" in info and not info.entry_count:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -315,6 +315,16 @@ class MusicBot(discord.Client):
                 )
                 self.config.spotify_enabled = False
 
+        # trigger yt tv oauth2 authorization.
+        if self.config.ytdlp_use_oauth2 and self.config.ytdlp_oauth2_url:
+            log.warning(
+                "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"
+            )
+            # could probably do this with items from an auto-playlist but meh.
+            await self.downloader.extract_info(
+                self.config.ytdlp_oauth2_url, download=False, process=True
+            )
+
         log.info("Initialized, now connecting to discord.")
         # this creates an output similar to a progress indicator.
         muffle_discord_console_log()

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -23,6 +23,7 @@ import configupdater
 from .constants import (
     DATA_FILE_COOKIES,
     DATA_FILE_SERVERS,
+    DATA_FILE_YTDLP_OAUTH2,
     DEFAULT_AUDIO_CACHE_DIR,
     DEFAULT_DATA_DIR,
     DEFAULT_FOOTER_TEXT,
@@ -719,6 +720,52 @@ class Config:
                 "Leave blank to use default, dynamically generated UA strings."
             ),
         )
+        self.ytdlp_use_oauth2: bool = self.register.init_option(
+            section="MusicBot",
+            option="YtdlpUseOAuth2",
+            dest="ytdlp_use_oauth2",
+            default=ConfigDefaults.ytdlp_use_oauth2,
+            getter="getboolean",
+            comment=(
+                "Experimental option to enable yt-dlp to use a YouTube account via OAuth2.\n"
+                "When enabled, you must use the generated URL and code to authorize an account.\n"
+                "The authorization token is then stored in the "
+                f"`{DEFAULT_DATA_DIR}/{DATA_FILE_YTDLP_OAUTH2}` file.\n"
+                "This option should not be used when cookies are enabled.\n"
+                "Using a personal account may not be recommended."
+            ),
+        )
+        self.ytdlp_oauth2_client_id: str = self.register.init_option(
+            section="Credentials",
+            option="YtdlpOAuth2ClientID",
+            dest="ytdlp_oauth2_client_id",
+            default=ConfigDefaults.ytdlp_oauth2_client_id,
+            comment=(
+                "Sets the YouTube API Client ID, used by Yt-dlp OAuth2 plugin.\n"
+                "Optional, unless built-in credentials are not working."
+            ),
+        )
+        self.ytdlp_oauth2_client_secret: str = self.register.init_option(
+            section="Credentials",
+            option="YtdlpOAuth2ClientSecret",
+            dest="ytdlp_oauth2_client_secret",
+            default=ConfigDefaults.ytdlp_oauth2_client_secret,
+            comment=(
+                "Sets the YouTube API Client Secret key, used by Yt-dlp OAuth2 plugin.\n"
+                "Optional, unless YtdlpOAuth2ClientID is set."
+            ),
+        )
+        self.ytdlp_oauth2_url: str = self.register.init_option(
+            section="MusicBot",
+            option="YtdlpOAuth2URL",
+            dest="ytdlp_oauth2_url",
+            default=ConfigDefaults.ytdlp_oauth2_url,
+            comment=(
+                "Optional youtube URL used at start-up for triggering OAuth2 authorization.\n"
+                "This starts the OAuth2 prompt early, rather than waiting for a song request.\n"
+                "Authorization must be completed before start-up will continue when this is set."
+            ),
+        )
 
         self.user_blocklist_enabled: bool = self.register.init_option(
             section="MusicBot",
@@ -1248,6 +1295,17 @@ class ConfigDefaults:
     auto_unpause_on_play: bool = False
     ytdlp_proxy: str = ""
     ytdlp_user_agent: str = ""
+    ytdlp_oauth2_url: str = ""
+    # These client details are taken from the original plugin code.
+    # Likely that they wont work forever, should be removed, but testing for now.
+    # PR #21 to get these from YT-TV seems broken already.  Maybe I am stupid.
+    # TODO: remove these when a working method to reliably extract them is available.
+    ytdlp_oauth2_client_id: str = (
+        "861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com"
+    )
+    ytdlp_oauth2_client_secret: str = "SboVhoG9s0rNafixCSGGKXAT"
+
+    ytdlp_use_oauth2: bool = False
     pre_download_next_song: bool = True
 
     song_blocklist: Set[str] = set()

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -1,4 +1,5 @@
 import subprocess
+from typing import List
 
 # VERSION is determined by asking the `git` executable about the current repository.
 # This fails if not cloned, or if git is not available for some reason.
@@ -60,6 +61,7 @@ DEFAULT_DATA_DIR: str = "data/"
 DATA_FILE_SERVERS: str = "server_names.txt"
 DATA_FILE_CACHEMAP: str = "playlist_cachemap.json"
 DATA_FILE_COOKIES: str = "cookies.txt"  # No support for this, go read yt-dlp docs.
+DATA_FILE_YTDLP_OAUTH2: str = "oauth2.token"
 DATA_GUILD_FILE_QUEUE: str = "queue.json"
 DATA_GUILD_FILE_CUR_SONG: str = "current.txt"
 DATA_GUILD_FILE_OPTIONS: str = "options.json"
@@ -113,6 +115,28 @@ DEFAULT_MAX_INFO_REQUEST_TIMEOUT: int = 10
 
 # Time to wait before starting pre-download when a new song is playing.
 DEFAULT_PRE_DOWNLOAD_DELAY: float = 4.0
+
+# Time in seconds to wait before oauth2 authorization fails.
+# This provides time to authorize as well as prevent process hang at shutdown.
+DEFAULT_YTDLP_OAUTH2_TTL: float = 180.0
+
+# Default / fallback scopes used for OAuth2 ytdlp plugin.
+DEFAULT_YTDLP_OAUTH2_SCOPES: str = (
+    "http://gdata.youtube.com https://www.googleapis.com/auth/youtube"
+)
+# Info Extractors to exclude from OAuth2 patching, when OAuth2 is enabled.
+YTDLP_OAUTH2_EXCLUDED_IES: List[str] = [
+    "YoutubeBaseInfoExtractor",
+    "YoutubeTabBaseInfoExtractor",
+]
+# Yt-dlp client creators that are not compatible with OAuth2 plugin.
+YTDLP_OAUTH2_UNSUPPORTED_CLIENTS: List[str] = [
+    "web_creator",
+    "android_creator",
+    "ios_creator",
+]
+# Additional Yt-dlp clients to add to the OAuth2 client list.
+YTDLP_OAUTH2_CLIENTS: List[str] = ["mweb"]
 
 # Discord and other API constants
 DISCORD_MSG_CHAR_LIMIT: int = 2000

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -3,6 +3,7 @@ import copy
 import datetime
 import functools
 import hashlib
+import importlib
 import logging
 import os
 import pathlib
@@ -23,6 +24,7 @@ from yt_dlp.utils import UnsupportedError
 from .constants import DEFAULT_MAX_INFO_DL_THREADS, DEFAULT_MAX_INFO_REQUEST_TIMEOUT
 from .exceptions import ExtractionError, MusicbotException
 from .spotify import Spotify
+from .ytdlp_oauth2_plugin import enable_ytdlp_oauth2_plugin
 
 if TYPE_CHECKING:
     from multidict import CIMultiDictProxy
@@ -108,6 +110,28 @@ class Downloader:
         if bot.config.ytdlp_proxy:
             log.info("Yt-dlp will use your configured proxy server.")
             ytdl_format_options["proxy"] = bot.config.ytdlp_proxy
+
+        if bot.config.ytdlp_use_oauth2:
+            # set the login info so oauth2 is prompted.
+            ytdl_format_options["username"] = "oauth2"
+            ytdl_format_options["password"] = ""
+            # ytdl_format_options["extractor_args"] = {
+            #    "youtubetab": {"skip": ["authcheck"]}
+            # }
+
+            # check if the original plugin is installed, and use it instead of ours.
+            # It's worth doing this because our version might fail to work,
+            # even if the original causes infinite loop hangs while auth is pending...
+            oauth_spec = importlib.utils.find_spec(
+                "yt_dlp_plugins.extractor.youtubeoauth"
+            )
+            if oauth_spec is not None:
+                log.warning(
+                    "Loading the original OAuth2 plugin. This may cause MusicBot to not close completely!\n"
+                    "Uninstall the yt-dlp-youtube-oauth2 package to use integrated OAuth2 features."
+                )
+            else:
+                enable_ytdlp_oauth2_plugin(self.bot.config)
 
         if self.download_folder:
             # print("setting template to " + os.path.join(download_folder, otmpl))

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -127,9 +127,14 @@ class Downloader:
             )
             if oauth_spec is not None:
                 log.warning(
-                    "Loading the original OAuth2 plugin. This may cause MusicBot to not close completely!\n"
-                    "Uninstall the yt-dlp-youtube-oauth2 package to use integrated OAuth2 features."
+                    "Original OAuth2 plugin is installed and will be used instead.\n"
+                    "This may cause MusicBot to not close completely, or hang pending authorization!\n"
+                    "To close MusicBot, you must manually Kill the MusicBot process!\n"
+                    "Yt-dlp is being set to show warnings and other log messages, to show the Auth code.\n"
+                    "Uninstall the yt-dlp-youtube-oauth2 package to use integrated OAuth2 features instead."
                 )
+                ytdl_format_options["quiet"] = False
+                ytdl_format_options["no_warnings"] = False
             else:
                 enable_ytdlp_oauth2_plugin(self.bot.config)
 

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -122,9 +122,13 @@ class Downloader:
             # check if the original plugin is installed, and use it instead of ours.
             # It's worth doing this because our version might fail to work,
             # even if the original causes infinite loop hangs while auth is pending...
-            oauth_spec = importlib.util.find_spec(
-                "yt_dlp_plugins.extractor.youtubeoauth"
-            )
+            try:
+                oauth_spec = importlib.util.find_spec(
+                    "yt_dlp_plugins.extractor.youtubeoauth"
+                )
+            except ModuleNotFoundError:
+                oauth_spec = None
+
             if oauth_spec is not None:
                 log.warning(
                     "Original OAuth2 plugin is installed and will be used instead.\n"

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -122,7 +122,7 @@ class Downloader:
             # check if the original plugin is installed, and use it instead of ours.
             # It's worth doing this because our version might fail to work,
             # even if the original causes infinite loop hangs while auth is pending...
-            oauth_spec = importlib.utils.find_spec(
+            oauth_spec = importlib.util.find_spec(
                 "yt_dlp_plugins.extractor.youtubeoauth"
             )
             if oauth_spec is not None:

--- a/musicbot/ytdlp_oauth2_plugin.py
+++ b/musicbot/ytdlp_oauth2_plugin.py
@@ -1,0 +1,195 @@
+#
+# This file contains code provided under an unlicense license.
+# Originally copied from the following repository on August 11, 2024:
+#   https://github.com/coletdjnz/yt-dlp-youtube-oauth2
+#
+# NOTICE:
+#  Modifications made herein are made by the MusicBot contributors in
+#  order to better integrate the features for use within MusicBot.
+#  Any modified portions of this source file may be provided under the
+#  terms of the MIT license, at the discretion of the contributor(s)
+#  which are listed here:
+#
+#  Name / Contact  |  License
+# -----------------+------------
+#  Fae             |  Unlicense
+#
+
+import datetime
+import json
+import time
+import urllib.parse
+import uuid
+
+import yt_dlp.networking
+from yt_dlp.utils import ExtractorError
+from yt_dlp.utils.traversal import traverse_obj
+from yt_dlp.extractor.common import InfoExtractor
+from yt_dlp.extractor.youtube import YoutubeBaseInfoExtractor
+import importlib
+import inspect
+
+YOUTUBE_IES = filter(
+    lambda member: issubclass(member[1], YoutubeBaseInfoExtractor),
+    inspect.getmembers(importlib.import_module('yt_dlp.extractor.youtube'), inspect.isclass)
+)
+
+# YouTube TV (TVHTML5)
+# TODO: dynamically extract these
+_CLIENT_ID = '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com'
+_CLIENT_SECRET = 'SboVhoG9s0rNafixCSGGKXAT'
+_SCOPES = 'http://gdata.youtube.com https://www.googleapis.com/auth/youtube'
+
+
+class YouTubeOAuth2Handler(InfoExtractor):
+    def store_token(self, token_data):
+        self.cache.store('youtube-oauth2', 'token_data', token_data)
+        self._TOKEN_DATA = token_data
+
+    def get_token(self):
+        if not getattr(self, '_TOKEN_DATA', None):
+            self._TOKEN_DATA = self.cache.load('youtube-oauth2', 'token_data')
+        return self._TOKEN_DATA
+
+    def validate_token_data(self, token_data):
+        return all(key in token_data for key in ('access_token', 'expires', 'refresh_token', 'token_type'))
+
+    def initialize_oauth(self):
+        token_data = self.get_token()
+
+        if token_data and not self.validate_token_data(token_data):
+            self.report_warning('Invalid cached OAuth2 token data')
+            token_data = None
+
+        if not token_data:
+            token_data = self.authorize()
+            self.store_token(token_data)
+
+        if token_data['expires'] < datetime.datetime.now(datetime.timezone.utc).timestamp() + 60:
+            self.to_screen('Access token expired, refreshing')
+            token_data = self.refresh_token(token_data['refresh_token'])
+            self.store_token(token_data)
+
+        return token_data
+
+    def handle_oauth(self, request: yt_dlp.networking.Request):
+
+        if not urllib.parse.urlparse(request.url).netloc.endswith('youtube.com'):
+            return
+
+        token_data = self.initialize_oauth()
+        # These are only require for cookies and interfere with OAuth2
+        request.headers.pop('X-Goog-PageId', None)
+        request.headers.pop('X-Goog-AuthUser', None)
+        # In case user tries to use cookies at the same time
+        if 'Authorization' in request.headers:
+            self.report_warning(
+                'Youtube cookies have been provided, but OAuth2 is being used.'
+                ' If you encounter problems, stop providing Youtube cookies to yt-dlp.')
+            request.headers.pop('Authorization', None)
+            request.headers.pop('X-Origin', None)
+
+        # Not even used anymore, should be removed from core...
+        request.headers.pop('X-Youtube-Identity-Token', None)
+
+        authorization_header = {'Authorization': f'{token_data["token_type"]} {token_data["access_token"]}'}
+        request.headers.update(authorization_header)
+
+    def refresh_token(self, refresh_token):
+        token_response = self._download_json(
+            'https://www.youtube.com/o/oauth2/token',
+            video_id='oauth2',
+            note='Refreshing OAuth2 Token',
+            data=json.dumps({
+                'client_id': _CLIENT_ID,
+                'client_secret': _CLIENT_SECRET,
+                'refresh_token': refresh_token,
+                'grant_type': 'refresh_token'
+            }).encode(),
+            headers={'Content-Type': 'application/json', '__youtube_oauth__': True})
+        error = traverse_obj(token_response, 'error')
+        if error:
+            self.report_warning(f'Failed to refresh access token: {error}. Restarting authorization flow')
+            return self.authorize()
+
+        return {
+            'access_token': token_response['access_token'],
+            'expires': datetime.datetime.now(datetime.timezone.utc).timestamp() + token_response['expires_in'],
+            'token_type': token_response['token_type'],
+            'refresh_token': token_response.get('refresh_token', refresh_token)
+        }
+
+    def authorize(self):
+        code_response = self._download_json(
+            'https://www.youtube.com/o/oauth2/device/code',
+            video_id='oauth2',
+            note='Initializing OAuth2 Authorization Flow',
+            data=json.dumps({
+                'client_id': _CLIENT_ID,
+                'scope': _SCOPES,
+                'device_id': uuid.uuid4().hex,
+                'device_model': 'ytlr::'
+            }).encode(),
+            headers={'Content-Type': 'application/json', '__youtube_oauth__': True})
+
+        verification_url = code_response['verification_url']
+        user_code = code_response['user_code']
+        self.to_screen(f'To give yt-dlp access to your account, go to  {verification_url}  and enter code  {user_code}')
+
+        while True:
+            token_response = self._download_json(
+                'https://www.youtube.com/o/oauth2/token',
+                video_id='oauth2',
+                note=False,
+                data=json.dumps({
+                    'client_id': _CLIENT_ID,
+                    'client_secret': _CLIENT_SECRET,
+                    'code': code_response['device_code'],
+                    'grant_type': 'http://oauth.net/grant_type/device/1.0'
+                }).encode(),
+                headers={'Content-Type': 'application/json', '__youtube_oauth__': True})
+
+            error = traverse_obj(token_response, 'error')
+            if error:
+                if error == 'authorization_pending':
+                    time.sleep(code_response['interval'])
+                    continue
+                elif error == 'expired_token':
+                    self.report_warning('The device code has expired, restarting authorization flow')
+                    return self.authorize()
+                else:
+                    raise ExtractorError(f'Unhandled OAuth2 Error: {error}')
+
+            self.to_screen('Authorization successful')
+            return {
+                'access_token': token_response['access_token'],
+                'expires': datetime.datetime.now(datetime.timezone.utc).timestamp() + token_response['expires_in'],
+                'refresh_token': token_response['refresh_token'],
+                'token_type': token_response['token_type']
+            }
+
+
+for _, ie in YOUTUBE_IES:
+    class _YouTubeOAuth(ie, YouTubeOAuth2Handler, plugin_name='oauth2'):
+        _NETRC_MACHINE = 'youtube'
+        _use_oauth2 = False
+
+        def _perform_login(self, username, password):
+            if username == 'oauth2':
+                self._use_oauth2 = True
+                self.initialize_oauth()
+
+        def _create_request(self, *args, **kwargs):
+            request = super()._create_request(*args, **kwargs)
+            if '__youtube_oauth__' in request.headers:
+                request.headers.pop('__youtube_oauth__')
+            elif self._use_oauth2:
+                self.handle_oauth(request)
+            return request
+
+        @property
+        def is_authenticated(self):
+            if self._use_oauth2:
+                token_data = self.get_token()
+                return token_data and self.validate_token_data(token_data)
+            return super().is_authenticated

--- a/musicbot/ytdlp_oauth2_plugin.py
+++ b/musicbot/ytdlp_oauth2_plugin.py
@@ -16,173 +16,202 @@
 #
 
 import datetime
+import importlib
+import inspect
 import json
 import time
 import urllib.parse
 import uuid
 
 import yt_dlp.networking
-from yt_dlp.utils import ExtractorError
-from yt_dlp.utils.traversal import traverse_obj
 from yt_dlp.extractor.common import InfoExtractor
 from yt_dlp.extractor.youtube import YoutubeBaseInfoExtractor
-import importlib
-import inspect
+from yt_dlp.utils import ExtractorError
+from yt_dlp.utils.traversal import traverse_obj
 
 YOUTUBE_IES = filter(
     lambda member: issubclass(member[1], YoutubeBaseInfoExtractor),
-    inspect.getmembers(importlib.import_module('yt_dlp.extractor.youtube'), inspect.isclass)
+    inspect.getmembers(
+        importlib.import_module("yt_dlp.extractor.youtube"), inspect.isclass
+    ),
 )
 
 # YouTube TV (TVHTML5)
 # TODO: dynamically extract these
-_CLIENT_ID = '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com'
-_CLIENT_SECRET = 'SboVhoG9s0rNafixCSGGKXAT'
-_SCOPES = 'http://gdata.youtube.com https://www.googleapis.com/auth/youtube'
+_CLIENT_ID = "861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com"
+_CLIENT_SECRET = "SboVhoG9s0rNafixCSGGKXAT"
+_SCOPES = "http://gdata.youtube.com https://www.googleapis.com/auth/youtube"
 
 
 class YouTubeOAuth2Handler(InfoExtractor):
     def store_token(self, token_data):
-        self.cache.store('youtube-oauth2', 'token_data', token_data)
+        self.cache.store("youtube-oauth2", "token_data", token_data)
         self._TOKEN_DATA = token_data
 
     def get_token(self):
-        if not getattr(self, '_TOKEN_DATA', None):
-            self._TOKEN_DATA = self.cache.load('youtube-oauth2', 'token_data')
+        if not getattr(self, "_TOKEN_DATA", None):
+            self._TOKEN_DATA = self.cache.load("youtube-oauth2", "token_data")
         return self._TOKEN_DATA
 
     def validate_token_data(self, token_data):
-        return all(key in token_data for key in ('access_token', 'expires', 'refresh_token', 'token_type'))
+        return all(
+            key in token_data
+            for key in ("access_token", "expires", "refresh_token", "token_type")
+        )
 
     def initialize_oauth(self):
         token_data = self.get_token()
 
         if token_data and not self.validate_token_data(token_data):
-            self.report_warning('Invalid cached OAuth2 token data')
+            self.report_warning("Invalid cached OAuth2 token data")
             token_data = None
 
         if not token_data:
             token_data = self.authorize()
             self.store_token(token_data)
 
-        if token_data['expires'] < datetime.datetime.now(datetime.timezone.utc).timestamp() + 60:
-            self.to_screen('Access token expired, refreshing')
-            token_data = self.refresh_token(token_data['refresh_token'])
+        if (
+            token_data["expires"]
+            < datetime.datetime.now(datetime.timezone.utc).timestamp() + 60
+        ):
+            self.to_screen("Access token expired, refreshing")
+            token_data = self.refresh_token(token_data["refresh_token"])
             self.store_token(token_data)
 
         return token_data
 
     def handle_oauth(self, request: yt_dlp.networking.Request):
 
-        if not urllib.parse.urlparse(request.url).netloc.endswith('youtube.com'):
+        if not urllib.parse.urlparse(request.url).netloc.endswith("youtube.com"):
             return
 
         token_data = self.initialize_oauth()
         # These are only require for cookies and interfere with OAuth2
-        request.headers.pop('X-Goog-PageId', None)
-        request.headers.pop('X-Goog-AuthUser', None)
+        request.headers.pop("X-Goog-PageId", None)
+        request.headers.pop("X-Goog-AuthUser", None)
         # In case user tries to use cookies at the same time
-        if 'Authorization' in request.headers:
+        if "Authorization" in request.headers:
             self.report_warning(
-                'Youtube cookies have been provided, but OAuth2 is being used.'
-                ' If you encounter problems, stop providing Youtube cookies to yt-dlp.')
-            request.headers.pop('Authorization', None)
-            request.headers.pop('X-Origin', None)
+                "Youtube cookies have been provided, but OAuth2 is being used."
+                " If you encounter problems, stop providing Youtube cookies to yt-dlp."
+            )
+            request.headers.pop("Authorization", None)
+            request.headers.pop("X-Origin", None)
 
         # Not even used anymore, should be removed from core...
-        request.headers.pop('X-Youtube-Identity-Token', None)
+        request.headers.pop("X-Youtube-Identity-Token", None)
 
-        authorization_header = {'Authorization': f'{token_data["token_type"]} {token_data["access_token"]}'}
+        authorization_header = {
+            "Authorization": f'{token_data["token_type"]} {token_data["access_token"]}'
+        }
         request.headers.update(authorization_header)
 
     def refresh_token(self, refresh_token):
         token_response = self._download_json(
-            'https://www.youtube.com/o/oauth2/token',
-            video_id='oauth2',
-            note='Refreshing OAuth2 Token',
-            data=json.dumps({
-                'client_id': _CLIENT_ID,
-                'client_secret': _CLIENT_SECRET,
-                'refresh_token': refresh_token,
-                'grant_type': 'refresh_token'
-            }).encode(),
-            headers={'Content-Type': 'application/json', '__youtube_oauth__': True})
-        error = traverse_obj(token_response, 'error')
+            "https://www.youtube.com/o/oauth2/token",
+            video_id="oauth2",
+            note="Refreshing OAuth2 Token",
+            data=json.dumps(
+                {
+                    "client_id": _CLIENT_ID,
+                    "client_secret": _CLIENT_SECRET,
+                    "refresh_token": refresh_token,
+                    "grant_type": "refresh_token",
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json", "__youtube_oauth__": True},
+        )
+        error = traverse_obj(token_response, "error")
         if error:
-            self.report_warning(f'Failed to refresh access token: {error}. Restarting authorization flow')
+            self.report_warning(
+                f"Failed to refresh access token: {error}. Restarting authorization flow"
+            )
             return self.authorize()
 
         return {
-            'access_token': token_response['access_token'],
-            'expires': datetime.datetime.now(datetime.timezone.utc).timestamp() + token_response['expires_in'],
-            'token_type': token_response['token_type'],
-            'refresh_token': token_response.get('refresh_token', refresh_token)
+            "access_token": token_response["access_token"],
+            "expires": datetime.datetime.now(datetime.timezone.utc).timestamp()
+            + token_response["expires_in"],
+            "token_type": token_response["token_type"],
+            "refresh_token": token_response.get("refresh_token", refresh_token),
         }
 
     def authorize(self):
         code_response = self._download_json(
-            'https://www.youtube.com/o/oauth2/device/code',
-            video_id='oauth2',
-            note='Initializing OAuth2 Authorization Flow',
-            data=json.dumps({
-                'client_id': _CLIENT_ID,
-                'scope': _SCOPES,
-                'device_id': uuid.uuid4().hex,
-                'device_model': 'ytlr::'
-            }).encode(),
-            headers={'Content-Type': 'application/json', '__youtube_oauth__': True})
+            "https://www.youtube.com/o/oauth2/device/code",
+            video_id="oauth2",
+            note="Initializing OAuth2 Authorization Flow",
+            data=json.dumps(
+                {
+                    "client_id": _CLIENT_ID,
+                    "scope": _SCOPES,
+                    "device_id": uuid.uuid4().hex,
+                    "device_model": "ytlr::",
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json", "__youtube_oauth__": True},
+        )
 
-        verification_url = code_response['verification_url']
-        user_code = code_response['user_code']
-        self.to_screen(f'To give yt-dlp access to your account, go to  {verification_url}  and enter code  {user_code}')
+        verification_url = code_response["verification_url"]
+        user_code = code_response["user_code"]
+        self.to_screen(
+            f"To give yt-dlp access to your account, go to  {verification_url}  and enter code  {user_code}"
+        )
 
         while True:
             token_response = self._download_json(
-                'https://www.youtube.com/o/oauth2/token',
-                video_id='oauth2',
+                "https://www.youtube.com/o/oauth2/token",
+                video_id="oauth2",
                 note=False,
-                data=json.dumps({
-                    'client_id': _CLIENT_ID,
-                    'client_secret': _CLIENT_SECRET,
-                    'code': code_response['device_code'],
-                    'grant_type': 'http://oauth.net/grant_type/device/1.0'
-                }).encode(),
-                headers={'Content-Type': 'application/json', '__youtube_oauth__': True})
+                data=json.dumps(
+                    {
+                        "client_id": _CLIENT_ID,
+                        "client_secret": _CLIENT_SECRET,
+                        "code": code_response["device_code"],
+                        "grant_type": "http://oauth.net/grant_type/device/1.0",
+                    }
+                ).encode(),
+                headers={"Content-Type": "application/json", "__youtube_oauth__": True},
+            )
 
-            error = traverse_obj(token_response, 'error')
+            error = traverse_obj(token_response, "error")
             if error:
-                if error == 'authorization_pending':
-                    time.sleep(code_response['interval'])
+                if error == "authorization_pending":
+                    time.sleep(code_response["interval"])
                     continue
-                elif error == 'expired_token':
-                    self.report_warning('The device code has expired, restarting authorization flow')
+                elif error == "expired_token":
+                    self.report_warning(
+                        "The device code has expired, restarting authorization flow"
+                    )
                     return self.authorize()
                 else:
-                    raise ExtractorError(f'Unhandled OAuth2 Error: {error}')
+                    raise ExtractorError(f"Unhandled OAuth2 Error: {error}")
 
-            self.to_screen('Authorization successful')
+            self.to_screen("Authorization successful")
             return {
-                'access_token': token_response['access_token'],
-                'expires': datetime.datetime.now(datetime.timezone.utc).timestamp() + token_response['expires_in'],
-                'refresh_token': token_response['refresh_token'],
-                'token_type': token_response['token_type']
+                "access_token": token_response["access_token"],
+                "expires": datetime.datetime.now(datetime.timezone.utc).timestamp()
+                + token_response["expires_in"],
+                "refresh_token": token_response["refresh_token"],
+                "token_type": token_response["token_type"],
             }
 
 
 for _, ie in YOUTUBE_IES:
-    class _YouTubeOAuth(ie, YouTubeOAuth2Handler, plugin_name='oauth2'):
-        _NETRC_MACHINE = 'youtube'
+
+    class _YouTubeOAuth(ie, YouTubeOAuth2Handler, plugin_name="oauth2"):
+        _NETRC_MACHINE = "youtube"
         _use_oauth2 = False
 
         def _perform_login(self, username, password):
-            if username == 'oauth2':
+            if username == "oauth2":
                 self._use_oauth2 = True
                 self.initialize_oauth()
 
         def _create_request(self, *args, **kwargs):
             request = super()._create_request(*args, **kwargs)
-            if '__youtube_oauth__' in request.headers:
-                request.headers.pop('__youtube_oauth__')
+            if "__youtube_oauth__" in request.headers:
+                request.headers.pop("__youtube_oauth__")
             elif self._use_oauth2:
                 self.handle_oauth(request)
             return request


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR contains a modified version of the yt-dlp OAuth2 plugin found here:  
https://github.com/coletdjnz/yt-dlp-youtube-oauth2

By default, the original oauth2 plugin will be used if it is installed.  This prevents conflicts between the original and the MusicBot integration, and allows folks to pick which one they want to use.  However, the original will wait indefinitely for authorization which will cause MusicBot to not fully shut down if authorization is still pending.  Users must manually kill the process in this case.

The integration adds a few options to control if the oauth2 feature is enabled, if it should prompt for authorization at start-up, and options to set your own API credentials should there be a need to in the future.  

This seems to be working in a test environment with versions `2024.07.16` and `2024.08.06` of yt-dlp.  But it could be broken with any older or newer version. 

I have not verified the issue about extractor name / permissions.  So getting that tested before this gets merged may be a good idea.