### PR TITLE
new feature: removerange

### DIFF
--- a/config/example_aliases.json
+++ b/config/example_aliases.json
@@ -26,6 +26,5 @@
     "latency": ["ping"],
     "summon": ["join", "connect", "come"],
     "disconnect": ["leave", "stop"],
-    "resume": ["unpause", "continue"],
-    "removerange": ["rangeremove"]
+    "resume": ["unpause", "continue"]
 }

--- a/config/example_aliases.json
+++ b/config/example_aliases.json
@@ -26,5 +26,6 @@
     "latency": ["ping"],
     "summon": ["join", "connect", "come"],
     "disconnect": ["leave", "stop"],
-    "resume": ["unpause", "continue"]
+    "resume": ["unpause", "continue"],
+    "removerange": ["rangeremove"]
 }

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -5411,7 +5411,7 @@ class MusicBot(discord.Client):
                     "Invalid entry number. Use the queue command to find queue positions.",
                 ) from e
 
-            if idx > len(player.playlist.entries):
+            if idx < 1 or idx > len(player.playlist.entries):
                 raise exceptions.CommandError(
                     "Invalid entry number. Use the queue command to find queue positions.",
                 )

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -5292,10 +5292,16 @@ class MusicBot(discord.Client):
         return Response(_D("Cleared all songs from the queue.", ssd_))
 
     @command_helper(
-        usage=["{cmd} [POSITION]"],
+        usage=[
+            "{cmd} <POSITION> <TO>\n"
+            + _Dd("    Remove song at POSITION.\n")
+            + "{cmd} <FROM> <TO>\n"
+            + _Dd("    Remove songs from position FROM to position TO.\n"),
+        ],
         desc=_Dd(
-            "Remove a song from the queue, optionally at the given queue position.\n"
-            "If the position is omitted, the song at the end of the queue is removed.\n"
+            "Remove a song from the queue at POSITION specified.\n"
+            "Remove multiple songs from the queue from position FROM to position TO specified.\n"
+            "If the position or positions are omitted, the song at the end of the queue is removed.\n"
             "Use the queue command to find position number of your track.\n"
             "However, positions of all songs are changed when a new song starts playing.\n"
         ),
@@ -5307,7 +5313,8 @@ class MusicBot(discord.Client):
         author: discord.Member,
         permissions: PermissionGroup,
         player: MusicPlayer,
-        index: str = "",
+        position: str,
+        leftover_args: List[str],
     ) -> CommandResponse:
         """
         Command to remove entries from the player queue using relative IDs or LIFO method.
@@ -5316,147 +5323,116 @@ class MusicBot(discord.Client):
         if not player.playlist.entries:
             raise exceptions.CommandError("Nothing in the queue to remove!")
 
-        if user_mentions:
-            for user in user_mentions:
-                if permissions.remove or author == user:
-                    try:
-                        entry_indexes = [
-                            e for e in player.playlist.entries if e.author == user
-                        ]
-                        for entry in entry_indexes:
-                            player.playlist.entries.remove(entry)
-                        entry_text = f"{len(entry_indexes)} item"
-                        if len(entry_indexes) > 1:
-                            entry_text += "s"
-                        return Response(
-                            _D("Removed `%(track)s` added by `%(user)s`", ssd_)
-                            % {"track": entry_text, "user": user.name},
-                        )
+        # removing range (2 positions used, FROM and TO)
+        if len(leftover_args) == 1:
+            indexes = []
+            try:
+                indexes.append(int(position) - 1)
+                indexes.append(int(leftover_args[0]) - 1)
+            except (ValueError, IndexError):
+                raise exceptions.CommandError("Song positions must be integers!")
 
-                    except ValueError as e:
-                        raise exceptions.CommandError(
-                            "Nothing found in the queue from user `%(user)s`",
-                            fmt_args={"user": user.name},
-                        ) from e
+            for i in indexes:
+                if i < 0 or i > len(player.playlist.entries) - 1:
+                    raise exceptions.CommandError(
+                        "Invalid positions. Use the queue command to find queue positions."
+                    )
 
+            # if wrong indices are the wrong order, simply reverse order
+            if indexes[0] > indexes[1]:
+                temp_index = indexes[0]
+                indexes[0] = indexes[1]
+                indexes[1] = temp_index
+
+            permission_to_remove = permissions.remove
+
+            # checks to see if all authors of entries to be removed is the same as the user running the cmd
+            if not permission_to_remove:
+                # Collects the authors of playlist entries from the given range
+                authors = [
+                    player.playlist.get_entry_at_index(idx).author
+                    for idx in range(indexes[0], indexes[1] + 1)
+                ]
+                permission_to_remove = set(authors) == {author}
+
+            if not permission_to_remove:
                 raise exceptions.PermissionsError(
-                    "You do not have the permission to remove that entry from the queue.\n"
-                    "You must be the one who queued it or have instant skip permissions.",
+                    "You do not have the permission to remove all the songs in the given range from the queue.\n"
                 )
 
-        if not index:
-            idx = len(player.playlist.entries)
-
-        try:
-            idx = int(index)
-        except (TypeError, ValueError) as e:
-            raise exceptions.CommandError(
-                "Invalid entry number. Use the queue command to find queue positions.",
-            ) from e
-
-        if idx > len(player.playlist.entries):
-            raise exceptions.CommandError(
-                "Invalid entry number. Use the queue command to find queue positions.",
-            )
-
-        if (
-            permissions.remove
-            or author == player.playlist.get_entry_at_index(idx - 1).author
-        ):
-            entry = player.playlist.delete_entry_at_index((idx - 1))
-            if entry.channel and entry.author:
-                return Response(
-                    _D("Removed entry `%(track)s` added by `%(user)s`", ssd_)
-                    % {"track": _D(entry.title, ssd_), "user": entry.author.name},
-                )
+            player.playlist.removerange(indexes[0], indexes[1])
 
             return Response(
-                _D("Removed entry `%(track)s`", ssd_)
-                % {"track": _D(entry.title, ssd_)},
-            )
-
-        raise exceptions.PermissionsError(
-            "You do not have the permission to remove that entry from the queue.\n"
-            "You must be the one who queued it or have instant skip permissions.",
-        )
-
-    @command_helper(
-        # fmt: off
-        usage=[
-            "{cmd} <FROM> <TO>\n"
-            + _Dd("    Remove songs at position FROM to position TO.\n"),
-        ],
-        # fmt: on
-        desc=_Dd(
-            "Use the queue command to find track position numbers.\n"
-            "However, positions of all songs are changed when a new song starts playing.\n"
-        ),
-    )
-    async def cmd_removerange(
-        self,
-        ssd_: Optional[GuildSpecificData],
-        permissions: PermissionGroup,
-        author: discord.Member,
-        player: MusicPlayer,
-        guild: discord.Guild,
-        channel: MessageableChannel,
-        command: str,
-        leftover_args: List[str],
-    ) -> CommandResponse:
-        """
-        Command to remove multiple entries from the player queue using relative IDs with FROM and TO position
-        """
-        if not player.current_entry:
-            return Response(
-                _D(
-                    "There are no songs queued. Play something with a play command.",
-                    ssd_,
-                ),
-            )
-
-        indexes = []
-        try:
-            indexes.append(int(command) - 1)
-            indexes.append(int(leftover_args[0]) - 1)
-        except (ValueError, IndexError):
-            raise exceptions.CommandError("Song positions must be integers!")
-
-        for i in indexes:
-            if i < 0 or i > len(player.playlist.entries) - 1:
-                raise exceptions.CommandError(
-                    "You gave a position outside the playlist size!"
-                )
-
-        # if wrong indices are the wrong order, simply reverse order
-        if indexes[0] > indexes[1]:
-            temp_index = indexes[0]
-            indexes[0] = indexes[1]
-            indexes[1] = temp_index
-        
-        # Collects the authors of playlist entries from the given range
-        authors = [
-            player.playlist.get_entry_at_index(idx).author
-            for idx in range(indexes[0], indexes[1] + 1)
-        ]
-        
-        if (not (permissions.remove or set(authors) == {author})) :
-            raise exceptions.PermissionsError(
-                "You do not have the permission to remove the songs in the given range from the queue.\n"
-            )
-
-        await self.safe_send_message(
-            channel,
-            Response(
                 _D(
                     "Successfully removed songs from position %(from)s in queue to position %(to)s!",
-                    self.server_data[guild.id],
+                    ssd_,
                 )
                 % {"from": indexes[0] + 1, "to": indexes[1] + 1},
-            ),
-        )
-        
-        player.playlist.removerange(indexes[0], indexes[1])
-        return None
+            )
+        else:
+            if user_mentions:
+                for user in user_mentions:
+                    if permissions.remove or author == user:
+                        try:
+                            entry_indexes = [
+                                e for e in player.playlist.entries if e.author == user
+                            ]
+                            for entry in entry_indexes:
+                                player.playlist.entries.remove(entry)
+                            entry_text = f"{len(entry_indexes)} item"
+                            if len(entry_indexes) > 1:
+                                entry_text += "s"
+                            return Response(
+                                _D("Removed `%(track)s` added by `%(user)s`", ssd_)
+                                % {"track": entry_text, "user": user.name},
+                            )
+
+                        except ValueError as e:
+                            raise exceptions.CommandError(
+                                "Nothing found in the queue from user `%(user)s`",
+                                fmt_args={"user": user.name},
+                            ) from e
+
+                    raise exceptions.PermissionsError(
+                        "You do not have the permission to remove that entry from the queue.\n"
+                        "You must be the one who queued it or have instant skip permissions.",
+                    )
+
+            if not position:
+                idx = len(player.playlist.entries)
+
+            try:
+                idx = int(position)
+            except (TypeError, ValueError) as e:
+                raise exceptions.CommandError(
+                    "Invalid entry number. Use the queue command to find queue positions.",
+                ) from e
+
+            if idx > len(player.playlist.entries):
+                raise exceptions.CommandError(
+                    "Invalid entry number. Use the queue command to find queue positions.",
+                )
+
+            if (
+                permissions.remove
+                or author == player.playlist.get_entry_at_index(idx - 1).author
+            ):
+                entry = player.playlist.delete_entry_at_index((idx - 1))
+                if entry.channel and entry.author:
+                    return Response(
+                        _D("Removed entry `%(track)s` added by `%(user)s`", ssd_)
+                        % {"track": _D(entry.title, ssd_), "user": entry.author.name},
+                    )
+
+                return Response(
+                    _D("Removed entry `%(track)s`", ssd_)
+                    % {"track": _D(entry.title, ssd_)},
+                )
+
+            raise exceptions.PermissionsError(
+                "You do not have the permission to remove that entry from the queue.\n"
+                "You must be the one who queued it or have instant skip permissions.",
+            )
 
     @command_helper(
         usage=["{cmd} [force | f]"],

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -5293,15 +5293,18 @@ class MusicBot(discord.Client):
 
     @command_helper(
         usage=[
-            "{cmd} <POSITION> <TO>\n"
-            + _Dd("    Remove song at POSITION.\n")
-            + "{cmd} <FROM> <TO>\n"
+            "{cmd} [POSITION]\n"
+            + _Dd("    Remove a song at the end of the queue or at [POSITION].\n"),
+            "{cmd} <FROM> <TO>\n"
             + _Dd("    Remove songs from position FROM to position TO.\n"),
+            "{cmd} <@USER>\n"
+            + _Dd("    Remove songs added by the mentioned user.\n"),
         ],
         desc=_Dd(
             "Remove a song from the queue at POSITION specified.\n"
             "Remove multiple songs from the queue from position FROM to position TO specified.\n"
-            "If the position or positions are omitted, the song at the end of the queue is removed.\n"
+            "Remove all songs from the queue added by the mentioned user.\n"
+            "If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
             "Use the queue command to find position number of your track.\n"
             "However, positions of all songs are changed when a new song starts playing.\n"
         ),
@@ -5313,8 +5316,8 @@ class MusicBot(discord.Client):
         author: discord.Member,
         permissions: PermissionGroup,
         player: MusicPlayer,
-        position: str,
-        leftover_args: List[str],
+        position: str = "",
+        leftover_args: List[str] = [],
     ) -> CommandResponse:
         """
         Command to remove entries from the player queue using relative IDs or LIFO method.

--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -5381,6 +5381,84 @@ class MusicBot(discord.Client):
         )
 
     @command_helper(
+        # fmt: off
+        usage=[
+            "{cmd} <FROM> <TO>\n"
+            + _Dd("    Remove songs at position FROM to position TO.\n"),
+        ],
+        # fmt: on
+        desc=_Dd(
+            "Use the queue command to find track position numbers.\n"
+            "However, positions of all songs are changed when a new song starts playing.\n"
+        ),
+    )
+    async def cmd_removerange(
+        self,
+        ssd_: Optional[GuildSpecificData],
+        permissions: PermissionGroup,
+        author: discord.Member,
+        player: MusicPlayer,
+        guild: discord.Guild,
+        channel: MessageableChannel,
+        command: str,
+        leftover_args: List[str],
+    ) -> CommandResponse:
+        """
+        Command to remove multiple entries from the player queue using relative IDs with FROM and TO position
+        """
+        if not player.current_entry:
+            return Response(
+                _D(
+                    "There are no songs queued. Play something with a play command.",
+                    ssd_,
+                ),
+            )
+
+        indexes = []
+        try:
+            indexes.append(int(command) - 1)
+            indexes.append(int(leftover_args[0]) - 1)
+        except (ValueError, IndexError):
+            raise exceptions.CommandError("Song positions must be integers!")
+
+        for i in indexes:
+            if i < 0 or i > len(player.playlist.entries) - 1:
+                raise exceptions.CommandError(
+                    "You gave a position outside the playlist size!"
+                )
+
+        # if wrong indices are the wrong order, simply reverse order
+        if indexes[0] > indexes[1]:
+            temp_index = indexes[0]
+            indexes[0] = indexes[1]
+            indexes[1] = temp_index
+        
+        # Collects the authors of playlist entries from the given range
+        authors = [
+            player.playlist.get_entry_at_index(idx).author
+            for idx in range(indexes[0], indexes[1] + 1)
+        ]
+        
+        if (not (permissions.remove or set(authors) == {author})) :
+            raise exceptions.PermissionsError(
+                "You do not have the permission to remove the songs in the given range from the queue.\n"
+            )
+
+        await self.safe_send_message(
+            channel,
+            Response(
+                _D(
+                    "Successfully removed songs from position %(from)s in queue to position %(to)s!",
+                    self.server_data[guild.id],
+                )
+                % {"from": indexes[0] + 1, "to": indexes[1] + 1},
+            ),
+        )
+        
+        player.playlist.removerange(indexes[0], indexes[1])
+        return None
+
+    @command_helper(
         usage=["{cmd} [force | f]"],
         desc=_Dd(
             "Skip or vote to skip the current playing song.\n"

--- a/musicbot/playlist.py
+++ b/musicbot/playlist.py
@@ -71,6 +71,18 @@ class Playlist(EventEmitter, Serializable):
         """Clears the deque of entries."""
         self.entries.clear()
 
+    def removerange(self, start: int, end: int) -> None:
+        """Clears a range of the deque of entries."""
+        if start == 0:
+            for i in range(end - start + 1):
+                self.entries.popleft()
+        elif end == len(self.entries) - 1:
+            for i in range(end - start + 1):
+                self.entries.pop()
+        else:
+            # Reconstruct the deque excluding the range [a, b]
+            self.entries = deque(list(self.entries)[:start] + list(self.entries)[end+1:])
+
     def get_entry_at_index(self, index: int) -> EntryTypes:
         """
         Uses deque rotate to seek to the given `index` and reference the


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [✓] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [✓] I have tested my changes on Python 3.8 or higher
- [] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
Introduced a new feature to remove a specified range that is queued to play. Useful for when a entire playlist is queued, but you would like to remove a range of songs from playing.

I tried to take example of implementation from cmd_move (multiple values passed in) and the permissions from cmd_remove

### Related issues (if applicable)

