### PR TITLE
Add Concurrency to speed up downloads.

### DIFF
--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -301,14 +301,14 @@ YtdlpUserAgent =
 # To allow either IPv4 or v6, set this to:  *
 YtdlpSourceAddress = *
 
+#Set the number of concurrent fragment downloads.
+YtdlpConcurrentFrags = 1
+
 # Toggle the user block list feature, without emptying the block list.
 EnableUserBlocklist = yes
 
 # Enable the song block list feature, without emptying the block list.
 EnableSongBlocklist = no
-
-#Set the number of concurrent fragment downloads.
-ConcurrentDownloads = 1
 
 [Files]
 # An optional file path to a text file listing Discord User IDs, one per line.

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -307,6 +307,9 @@ EnableUserBlocklist = yes
 # Enable the song block list feature, without emptying the block list.
 EnableSongBlocklist = no
 
+#Set the number of concurrent fragment downloads.
+ConcurrentDownloads = 1
+
 [Files]
 # An optional file path to a text file listing Discord User IDs, one per line.
 UserBlocklistFile = 

--- a/config/example_options.ini
+++ b/config/example_options.ini
@@ -301,7 +301,8 @@ YtdlpUserAgent =
 # To allow either IPv4 or v6, set this to:  *
 YtdlpSourceAddress = *
 
-#Set the number of concurrent fragment downloads.
+#Sets the number of threads to use for native hls and dash downloads. 
+#It is likely to increase network load exponentially, use caution.
 YtdlpConcurrentFrags = 1
 
 # Toggle the user block list feature, without emptying the block list.

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -988,6 +988,15 @@ class Config:
             comment=_Dd(
                 "Enable the song block list feature, without emptying the block list."
             ),
+        self.concurrent_fragment_downloads: int = self.register.init_option(
+            section="MusicBot",
+            option="ConcurrentDownloads",
+            dest="concurrent_fragment_downloads",
+            default=ConfigDefaults.concurrent_fragment_downloads,
+            getter="getint",
+            comment=_Dd(
+                "Set the number of concurrent fragment downloads."
+            ),
         )
 
         ########################################################################
@@ -1551,6 +1560,7 @@ class ConfigDefaults:
     ytdlp_proxy: str = ""
     ytdlp_user_agent: str = ""
     ytdlp_source_address: str = "*"
+    concurrent_fragment_downloads = 1
 
     pre_download_next_song: bool = True
     default_search_service: str = "ytsearch"

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -988,9 +988,10 @@ class Config:
             comment=_Dd(
                 "Enable the song block list feature, without emptying the block list."
             ),
+        )
         self.concurrent_fragment_downloads: int = self.register.init_option(
             section="MusicBot",
-            option="ConcurrentDownloads",
+            option="YtdlpConcurrentFrags",
             dest="concurrent_fragment_downloads",
             default=ConfigDefaults.concurrent_fragment_downloads,
             getter="getint",

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -85,6 +85,7 @@ ytdl_format_options_immutable = MappingProxyType(
         "usenetrc": True,
         "no_color": True,
         "retries": 1,
+        "concurrent_fragment_downloads": 16,
     }
 )
 

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -85,7 +85,7 @@ ytdl_format_options_immutable = MappingProxyType(
         "usenetrc": True,
         "no_color": True,
         "retries": 1,
-        "concurrent_fragment_downloads": 16,
+        "concurrent_fragment_downloads": None,
     }
 )
 
@@ -140,6 +140,10 @@ class Downloader:
         if bot.config.ytdlp_source_address != "*":
             ytdl_format_options["source_address"] = bot.config.ytdlp_source_address
 
+        # apply download concurrency settings.
+        if bot.config.concurrent_fragment_downloads != "1":
+            ytdl_format_options["concurrent_fragment_downloads"] = bot.config.concurrent_fragment_downloads
+        
         # enable verbose ytdlp logs if debug mode is enabled.
         if bot.config.debug_mode:
             ytdl_format_options["no_warnings"] = False


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
The PR merely adds the `concurrent_fragment_downloads` option configured at 16 concurrent downloads to the downloader.py to speed up downloads when someone from your server decides to have a 10 hour long sound playing on the background as a joke and the download reads "50 minutes" to be completed, ultimately defeating his tomfoolery.

https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L511
https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/downloader/fragment.py#L38


### Related issues (if applicable)

