### PR TITLE
Fixes and i18n tweaks

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -912,14 +912,14 @@ class ConfigAssistantTextSystem:
                 self.sct_selno = 0
 
         def remove_callback() -> None:
-            nonlocal selected_opt
+            nonlocal selected_opt  # noqa: F824
             if self.mgr_perms is None or selected_opt is None:
                 return
             self.mgr_perms.remove_group(selected_opt.section)
             self.edited_perms.add(selected_opt)
 
         def add_callback() -> None:
-            nonlocal groups
+            nonlocal groups  # noqa: F824
             if not self.mgr_perms:
                 return
             self.win.clear()

--- a/i18n/lang.py
+++ b/i18n/lang.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+"""
+MusicBot Lang Tool
+A collection of functions useful to manage translations in PO/MO formats.
+Learn more by using:
+  lang.py --help
+
+
+Requirements:
+- polib
+
+Optional:
+- marko
+- argostranslate
+
+"""
 
 import argparse
 import difflib
@@ -225,7 +240,7 @@ class LangTool:
         Short simply excludes the file:line comments from the diff output.
         """
         print("Preparing diff for source strings...")
-        short_ignore = ["@@", "+#:", "-#:"]
+        short_ignore = ["@@", "+#", "-#"]
         self._do_diff = True
         self.extract()
 
@@ -580,12 +595,51 @@ class LangTool:
                 entry.flags.append("machine-translated")
             po.save()
 
+    def check_and_compile(self):
+        """Checks and re-compiles mo files if po file meta data does not match."""
+        self._check_polib()
+        import polib  # pylint: disable=import-error,useless-suppression
+
+        def _cmp_msgstr(a, b):
+            for pt_str in a:
+                if pt_str not in b:
+                    return False
+            return True
+
+        print("Checking and compiling mo files...")
+        for po_file in self.basedir.glob(self._po_file_pattern):
+            mo_file = po_file.with_suffix(".mo")
+            locale = po_file.parent.parent.name
+            if self.args.lang and self.args.lang != locale:
+                continue
+
+            po = polib.pofile(po_file)
+
+            if not mo_file.is_file():
+                po.save_as_mofile(mo_file)
+                print("Compiled missing file: ", mo_file)
+                continue
+
+            mo = polib.mofile(mo_file)
+            if mo.metadata != po.metadata:
+                po.save_as_mofile(mo_file)
+                print("Re-compiled due to headers: ", mo_file)
+                continue
+
+            # check translated strings for differences.
+            po_mstr = [e.msgstr for e in po.translated_entries()]
+            mo_mstr = [e.msgstr for e in mo.translated_entries()]
+            if not _cmp_msgstr(po_mstr, mo_mstr):
+                po.save_as_mofile(mo_file)
+                print("Re-compiled due to translations: ", mo_file)
+                continue
+
 
 def main():
     """MusicBot i18n tool entry point."""
     ap = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description=("Helper tool for i18n tasks in MusicBot."),
+        description=("A tool for translation related tasks in MusicBot."),
         epilog=(
             "For more help and support with this bot, join our discord:"
             "\n  https://discord.gg/bots\n\n"
@@ -594,6 +648,7 @@ def main():
         ),
     )
 
+    # option: -L  lang
     ap.add_argument(
         "-L",
         dest="lang",
@@ -603,34 +658,39 @@ def main():
         metavar="LOCALE",
     )
 
+    # option: -c  do_compile
     ap.add_argument(
         "-c",
         dest="do_compile",
         action="store_true",
-        help="Compile existing PO files into MO files.",
+        help="Compile existing translation PO files into MO files.",
     )
 
+    # option: -e  do_extract
     ap.add_argument(
         "-e",
         dest="do_extract",
         action="store_true",
-        help="Extract strings to POT files.",
+        help="Extract strings from source-code to POT files (blank translation templates.)",
     )
 
+    # option: -d  do_diff_short
     ap.add_argument(
         "-d",
         dest="do_diff_short",
         action="store_true",
-        help="Diff new extractions to the existing POT file.  Ignores location comment changes.",
+        help="Show differences between source-code extractions and the existing POT files.",
     )
 
+    # option: -D  do_diff_long
     ap.add_argument(
         "-D",
         dest="do_diff_long",
         action="store_true",
-        help="Same as -d but show all changes.",
+        help="Same as argument -d but shows all changes, instead of hiding comments and flags.",
     )
 
+    # option: -t  do_testlang
     ap.add_argument(
         "-t",
         dest="do_testlang",
@@ -638,6 +698,7 @@ def main():
         help="Create or update the 'xx' test language.",
     )
 
+    # option: -s  do_stats
     ap.add_argument(
         "-s",
         dest="do_stats",
@@ -645,32 +706,47 @@ def main():
         help="Show translation stats for existing PO files, by extracting strings from sources first.",
     )
 
+    # option: -sJ  save_json with do_stats
     ap.add_argument(
         "-J",
         dest="save_json",
         action="store_true",
-        help="Save stats to JSON for use in the repository.",
+        help="Save stats to JSON for use in the repository. Use with -s option.",
     )
 
+    # option:  -sB  save_badges with do_stats
     ap.add_argument(
         "-B",
         dest="save_badges",
         action="store_true",
-        help="Save stats will save badges to use in the repository.",
+        help="Save stats will save badges to use in the repository. Use with -s option.",
     )
 
+    # option: -u  do_update
     ap.add_argument(
         "-u",
         dest="do_update",
         action="store_true",
-        help="Update existing POT files and then update existing PO files.",
+        help=(
+            "Update all existing translation files (PO & POT) from source-code. "
+            "Existing translation files will have new strings to translate."
+        ),
     )
 
+    # option: -A  do_argostranslate
     ap.add_argument(
         "-A",
         dest="do_argostranslate",
         action="store_true",
-        help="Update all missing translations with Argos-translate machine translations.",
+        help="Update all missing translations in PO files with Argos-translate machine translations.",
+    )
+
+    # option: --jit-mo  jit_mo
+    ap.add_argument(
+        "--jit-mo",
+        dest="jit_mo",
+        action="store_true",
+        help="Automatically compile MO files if PO files contain different translations or headers.",
     )
 
     _args = ap.parse_args()
@@ -711,6 +787,9 @@ def main():
 
     if _args.do_compile:
         langtool.compile()
+
+    if _args.jit_mo:
+        langtool.check_and_compile()
 
 
 if __name__ == "__main__":

--- a/i18n/lang.py
+++ b/i18n/lang.py
@@ -21,6 +21,7 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 import urllib.parse
@@ -634,6 +635,36 @@ class LangTool:
                 print("Re-compiled due to translations: ", mo_file)
                 continue
 
+    def mk_new_lang(self, lang_code: str) -> None:
+        """
+        Makes all the required directories and files for a new language.
+        """
+        self._check_polib()
+        import polib  # pylint: disable=import-error,useless-suppression
+
+        langpath = self.basedir.joinpath(lang_code, "LC_MESSAGES")
+        logpath = langpath.joinpath(self._logs_pot_path.stem).with_suffix(".po")
+        msgpath = langpath.joinpath(self._msgs_pot_path.stem).with_suffix(".po")
+        if langpath.exists():
+            print("Language already exists with code: ", lang_code)
+            return
+
+        langpath.mkdir(parents=True)
+
+        shutil.copy(self._logs_pot_path, logpath)
+        po = polib.pofile(logpath)
+        po.metadata["Language"] = lang_code
+        po.metadata["Content-Type"] = "text/plain; charset=UTF-8"
+        po.save()
+        print("Created: ", logpath)
+
+        shutil.copy(self._msgs_pot_path, msgpath)
+        po = polib.pofile(msgpath)
+        po.metadata["Language"] = lang_code
+        po.metadata["Content-Type"] = "text/plain; charset=UTF-8"
+        po.save()
+        print("Created: ", msgpath)
+
 
 def main():
     """MusicBot i18n tool entry point."""
@@ -714,7 +745,7 @@ def main():
         help="Save stats to JSON for use in the repository. Use with -s option.",
     )
 
-    # option:  -sB  save_badges with do_stats
+    # option: -sB  save_badges with do_stats
     ap.add_argument(
         "-B",
         dest="save_badges",
@@ -741,6 +772,16 @@ def main():
         help="Update all missing translations in PO files with Argos-translate machine translations.",
     )
 
+    # option: --new  new_lang
+    ap.add_argument(
+        "--new",
+        dest="new_lang",
+        type=str,
+        default="",
+        metavar="LOCALE",
+        help="Create a new language with code LOCALE. This creates folders and PO files ready for translation.",
+    )
+
     # option: --jit-mo  jit_mo
     ap.add_argument(
         "--jit-mo",
@@ -763,6 +804,10 @@ def main():
         sys.exit(1)
 
     langtool = LangTool(_args, _basedir)
+
+    if _args.new_lang:
+        langtool.mk_new_lang(_args.new_lang)
+        sys.exit(0)
 
     if _args.do_diff_short or _args.do_diff_long:
         langtool.diff(short=not _args.do_diff_long)

--- a/i18n/msgfmt.py
+++ b/i18n/msgfmt.py
@@ -51,7 +51,7 @@ def usage(code, msg=""):
 
 def add(ctxt, msgid, msgstr, fuzzy):
     "Add a non-fuzzy translation to the dictionary."
-    global MESSAGES  # pylint: disable=global-variable-not-assigned
+    global MESSAGES  # noqa: F824  # pylint: disable=global-variable-not-assigned
     if not fuzzy and msgstr:
         if ctxt is None:
             MESSAGES[msgid] = msgstr
@@ -61,7 +61,7 @@ def add(ctxt, msgid, msgstr, fuzzy):
 
 def generate():
     "Return the generated output."
-    global MESSAGES  # pylint: disable=global-variable-not-assigned
+    global MESSAGES  # noqa: F824  # pylint: disable=global-variable-not-assigned
     # the keys are sorted in the .mo file
     keys = sorted(MESSAGES.keys())
     offsets = []

--- a/i18n/readme.md
+++ b/i18n/readme.md
@@ -23,6 +23,8 @@ Replace `xx` above with the locale code of your choice. Only one language code c
 For more info on these, use the `--help` launch option.  
 
 > **Note:**  Translations can also be used to customize the output of MusicBot without editing code!  
+> We recommend creating a "custom language" to avoid issues with updates.  
+> Simply copy the directory with the language you use and rename it `xx_custom` then add `--lang=xx_custom` to your launch arguments.  
 
 ## How MusicBot loads translations  
 
@@ -59,8 +61,13 @@ Of course, the `.pot` and `.po` files are just plain text.  So you can edit them
 
 ### How to compile `.mo` files.
 
-To compile the `.mo` files, you generally have two options.  
-If you used Poedit for translations, you can also use it to compile the `.po` into a `.mo` file.  
+MusicBot will automatically compile `.mo` files on start-up under any of these conditions:
+- The `.mo` file does not exist.  
+- The `.po` contains headers which are different from the `.mo` file.
+- The `.po` contains translations or changes not in the `.mo` file.
+
+To manually compile the `.mo` files, you generally have two options.  
+If you used [Poedit](https://poedit.net/) for translations, you can also use it to compile the `.po` into a `.mo` file.  
 
 If you edited using another editor, MusicBot provides an option in the `lang.py` script to enable compiling on any system.  
 Follow these steps to compile manually:  
@@ -138,35 +145,49 @@ The script provides these command line flags:
 - `-h` or `--help`  
   Shows the help message and exits.  
 
-- `-L`  
-  Select a single language code to operate on, instead of all installed.
+- `-L [LOCALE]`  
+  Select a single language code to run tasks on, instead of all installed languages.
 
 - `-c`  
-  Compile existing PO files into MO files.  
-  This requires the `polib` python package.  
+  Compile existing translation PO files into MO files.
+  This requires the `polib` python package.
 
 - `-e`  
-  Extract strings into POT files.
+  Extract strings from source-code to POT files (blank translation templates.)
 
 - `-d`  
-  Shows new changes to POT files without updating them.  
-  This ignores gettext location comment changes.
+  Show differences between source-code extractions and the existing POT files.  
+  Comments and line markers are hidden.  
 
 - `-D`  
-  Same as -d flat but show all changes, including comments.
+  Same as argument -d but shows all changes, including comments and line markers.  
 
 - `-t`  
-  Create or update the 'xx' test language.  
-  The translations are reversed source strings, used to test code changes.  
+  Create or update the 'xx' test language.
   This requires the `polib` python package.
 
 - `-s`  
-  Show translation stats for existing PO files, such as completion and number of missing translations.  
+  Show translation stats for existing PO files, by extracting strings from sources first.
+  This requires the `polib` python package.
+
+- `-J`  
+  Save stats to JSON for use in the repository.  
+  Use with -s option.
+
+- `-B`  
+  Save stats will save badges to use in the repository.  
+  Use with `-s` option.  
 
 - `-u`  
-  Extracts strings to POT files, then updates existing PO files with new strings.  
+  Update all existing translation files (PO & POT) from source-code.  
+  Existing translation files will have new strings to translate.  
   This requires the `polib` python package.
 
 - `-A`  
-  Attempt to automatically translate all untranslated strings using machine translations.  
+  Update all missing translations in PO files with Argos-translate machine translations.  
   This requires the `polib` as well as `argostranslate` and `marko` python packages.  
+
+- `--jit-mo`  
+  Automatically compile MO files if PO files contain different translations or headers.  
+  This requires the `polib` python package.
+

--- a/i18n/readme.md
+++ b/i18n/readme.md
@@ -2,114 +2,109 @@
 
 ![Translations: 66.2%](https://img.shields.io/badge/Translations-66.2%25-orange?style=flat-square)  
 
-MusicBot makes use of GNU Gettext for translation of display text.  
-We use the typical `.po`/`.mo` file format to enable translations and bundle a few 
-tools to aid contributors and users with aspects of gettext translation. 
-This readme details how we use Gettext in our code and how you can update or add translations.  
+MusicBot provides some support for translations and customized display text.  
+This guide will explain how you can make use of this feature for specific goals.  
 
-The language directories you'll find or add in `./i18n/` should be named using language codes which mostly conform to the [Locale-Names specification](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Locale-Names.html) by gettext.  
+<details>
+  <summary> Getting Started </summary>  
 
-By default, MusicBot will detect and use your system language, if translations are available.  
-To set a specific language, MusicBot provides these launch options:  
+## Getting started
 
-- `--log_lang=xx`  
-  To set log language only.  
-- `--msg_lang=xx`  
-  To set discord default language only.  
-- `--lang=xx`  
-  To set both log and discord language at once.  
+Before you begin, there are some details you should be aware of.  
 
-Replace `xx` above with the locale code of your choice. Only one language code can be set using these options.  
-For more info on these, use the `--help` launch option.  
+MusicBot provides two domains for text:  
+- `musicbot_logs` - Text shown primarilly in logs or console.  
+- `musicbot_messages` - Text shown primarilly on discord.  
 
-> **Note:**  Translations can also be used to customize the output of MusicBot without editing code!  
-> We recommend creating a "custom language" to avoid issues with updates.  
-> Simply copy the directory with the language you use and rename it `xx_custom` then add `--lang=xx_custom` to your launch arguments.  
+Translation files use the GNU Gettext file formats. Those are:  
+- `.pot` - A blank template, with text extracted from source code but no translations.
+- `.po` - Similar to POT, with full or partial translations and a specific language code.
+- `.mo` - A compiled version of PO file, used at runtime.  MusicBot will compile these automatically.  
 
-## How MusicBot loads translations  
+The `.po` and `.pot` files are plain-text files.  
+You can edit them with a dedicated translation editor, like [Poedit](https://poedit.net/) 
+or with a code/text editor application.  
+For plain-text editing, please read the [PO-Files](https://www.gnu.org/software/gettext/manual/gettext.html#PO-Files) section of Gettext manual for details on the contents of a PO file and specific meanings.  
 
-At start-up, MusicBot looks for language files based on a longest-match first.  
-For example, assume your system language is `en_GB`.  
-When MusicBot starts, it will scan `./i18n/en_GB/LC_MESSAGES/` for translation files with the `.mo` extension. If that fails, bot will look for a shorter version of the language code, in this case just `./i18n/en/...` instead.  
+Official languages use the Gettext [Locale-Names specification](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Locale-Names.html) for compatibility with system language codes.  
+Users should review the above specification when picking language codes for contributing new languages or to avoid conflicts between "custom" codes and official codes.  
 
-Note that the locale codes are case-sensitive, and MusicBot will look for a directory with the exact code you provide.
-
-> **Note:** On unix-like (Linux / Mac) systems, MusicBot makes use of the Environment Variables: `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG` in that order.  
-The first variable with a non-empty value is selected, and multiple languages may be specified in order of preference by separating them with a colon `:` character.  
-
-## How to add a new Language  
-
-Adding a new language to MusicBot is easy, and requires only a few tools.  Namely, an editor for the translations and an extra python package called `polib` to compile them. We will cover both later.  
-
-MusicBot provides some `.pot` files which contain texts extracted from the source code.  You can use these to create `.po` files containing translations for the language of your choice, which are use to compile the `.mo` translation files used by MusicBot.
-
-Here is a step by step break down of the process:  
-
-1. Pick a language code. For example: `es_ES` as in Spanish of Spain.  
-2. Create the new language directories.  
-   With the example code, the path is: `./i18n/es_ES/LC_MESSAGES/`  
-3. Copy the `.pot` files to the folder above, and rename them with `.po` extensions.  
-4. Update the `Language:` header with the language code.  
-5. Translate the strings and save the `.po` files.  
-6. Use an editor or the `lang.py` script to create `.mo` files.  
-7. Test your translations by launching with `run.sh --lang=es_ES`  
-
-### What editor to use
-
-To edit translations you'll need an editor.  Specific to Gettext, you might try [Poedit](https://poedit.net/), which is available for free on most desktop OS.  
-Of course, the `.pot` and `.po` files are just plain text.  So you can edit them with any text editor if you understand the PO file format. (Visit the Gettext manual to [understand the PO format](https://www.gnu.org/software/gettext/manual/gettext.html#PO-Files))
-
-### How to compile `.mo` files.
-
-MusicBot will automatically compile `.mo` files on start-up under any of these conditions:
-- The `.mo` file does not exist.  
-- The `.po` contains headers which are different from the `.mo` file.
-- The `.po` contains translations or changes not in the `.mo` file.
-
-To manually compile the `.mo` files, you generally have two options.  
-If you used [Poedit](https://poedit.net/) for translations, you can also use it to compile the `.po` into a `.mo` file.  
-
-If you edited using another editor, MusicBot provides an option in the `lang.py` script to enable compiling on any system.  
-Follow these steps to compile manually:  
-
-1. First, make sure you've downloaded the PO files into their respective language directories.  
-2. Double check the Language code in the PO file matches the code used in the language directory.
-3. Make sure you have the `polib` python package installed.  
-   You can use `pip install polib` or use your system's package manager to find and install the appropriate package.  
-4. Run the lang tool with `python3 lang.py -c` to compile all existing PO files.
-
-MusicBot should now be able to use the new translations!
+Lastly, MusicBot provides four ways to set language:  
+- Command line options:  
+  - `--lang=` - Set language for logs and discord text.  
+  - `--log_lang=` - Set language for only the log text.  
+  - `--msg_lang=` - Set language for only discord text.  
+- Runtime commands:  
+  - `language` - Set or reset a per-server language selection.  
+                 This will override command line options or the default language.  
 
 ---
 
-## Notes for Developers  
+</details>
 
-If you've never heard of Gettext before, getting started might be a little confusing.  For developers and users alike, you may find many answers to your questions about Gettext within the [GNU Gettext manual](https://www.gnu.org/software/gettext/manual/index.html)  
 
-### Basics of Gettext:
 
-- Files ending with `.pot` are templates, containing all the source strings but no translations.  
-  Plain text files that you edit to make `.po` files.  
-- Files ending with `.po` are fully or partially translated templates with a specific language code and meta data set.  
-  Also plain-text, multiple speakers of the selected language may collaborate with this file.
-- Files ending with `.mo` are compiled binary versions of the `.po` file, that make translation at runtime possible.  
-  MusicBot only looks for these when loading translations.
-- All changes to translations must be compiled into a `.mo` file before you can see them.
-- Translations must not change/rename or add placeholders, but may remove them entirely if needed.
+<details>
+  <summary> How To Customize Text </summary>
+
+## How to customize text
+
+To customize MusicBot text you have two options:  
+- Edit the source code directly.  
+- Edit a translation file.  
+
+We recommend copying an existing language and making edits to it.  
+This will make it easy to keep your changes when MusicBot updates, if there are changes to language files.  
+
+The basic steps are:  
+1. Copy your language folder, for example: `en_US`  
+2. Rename it but avoid using existing locale codes. For example: `xx_custom`  
+3. Next open the file `xx_custom/LC_MESSAGES/musicbot_messages.po` to make desired changes.
+4. Run the bot with `--lang=xx_custom` as a command line option.
+
+---
+
+</details>
+
+
+
+<details>
+  <summary> Adding a Language </summary>
+
+## Adding a new language
+
+Adding a language is almost as simple as customizing text, you only need the language code for your language of choice.  
+Follow these steps to add a new language:  
+1. Select a valid language code which conforms to the [Locale-Names specification](https://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/Locale-Names.html)
+2. Create the required files and folders using the language tool:  
+   `lang.py --new=LOCALE` replace `LOCALE` with your desired language code.
+3. Open the new `.po` files and start translating.
+
+---
+
+</details>
+
+
+
+<details>
+  <summary> Notes for Source Code </summary>
+
+## Notes for Source Code
 
 ### Placeholders in Strings:
 
 Regarding "placeholders", MusicBot sometimes needs to include variable data in output text.  
 To do this, we use traditional percent or modulo (`%`) formatting placeholders in Python that resembles C-style `sprintf` string formatting.  
-For example, the placeholders: `%(user)s` or `%s` get replaced at runtime.
+For example, the placeholders: `%(user)s` or `%s` get replaced at runtime with potentially non-translatable data.
 
 These placeholders can be removed from translated strings but must not be changed or added without complimentary source code changes.  
 Placeholders with no association in the source code will cause errors.  
+Placeholders removed from a string will not.  
 
 For details on how this style of formatting works, check out the [printf-style string formatting](https://docs.python.org/3.10/library/stdtypes.html#printf-style-string-formatting) section of the python manual.
 
 > **Note:** Some strings also contain variables in curly-braces (`{` and `}`) These may be used for simple substitutions in user-supplied data, like the bot status message.  
-They are not used by Python's format functions and if changed will quietly fail to substitute.  
+They are not used by Python's format functions and if changed may quietly fail to substitute.  
 
 ### Updating Source Strings
 
@@ -133,12 +128,31 @@ There are some important things to remember when changing strings in source code
    6. The `_D` and `_Dn` functions require an optional `GuildSpecificData` to enable per-server language selection.
 
 4. Finally, all changes and additional strings need to be extracted before they can be translated.  
-   Developers should make sure the POT files are up-to-date when submitting source code changes.
+   Developers should make sure to run `lang.py -u` to update the `.pot` and existing `.po` files when they make changes.  
 
-### Using the `lang.py` script:
+---
 
-MusicBot provides a bundled script named `lang.py` which can accomplish a number of translation related tasks.  
-Some options require the `polib` python package in order to be used.  
+</details>
+
+
+
+<details>
+  <summary> About Bundled Scripts </summary>  
+
+## About bundled scripts  
+
+The scripts contained in the `i18n` directory provide cross-platform tools to aid in translation tasks.  
+Each script supports the `-h` or `--help` command line option to display usage documentation.  
+
+A breif summary for each script file:  
+- `lang.py`  -  Language tool, the primary script used for most translation tasks.  
+- `msgfmt.py`  -  Modified version of python's msgfmt compatible utility.  
+- `pygettext.py`  -  Modified version of python's xgettext compatible utility.  
+
+<details>
+  <summary> lang.py command line options </summary>
+
+### `lang.py` Command line options:
 
 The script provides these command line flags:
 
@@ -187,7 +201,17 @@ The script provides these command line flags:
   Update all missing translations in PO files with Argos-translate machine translations.  
   This requires the `polib` as well as `argostranslate` and `marko` python packages.  
 
+- `--new [LOCALE]`  
+  Create a new language with code LOCALE.  
+  This creates folders and PO files ready for translation.  
+
 - `--jit-mo`  
   Automatically compile MO files if PO files contain different translations or headers.  
   This requires the `polib` python package.
+
+</details>
+
+---
+
+</details>
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 # Check if this script is being run on windows and redirect the user.  
 if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] ; then
     echo "install.sh is not for Windows.  Use the install.bat file instead."
-    sleep 5
+    read -rp "Press any key to exit."
     exit 2
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,14 @@
 # a variety of different Linux distros.
 # 
 
-# TODO: Venv install with pre-cloned repo needs fixed.
+#-----------------------------------------------------------------------------------------------------#
+# Check if this script is being run on windows and redirect the user.  
+if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] ; then
+    echo "install.sh is not for Windows.  Use the install.bat file instead."
+    sleep 5
+    exit 2
+fi
+
 
 #-----------------------------------------------Configs-----------------------------------------------#
 MusicBotGitURL="https://github.com/Just-Some-Bots/MusicBot.git"

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -331,27 +331,10 @@ class MusicBot(discord.Client):
                 self.config.spotify_enabled = False
                 time.sleep(5)  # make sure they see the problem
         else:
-            try:
-                log.warning(
-                    "The config did not have Spotify app credentials, attempting to use guest mode."
-                )
-                self.spotify = Spotify(
-                    None, None, aiosession=self.session, loop=self.loop
-                )
-                if not await self.spotify.has_token():
-                    log.warning("Spotify did not provide us with a token. Disabling.")
-                    self.config.spotify_enabled = False
-                else:
-                    log.info(
-                        "Authenticated with Spotify successfully using guest mode."
-                    )
-                    self.config.spotify_enabled = True
-            except exceptions.SpotifyError as e:
-                log.warning(
-                    "Could not start Spotify client using guest mode. Details: %s.",
-                    e.message % e.fmt_args,
-                )
-                self.config.spotify_enabled = False
+            log.warning(
+                "Your config does not have Spotify app credentials. Spotify support will not be available."
+            )
+            self.config.spotify_enabled = False
 
         log.info("Initialized, now connecting to discord.")
         # this creates an output similar to a progress indicator.

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -1174,9 +1174,21 @@ class MusicBot(discord.Client):
                     if potential_channel and potential_channel.guild == guild:
                         np_channel = potential_channel
                         break
+            elif self.config.bound_channels:
+                for potential_channel_id in self.config.bound_channels:
+                    potential_channel = self.get_channel(potential_channel_id)
+                    if isinstance(potential_channel, discord.abc.PrivateChannel):
+                        continue
 
-            if not np_channel and last_np_msg:
-                np_channel = last_np_msg.channel
+                    if not isinstance(potential_channel, discord.abc.Messageable):
+                        continue
+
+                    if potential_channel and potential_channel.guild == guild:
+                        np_channel = potential_channel
+                        break
+
+            if not np_channel and ssd_.last_np_channel:
+                np_channel = ssd_.last_np_channel  # type: ignore[assignment]
 
         content = Response("")
         if entry.thumbnail_url:

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -6340,6 +6340,7 @@ class MusicBot(discord.Client):
 
         # add the tracks to the embed fields
         tracks_list = ""
+        tracks_per_page = 0
         queue_segment = list(player.playlist.entries)[start_index:end_index]
         for idx, item in enumerate(queue_segment, starting_at):
             if item == player.current_entry:
@@ -6351,12 +6352,31 @@ class MusicBot(discord.Client):
             if item.channel and item.author:
                 added_by = item.author.name
 
-            tracks_list += _D(
+            # shorten the titles to get more tracks in the list.
+            title = item.title
+            if len(item.title) > 40:
+                title = item.title[:40] + " ..."
+
+            next_track_list = _D(
                 "**Entry #%(index)s:**"
                 "Title: `%(title)s`\n"
                 "Added by: `%(user)s`\n\n",
                 ssd_,
-            ) % {"index": idx, "title": _D(item.title, ssd_), "user": added_by}
+            ) % {"index": idx, "title": _D(title, ssd_), "user": added_by}
+            # We limit the track list, and leave extra space for the rest of the description text.
+            if (len(tracks_list) + len(next_track_list)) < 3840:
+                tracks_per_page += 1
+                tracks_list += next_track_list
+
+        if (
+            self.config.queue_length > tracks_per_page
+            and total_entry_count > self.config.queue_length
+        ):
+            log.warning(
+                "You may have QueueLength set too high! "
+                "The setting is %(option)d but we could only list %(count)d tracks.",
+                {"option": self.config.queue_length, "count": tracks_per_page},
+            )
 
         embed = Response(
             _D(

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3331,7 +3331,7 @@ class MusicBot(discord.Client):
         # fmt: on
         desc=_Dd(
             "Manage auto playlist files and per-guild settings.\n"
-            "Auto playlists use a their own queue, only playing when the main queue is empty."
+            "Auto playlists use their own queue, only playing when the main queue is empty."
         ),
         remap_subs={"+": "add", "-": "remove"},
     )

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -4426,17 +4426,18 @@ class MusicBot(discord.Client):
 
             # if the result has "entries" but it's empty, it might be a failed search.
             if "entries" in info and not info.entry_count:
-                if check_extractor(info.extractor, "youtube:search"):
+                if check_extractor(info.extractor, "search"):
                     # TOOD: UI, i18n stuff
                     raise exceptions.CommandError(
-                        "YouTube search returned no results for:  %(url)s",
-                        fmt_args={"url": song_url},
+                        "Search returned no results with %(extractor)s for:  %(url)s",
+                        fmt_args={"url": song_url, "extractor": info.extractor},
                     )
 
             # If the result has usable entries, we assume it is a playlist
+            # but with only one entry is may be a search result.
             listlen = 1
             track_title = ""
-            if info.has_entries:
+            if info.has_entries and info.entry_count > 1:
                 await self._do_playlist_checks(player, author, info)
 
                 num_songs = info.playlist_count or info.entry_count

--- a/musicbot/constructs.py
+++ b/musicbot/constructs.py
@@ -144,10 +144,15 @@ class GuildSpecificData:
 
     @property
     def last_np_msg(self) -> Optional[discord.Message]:
+        """
+        The last discord.Message object used for Now Playing, if any.
+        When this value is set, it will also cause `last_np_channel` to be updated.
+        """
         return self._last_np_msg
 
     @last_np_msg.setter
     def last_np_msg(self, value: Optional[discord.Message]) -> None:
+        """Update the last now playing message and the channel ID for future messages."""
         self._last_np_msg = value
         if value is not None:
             self._last_np_ch_id = value.channel.id

--- a/musicbot/constructs.py
+++ b/musicbot/constructs.py
@@ -473,10 +473,10 @@ class MusicBotResponse(discord.Embed):
                     fields += _D("%(value)s\n", ssd_) % {"value": field.value}
 
         # only pick one image if both thumbnail and image are set,
-        if self.image:
+        if self.image and self.image.url:
             # TRANSLATORS: text-only format for embed image or thumbnail.
             image = _D("%(url)s", ssd_) % {"url": self.image.url}
-        elif self.thumbnail:
+        elif self.thumbnail and self.thumbnail.url:
             image = _D("%(url)s", ssd_) % {"url": self.thumbnail.url}
 
         return _D(

--- a/musicbot/constructs.py
+++ b/musicbot/constructs.py
@@ -90,9 +90,10 @@ class GuildSpecificData:
         self._file_lock: asyncio.Lock = asyncio.Lock()
         self._loading_lock: asyncio.Lock = asyncio.Lock()
         self._is_file_loaded: bool = False
+        self._last_np_ch_id: int = 0
+        self._last_np_msg: Optional[discord.Message] = None
 
         # Members below are available for public use.
-        self.last_np_msg: Optional[discord.Message] = None
         self.last_played_song_subject: str = ""
         self.follow_user: Optional[discord.Member] = None
         self.auto_join_channel: Optional[
@@ -140,6 +141,32 @@ class GuildSpecificData:
         if not pl.loaded:
             await pl.load()
         return pl
+
+    @property
+    def last_np_msg(self) -> Optional[discord.Message]:
+        return self._last_np_msg
+
+    @last_np_msg.setter
+    def last_np_msg(self, value: Optional[discord.Message]) -> None:
+        self._last_np_msg = value
+        if value is not None:
+            self._last_np_ch_id = value.channel.id
+        else:
+            self._last_np_ch_id = 0
+
+    @property
+    def last_np_channel(self) -> Optional[discord.abc.Messageable]:
+        """Gets the last channel used in the guild for Now Playing messages."""
+        ch = None
+        if not self.is_ready():
+            return ch
+
+        if self._last_np_ch_id != 0:
+            guild = self._bot.get_guild(self.guild_id)
+            if guild:
+                ch = guild.get_channel_or_thread(self._last_np_ch_id)
+
+        return ch  # type: ignore[return-value]
 
     @property
     def guild_id(self) -> int:
@@ -249,6 +276,8 @@ class GuildSpecificData:
 
             self.lang_code = options.get("language", "")
 
+            self._last_np_ch_id = int(options.get("last_np_ch_id", 0))
+
             guild_prefix = options.get("command_prefix", None)
             if guild_prefix:
                 self._command_prefix = guild_prefix
@@ -290,6 +319,7 @@ class GuildSpecificData:
             "command_prefix": self._command_prefix,
             "auto_playlist": auto_playlist,
             "language": self.lang_code,
+            "last_np_ch_id": self._last_np_ch_id,
         }
 
         async with self._file_lock:

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -560,7 +560,7 @@ class Downloader:
             and len(data.get("entries", [])) == 1
             and isinstance(data.get("entries", None), list)
             and data.get("playlist_count", 0) == 1
-            and not any(song_subject.startswith(e) for e in self._supported_search)
+            and any(song_subject.startswith(e) for e in self._supported_search)
         ):
             log.noise(  # type: ignore[attr-defined]
                 "Extractor %(extractor)s returned single-entry result, replacing base info with entry info.",
@@ -569,7 +569,6 @@ class Downloader:
             entry_info = copy.deepcopy(data["entries"][0])
             for key in entry_info:
                 data[key] = entry_info[key]
-            del data["entries"]
 
         return data
 

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -70,7 +70,7 @@ class YtdlpLogHook:
 ytdl_format_options_immutable = MappingProxyType(
     {
         "format": "bestaudio/best",
-        "outtmpl": "%(extractor)s-%(id)s-%(title)s-%(qhash)s.%(ext)s",
+        "outtmpl": "%(extractor)s-%(id)s-%(title).64B-%(qhash)s.%(ext)s",
         "restrictfilenames": True,
         "noplaylist": True,
         "nocheckcertificate": True,

--- a/musicbot/i18n.py
+++ b/musicbot/i18n.py
@@ -6,6 +6,7 @@ import locale
 import logging
 import os
 import pathlib
+import subprocess
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union
 
@@ -110,6 +111,8 @@ class I18n:
     See I18n.install() for details on global functions.
     """
 
+    _i18n_compiled: bool = False
+
     def __init__(
         self,
         localedir: Optional[pathlib.Path] = None,
@@ -125,6 +128,16 @@ class I18n:
         :param: `msg_lang` An optional language selection for discord text that is prefered over defaults.
         :param: `auto_install` Automaticlly add global functions for translations.
         """
+        # Make sure all po changes are compiled to mo files.
+        # This is an Ouroboros. It's fine...
+        try:
+            if not I18n._i18n_compiled:
+                subprocess.check_call([sys.executable, "./i18n/lang.py", "--jit-mo"])
+                I18n._i18n_compiled = True
+        except (OSError, ValueError, subprocess.CalledProcessError):
+            I18n._i18n_compiled = True
+            print("Auto-compile MO files failed.")
+
         # set the path where translations are stored.
         if localedir:
             self._locale_dir: pathlib.Path = localedir

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ colorama >= 0.4.6; sys_platform == 'win32'
 cffi --only-binary all; sys_platform == 'win32'
 certifi
 configupdater
+polib

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,14 @@
 # make sure we're in MusicBot directory...
 cd "$(dirname "${BASH_SOURCE[0]}")" || { echo "Could not change directory to MusicBot."; exit 1; }
 
+
+# Check if this script is being run on windows and redirect the user.  
+if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] ; then
+    echo "run.sh is not for Windows.  Use the run.bat file instead."
+    sleep 5
+    exit 2
+fi
+
 # provides an exit that also deactivates venv.
 function do_exit() {
     if [ "${VIRTUAL_ENV}" != "" ] ; then

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")" || { echo "Could not change directory to Mus
 # Check if this script is being run on windows and redirect the user.  
 if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]] ; then
     echo "run.sh is not for Windows.  Use the run.bat file instead."
-    sleep 5
+    read -rp "Press any key to exit."
     exit 2
 fi
 


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.9 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR includes the following changes:  
- Cache file names have title values limited to 64 characters.  
- Now playing messages now attempt to use bound channel config if set.  
- Now playing messages now saves the last used channel ID between restarts.  
- Queue messages use shorter names to fit more tracks, and also issues a warning if your QueueLength is bigger than the number of tracks that can fit in the message.  
- Spotify Guest Mode is no longer available, and it has been removed.  
- Fixed a bug that caused markdown / text Responses to print "None" at the end of a message.  
- Prevent `.sh` scripts from being run on windows to avoid mix ups.
- Fixed play command treating search results like playlists even with 1 entry.  
- Added `polib` to requirements.txt for i18n tools.  
- Language files auto-compile on start-up.  
- Added `lang.py --new` to make adding new languages even easier.   
- Rewrote the i18n ReadMe to be less verbose.  