### PR TITLE
Remove optional speed components from discord.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pynacl
-#discord.py [voice, speed] >= 2.4.0
-discord.py [voice, speed] @ git+https://github.com/Rapptz/discord.py
+#discord.py [voice] >= 2.4.0
+discord.py [voice] @ git+https://github.com/Rapptz/discord.py
 pip
 yt-dlp
 colorlog


### PR DESCRIPTION
The optional speed components often complicate or break installs due to compatibility issues in different environments.   They can be added by users as needed or desired rather than being a default requirement.  

This change has been tested by a user and reported as working via discord, so I'm adding it to get ahead of further issues.  