### PR TITLE
Add github workflow for publishing a docker image

### DIFF
--- a/.github/workflows/docker_image_release.yml
+++ b/.github/workflows/docker_image_release.yml
@@ -1,0 +1,41 @@
+name: Create and publish Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This builds an image using the Dockerfile in the root dir of the repo and publishes it to GitHubs container registry.

~Let me know if you want me to add an example docker-compose.yml file to the readme or the docs on how to install the bot using the image.~ Nvm, I didn't realize there was a `docker-compose.example.yml` in the repo

The `Dockerfile` should also probably be updated to Python 3.10 at some point