### PR TITLE
Update for EJS, deno, and py 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 ~*/
 .vscode/
 *.service
-*.coverage
+.coverage*
 
 audio_cache/
 dectalk/

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![GitHub stars](https://img.shields.io/github/stars/Just-Some-Bots/MusicBot.svg)](https://github.com/Just-Some-Bots/MusicBot/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/Just-Some-Bots/MusicBot.svg)](https://github.com/Just-Some-Bots/MusicBot/network)
-[![Python version](https://img.shields.io/badge/python-3.9%20to%203.13-blue.svg)](https://python.org)
+[![Python version](https://img.shields.io/badge/python-3.10%20to%203.13-blue.svg)](https://python.org)
 [![Translations: 66.2%](https://img.shields.io/badge/Translations-66.2%25-yellow)](./i18n/readme.md)
 [![Discord](https://discordapp.com/api/guilds/129489631539494912/widget.png?style=shield)](https://discord.gg/bots)  
 
 
-MusicBot is the original Discord music bot written for [Python](https://www.python.org "Python homepage") 3.9 to 3.13, using the [discord.py](https://github.com/Rapptz/discord.py) library. It plays requested songs from YouTube and other services into a Discord server (or multiple servers). If the queue is empty, MusicBot will play a list of existing songs that is configurable. The bot features a permission system, allowing owners to restrict commands to certain people. MusicBot is capable of streaming live media into a voice channel.
+MusicBot is the original Discord music bot written for [Python](https://www.python.org "Python homepage") 3.10 to 3.13, using the [discord.py](https://github.com/Rapptz/discord.py) library. It plays requested songs from YouTube and other services into a Discord server (or multiple servers). If the queue is empty, MusicBot will play a list of existing songs that is configurable. The bot features a permission system, allowing owners to restrict commands to certain people. MusicBot is capable of streaming live media into a voice channel.
 
 ![Main](https://i.imgur.com/FWcHtcS.png)
 

--- a/i18n/en_US/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/en_US/LC_MESSAGES/musicbot_logs.po
@@ -1,10 +1,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
-"PO-Revision-Date: 2025-03-12 22:29-0700\n"
+"PO-Revision-Date: 2025-05-02 07:02-0700\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
 "Language: en_US\n"
@@ -156,7 +156,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify did not provide us with a token. Disabling."
 
@@ -175,63 +175,43 @@ msgstr ""
 "Could not start Spotify client. Is your client ID and secret correct? "
 "Details: %s. Continuing anyway in 5 seconds..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Authenticated with Spotify successfully using guest mode."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr "Could not start Spotify client using guest mode. Details: %s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Initialized, now connecting to discord."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Network ping test is disabled via config."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "Network ping test is closing down."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "Could not resolve ping target."
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Network ping test cancelled."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Network testing via HTTP does not have a session to borrow."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "Could not locate `ping` executable in your environment."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -245,7 +225,7 @@ msgstr ""
 "Alternatively disable network checking via config."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -259,7 +239,7 @@ msgstr ""
 "Alternatively disable network checking via config."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -273,28 +253,28 @@ msgstr ""
 "Alternatively disable network checking via config."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "MusicBot detected network is available again."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "Voiceprint is not connected, waiting to resume Multiplayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Resuming playback of player:  (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot detected a network outage."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -302,7 +282,7 @@ msgstr ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -312,144 +292,144 @@ msgstr ""
 "got:  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "Checking for channels to auto-join or resume..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr "Guild not available, cannot auto join:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr "Will try resuming voice session instead of Auto-Joining channel:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Found owner in voice channel:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Discarding MusicPlayer and making a new one..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot will make a new MusicPlayer now..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Finished joining configured channels."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Member is not voice-enabled and cannot use this command."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "You cannot use this command when not in the voice channel."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Getting bot Application Info."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot does not have permission to Connect in channel:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot does not have permission to Speak in channel:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Reusing bots VoiceClient from guild:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "Forcing disconnect on stale VoiceClient in guild:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "Disconnect failed or was cancelled?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "MusicBot is unable to connect to the channel right now:  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -458,12 +438,12 @@ msgstr ""
 "Try again later, or restart the bot if this continues."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot has a VoiceClient now..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -473,54 +453,54 @@ msgstr ""
 "connect to:  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr "MusicBot VoiceClient connection attempt was cancelled. No retry."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot is requesting to speak in channel: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot does not have permission to speak."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot could not request to speak."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Disconnecting a MusicPlayer in guild:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Disconnecting VoiceClient before we kill the MusicPlayer."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "The disconnect failed or was cancelled."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -529,18 +509,18 @@ msgstr ""
 "anyway..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Disconnecting a rogue VoiceClient in guild:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Disconnecting a non-guild VoiceClient..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -550,19 +530,19 @@ msgstr ""
 "The object is actually of type:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Guild (%(guild)s) wants a player, optional:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -571,24 +551,24 @@ msgstr ""
 "restart the bot."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer has a VoiceClient that is not connected."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "MusicPlayer obj:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -598,7 +578,7 @@ msgstr ""
 "Create: %(create)s  Deserialize:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -608,7 +588,7 @@ msgstr ""
 "entries"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -617,84 +597,84 @@ msgstr ""
 "Use the summon command to bring the bot to your voice channel."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Something is wrong, we didn't get the VoiceClient."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "Running on_player_play"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Setting URL history guild %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "No thumbnail set for entry with URL: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "no channel to put now playing message into"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "ignored now-playing message as it was already posted."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "Running on_player_resume"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "Running on_player_pause"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Running on_player_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Running on_player_finished_playing"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "Event loop is closed, nothing else to do here."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Logout under way, ignoring this event."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr "VoiceClient says it is not connected, nothing else we can do here."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "Player finished and queue is empty, leaving voice channel..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr "Looping over queue to expunge songs with missing author..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -702,290 +682,290 @@ msgstr ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr "No playable songs in the Guild autoplaylist, disabling."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "No content in current autoplaylist. Filling with new music..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Looping over player autoplaylist..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Error while processing song \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Error extracting song \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot needs to stop the auto playlist extraction and bail."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr "MusicBot got an unhandled exception in player finished event."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr "Expanding auto playlist with entries extracted from:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "Error adding song from autoplaylist: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Exception data for above error:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "No playable songs in the autoplaylist, disabling."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "Running on_player_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr "Automatically skipping auto-playlist entry for queued entry."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "MusicPlayer exception for entry: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "MusicPlayer exception."
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "Auto playlist track could not be played:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "Logout under way, ignoring status update event."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Update bot status:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Serializing queue for %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Deserializing queue for %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Writing current song for %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "Cannot send non-response object:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Tried sending an invalid response object."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "sending embed to: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "sending text to: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "Cannot send message to \"%s\", no permission"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "Cannot send message to \"%s\", invalid or deleted channel"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "Message is over the message size limit (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr "Could not send private message, sending in fallback channel instead."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr "Rate limited send message, retrying in %s seconds."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Cancelled message retry for:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "Rate limited send message, but cannot retry!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "Failed to send message in fallback channel."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Failed to send due to an HTTP error."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "Cannot delete message \"%s\", no permission"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "Cannot delete message \"%s\", message not found"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr "Rate limited message delete, retrying in %s seconds."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "Rate limited message delete, but cannot retry!"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Failed to delete message"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Got HTTPException trying to delete message: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "Cannot edit message \"%s\", message not found"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Sending message instead"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr "Rate limited edit message, retrying in %s seconds."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Cancelled message edit for:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Failed to edit message"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Got HTTPException trying to edit message %s to: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Cancelled delete for message (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Caught a signal from the OS: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Disconnecting and closing down MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "Exception thrown while handling interrupt signal!"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot is now doing shutdown steps..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1008,44 +988,44 @@ msgstr ""
 "  Check API status at the official site: discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "Waiting for download threads to finish up..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Will wait for task:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Will try to cancel task:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "Awaiting pending tasks..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Closing HTTP Connector."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Closing aiohttp session."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "Logout has been called."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1055,80 +1035,80 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Exception in %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot resumed a session with discord."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Finish on_ready"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Logged in, now getting MusicBot ready..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "ClientUser is somehow none, we gotta bail..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Owner:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Guild List:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "Left %s due to bot owner not found"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr "Not proceeding with checks in %s servers due to unavailability"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "Owner could not be found on any guild (id: %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Owner unknown, bot is not on any guilds."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1142,247 +1122,247 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Got None for bound channel with ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "Cannot bind to non Messageable channel with ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Bound to text channels:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "Not bound to any text channels"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "Got None for auto join channel with ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr "Cannot auto join to non-connectable channel with ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Auto joining voice channels:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "Not auto joining any voice channels"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "Event on_ready has fired %s times"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Getting application info."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "Ensuring data folders exist"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Validating config"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Validating permissions config"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Disabled"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Enabled"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Options:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Command prefix: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  Default volume: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Skip threshold: %(num)d votes or %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Now Playing @mentions: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Auto-Playlist: %(status)s (order: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "random"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "sequential"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Auto-Pause: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Delete Messages: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Delete Invoking: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Delete Now Playing: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Debug Mode: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  Downloaded songs will be %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Delete if unused for %d days"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Status message: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Spotify integration: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Timeout: %s seconds"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Timeout: %d seconds"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Self Deafen: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Per-server command prefix: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Round Robin Queue: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "The requested song `%(subject)s` is blocked by the song block list."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "Channel activity already waiting in guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1390,31 +1370,31 @@ msgstr ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "Channel activity timer for %s has expired. Disconnecting."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Channel activity timer canceled for: %(channel)s in %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Ignoring player inactivity in auto-joined channel:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "Player activity timer already waiting in guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1422,129 +1402,129 @@ msgstr ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "Player activity timer for %s has expired. Disconnecting."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Player activity timer canceled for: %(channel)s in %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Player activity timer is being reset."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "No such command"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "You must mention a user or provide their ID number."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "Invalid sub-command given. Use `help blockuser` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot could not find the user(s) you specified."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "The owner cannot be added to the block list."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr "Not removing user from block list, not listed:  %(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Cannot add the users you listed, they are already added."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "You must provide a song subject if no song is currently playing."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "Invalid sub-command given. Use `help blocksong` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Subject `%(subject)s` is already in the song block list."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "The subject is not in the song block list and cannot be removed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "The supplied song link is invalid"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "The queue is empty. Add some songs with a play command!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "This song is already in the autoplaylist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "This song is not yet in the autoplaylist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "You must provide a playlist filename."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "You are not allowed to request playlists"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "Playlist has too many entries (%(songs)s but max is %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1556,12 +1536,12 @@ msgstr ""
 "The limit is %(max)s for your group."
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Ignoring auto-pause due to network outage."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1570,12 +1550,12 @@ msgstr ""
 "pause."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Already processing auto-pause, ignoring this event."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1585,55 +1565,55 @@ msgstr ""
 "guild:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "Auto-pause waiting was cancelled."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr "A new MusicPlayer is being connected, ignoring old auto-pause event."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr "Playing in an empty voice channel, running auto pause for guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "Previously auto paused player is unpausing for guild: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Cannot use seek if there is nothing playing."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "Cannot use seek on current track, it has an unknown duration."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Seeking is not supported for streams."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "Cannot use seek without a time to position playback."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Could not convert `%(input)s` to a valid time in seconds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1643,66 +1623,66 @@ msgstr ""
 " a length of `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Invalid sub-command. Use the command `help repeat` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "The player is not currently looping."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Song positions must be integers!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "You gave a position outside the playlist size!"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 "Could not prompt for playlist playback, no message to add reactions to."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Local media playback is not enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL is invalid or not currently supported."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Detected a Spotify URL, but Spotify is not enabled."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "You have reached your enqueued song limit (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke mode is enabled, please try again when its disabled!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Issue with extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1712,15 +1692,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "That video cannot be played. Try using the stream command."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "YouTube search returned no results for:  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1827,18 +1801,18 @@ msgid "Player is not playing."
 msgstr "Player is not playing."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Nothing in the queue to remove!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nothing found in the queue from user `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1847,38 +1821,38 @@ msgstr ""
 "You must be the one who queued it or have instant skip permissions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Invalid entry number. Use the queue command to find queue positions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Can't skip! The player is not playing!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "You do not have permission to force skip a looped song."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "You do not have permission to force skip."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "You do not have permission to skip a looped song."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` is not a valid number"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1888,7 +1862,7 @@ msgstr ""
 "Volume can only be set from 1 to 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1896,7 +1870,7 @@ msgstr ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1905,28 +1879,28 @@ msgstr ""
 "Use the config command to set a default playback speed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Speed cannot be applied to streamed media."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "You must provide a speed to set."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "The speed you provided is invalid. Use a number between 0.5 and 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Invalid option for command: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1936,28 +1910,28 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "You must supply an alias and a command to alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "You must supply an alias name to remove."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Config cannot use channel and user mentions at the same time."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1967,7 +1941,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1976,17 +1950,17 @@ msgstr ""
 "section and option name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "The option given is ambiguous, please provide a section name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "You must provide a section name and option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1996,97 +1970,97 @@ msgstr ""
 "The available sections are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "The option `%(option)s` is not available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Option `%(option)s` is not editable. Cannot save to disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Failed to save the option:  `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` is not editable, value cannot be displayed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Option `%(option)s` is not editable. Cannot update setting."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "You must provide a section, option, and value for this sub command."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Doing set with on %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` was not updated!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "Option `%(option)s` is not editable. Cannot reset to default."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Resetting %(config)s to default %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` was not reset to default!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "The option command is deprecated, use the config command instead."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Invalid option specified, use: info, update, or clear"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**Failed** to delete cache, check logs for more info..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Queue page argument must be a whole number."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "There are no songs queued! Queue something with a play command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2096,22 +2070,22 @@ msgstr ""
 "There are **%(total)s** pages."
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "Skipped the current playlist entry."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "Not enough entries to paginate the queue."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr "Could not post queue message, no message to add reactions to."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2120,17 +2094,17 @@ msgstr ""
 "If the issue persists, file a bug report."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Cannot use purge on private DM channel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "The given URL was not a valid URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2140,12 +2114,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "This does not seem to be a playlist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2154,17 +2128,17 @@ msgstr ""
 "again."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Could not determine the discord User.  Try again."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Permissions cannot use channel and user mentions at the same time."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2174,23 +2148,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "You must provide a group or option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "You must provide a group, option, and value to set for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "The %(option)s sub-command requires a group and permission name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2200,47 +2174,47 @@ msgstr ""
 "The available groups are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "The permission `%(option)s` is not available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Cannot add group `%(group)s` it already exists."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Cannot remove built-in group."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "The owner group is not editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Failed to save the group:  `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Doing set on %(option)s with value: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` was not updated!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2249,7 +2223,7 @@ msgstr ""
 "Remember name changes are limited to twice per hour.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2259,12 +2233,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Unable to change nickname: no permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2274,12 +2248,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Custom emoji must be from this server to use as a prefix."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2288,28 +2262,28 @@ msgstr ""
 "Use the config command to update the prefix instead."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "This command can only be used in guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "Invalid sub-command given. Use the help command for more information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Cannot set language to `%(locale)s` it is not available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "You must provide a URL or attach a file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2319,63 +2293,63 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot found a %s with no guild!  This could be a problem."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Not currently connected to server `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "You must provide an ID or name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No guild was found with the ID or name `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Activating debug breakpoint ID: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Could not import `objgraph`, is it installed?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Debug code ran with eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Debug code ran with exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "Debug code failed to execute."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2391,54 +2365,54 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Sub-command must be one of: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Could not locate git executable."
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "Failed while checking for updates via git command."
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Package missing meta in pip report."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr "Failed to get pip update status due to some error."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Got a strange voice client entry."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies already enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Could not enable cookies due to error:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2448,154 +2422,154 @@ msgstr ""
 "Cookies temporarily disabled and will be re-enabled on next restart."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 "No attached uploads were found, try again while uploading a cookie file."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "Could not remove old, disabled cookies file:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Error downloading the cookies file from discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Could not save cookies to disk:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Got a message with no channel, somehow:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignoring command from myself (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignoring command from other bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignoring command from channel of type:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Message from %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "This command is not allowed for your permissions group:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "This command requires you to be in a Voice channel."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "Invalid command usage, missing values for params: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Error in %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Exception while handling command: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Cannot generate help for missing command:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Missing help data for command:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Leaving voice channel %s in %s due to inactivity."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot has become connected."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot has become disconnected."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Got a Socket Event:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState updated before on_ready finished"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignoring %s in %s as it is a bound voice channel."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s has been detected as empty. Handling timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "A user joined %s, cancelling timer."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2603,30 +2577,30 @@ msgstr ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "The bot got moved and the voice channel %s is not empty."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "No longer following user %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Following user `%(user)s` to channel:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState disconnect before.channel is None."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2636,97 +2610,97 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Reconnecting to auto-joined guild on channel:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Cannot auto join channel:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Bot has been added to guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Left guild '%s' due to bot owner not found."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Creating data folder for guild %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Bot has been removed from guild: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Updated guild list:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Guild \"%s\" has become available."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Resuming player in \"%s\" due to availability."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Guild \"%s\" has become unavailable."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausing player in \"%s\" due to unavailability."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Guild update for:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Channel update for:  %(channel)s  --  %(changes)s"
@@ -2744,7 +2718,7 @@ msgid "Loading config from:  %s"
 msgstr "Loading config from:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2774,7 +2748,7 @@ msgstr ""
 "  Use the example options as a template or copy it from the repository."
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2784,7 +2758,7 @@ msgstr ""
 "instead."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2793,7 +2767,7 @@ msgstr ""
 " Using default instead."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2812,12 +2786,12 @@ msgstr ""
 "  Make sure the path you configured is a path to a folder / directory."
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "An exception was thrown while validating AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2839,13 +2813,13 @@ msgstr ""
 "  Double check the setting is a valid, accessible directory path."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Audio Cache will be stored in:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2865,7 +2839,7 @@ msgstr ""
 "  Set the Token config option or set environment variable %(env_var)s with an App token."
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2874,7 +2848,7 @@ msgstr ""
 "characters."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2884,17 +2858,17 @@ msgstr ""
 "of %.3f will be limited instead."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Validating options with service data..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "Acquired owner ID via API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2915,12 +2889,12 @@ msgstr ""
 "  Manually set the 'OwnerID' config option or try again later."
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot does not have a user instance, cannot proceed."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2939,12 +2913,12 @@ msgstr ""
 "  Do not use the Bot or App ID in the 'OwnerID' field."
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "Config options file not found. Checking for alternatives..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2954,18 +2928,18 @@ msgstr ""
 "extensions on."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copying existing example options file:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr "Something went wrong while trying to find a config option file."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2987,7 +2961,7 @@ msgstr ""
 "  Verify the config folder and files exist and can be read by MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3011,12 +2985,12 @@ msgstr ""
 "  Copy the example file from the repo if all else fails."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! Config option has getter that is not available."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3025,43 +2999,43 @@ msgstr ""
 " type."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "Option was missing previously."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Config section not in parsed config! Missing: %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Saved config option: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Failed to save config:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Failed to save default INI file at:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3081,7 +3055,7 @@ msgstr ""
 "  Set %(option)s to a numerical ID or set it to `auto` or `0` for automatic owner binding."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3101,7 +3075,7 @@ msgstr ""
 "  Check the path setting and make sure the file exists and is accessible to MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3121,7 +3095,7 @@ msgstr ""
 "  Ensure all IDs are numerical, and separated only by spaces or commas."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3131,7 +3105,7 @@ msgstr ""
 "%(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3141,7 +3115,7 @@ msgstr ""
 " default instead."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3151,7 +3125,7 @@ msgstr ""
 "(%(value)s) and will be set to %(fallback)s instead."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3159,139 +3133,139 @@ msgstr ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Upgrading config file with renamed options..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "Failed to upgrade config.  You'll need to upgrade it manually."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Block list file not found:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Could not load block list from file:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Could not update the block list file:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Loaded User Block list with %s entries."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "We found a legacy blacklist file, it will be renamed to:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Loaded a Song Block list with %s entries."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "No file for guild %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "Loading guild data for guild with ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "An OS error prevented reading guild data file:  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr "Could not save guild specific data due to OS Error."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr "Failed to serialize guild specific data due to invalid data."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Forcing YTDLP to use User Agent:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot will use cookies for yt-dlp from:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp will use your configured proxy server."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD seems to have no headers..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr "Checking media headers failed due to timeout."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Failed HEAD request for:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "HEAD Request exception: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3301,84 +3275,84 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Sanitized YTDL Extraction Info (not JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Song info extraction returned no data."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Cannot continue extraction, event loop is closed."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL is invalid or not supported."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Download Error with stream URL"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "Assuming content is a direct stream"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Cannot stream an invalid URL."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Called safe_extract_info with:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "The local media file could not be found."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Missing __input_subject from YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Warning, duration error for: %(url)s"
@@ -3424,12 +3398,12 @@ msgstr ""
 "Entry name:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr "Entry data is missing version number, cannot deserialize."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr "Entry data has the wrong version number, cannot deserialize."
 
@@ -3459,7 +3433,7 @@ msgstr ""
 "Deserialized URLPlaylistEntry has an author ID but no channel for lookup!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "Could not load %s"
@@ -3471,7 +3445,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr "Cannot download Spotify links, processing error with type: %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Getting ready for entry:  %r"
@@ -3493,7 +3467,7 @@ msgid "Download already cached at:  %s"
 msgstr "Download already cached at:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3511,7 +3485,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Got duration of %(time)s seconds for file:  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3522,75 +3496,75 @@ msgstr ""
 "work, but will mean your tracks will not be equalized."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Exception while checking entry data."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Trying to get duration via pymediainfo for:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "Failed to get duration via pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Trying to get duration via ffprobe for:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "Could not locate ffprobe in your path!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe returned something that could not be used."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe could not be executed for some reason."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Calculating mean volume of:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "Could not locate ffmpeg on your path!"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "Could not parse 'I' in normalize json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "Could not parse 'LRA' in normalize json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "Could not parse 'TP' in normalize json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "Could not parse 'thresh' in normalize json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "Could not parse 'offset' in normalize json."
 
@@ -3633,78 +3607,78 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Download failed due to a yt-dlp error: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "Extraction encountered an unhandled exception."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "Download failed due to an unhandled exception: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Download failed:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Failed to extract data for the requested media."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Download complete:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3713,7 +3687,7 @@ msgstr ""
 "lookup!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Got duration of %(seconds)s seconds for file:  %(file)s"
@@ -3822,19 +3796,19 @@ msgstr ""
 "%(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Lang Argument Error:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr "Failed to load log translations for any of:  [%s]  in:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4160,63 +4134,63 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Decoded data from ffmpeg: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Adding stream entry for URL:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Could not extract information"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "This is a playlist."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr "Entry info appears to be a stream, adding stream entry..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Invalid content type `%(type)s` for URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "Got text/html for content-type, this might be a stream."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Questionable content-type \"%(type)s\" for url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Adding URLPlaylistEntry for: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Adding LocalFilePlaylistEntry for: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "Ignored video from compound playlist link with ID:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4224,7 +4198,7 @@ msgstr ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4232,46 +4206,46 @@ msgstr ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr "Not adding YouTube video because it is marked private or deleted:  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "Could not add item"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Item: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "Skipped %s bad entries"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Reorder looping over entries."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Pre-downloading next track:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "no duration data"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "no duration data in current entry"
 
@@ -4842,42 +4816,42 @@ msgstr ""
 "contain values compatible with strftime().  (Default:  '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Version:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "Opened a new MusicBot instance. This terminal can be safely closed!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Loading MusicBot version:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Log opened:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Changing working directory to:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4888,7 +4862,7 @@ msgstr ""
 "location."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4897,7 +4871,7 @@ msgstr ""
 "If you did not use git to clone the repository, you are strongly urged to."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4906,12 +4880,12 @@ msgstr ""
 "exiting."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Here is the exact error, it could be a bug."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4920,7 +4894,7 @@ msgstr ""
 "you can open the failing site in Microsoft Edge or IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -4929,17 +4903,17 @@ msgstr ""
 "instead."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Syntax error (modification detected, did you edit the code?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Syntax error (this is a bug, not your fault)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4960,12 +4934,12 @@ msgstr ""
 "  or launch without `--no-install-deps` and MusicBot will try to install them for you."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "Attempting to install MusicBot dependency packages automatically...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5001,12 +4975,12 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, lets hope installing dependencies worked!"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5015,58 +4989,58 @@ msgstr ""
 "exit..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "The exception which caused the above error: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot is doing a soft restart..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot is doing a full process restart..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Error starting bot"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Closing event loop."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Restarting in %s seconds..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "All done."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "OK, we're closing!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr "MusicBot is now doing start up steps..."
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr "Start up failed at login."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr "No playlist file exists with the name: `%(playlist)s`"
@@ -5093,12 +5067,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr "OS level error while trying to delete queue file: %(path)s"
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr "Generating new config options files..."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5120,7 +5094,7 @@ msgstr ""
 "  Make sure MusicBot can read and write to your config files.\n"
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5207,45 +5181,45 @@ msgstr ""
 "MusicBot must have permission to create this directory.\n"
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr "Private Channel"
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr "Unknown User DM"
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr "User DM: %(name)s"
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr "Unknown Channel (Partial)"
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr "Unnamed Channel: %(id)s"
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr "Unknown Channel"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Unknown"
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
@@ -5257,180 +5231,180 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr "  Command by @mention: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr "  Command aliases: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr "    Legacy skip: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr "    Author insta-skip: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr "  Auto-join Owner's voice channel: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr "    Save per-server queue history: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr "    Save global queue history: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr "    Remove URLs on extraction error: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr "    Skip playlist for user requests: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr "  Songs blocklist: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr "  Users blocklist: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr "    Delete if cache exceeds %s"
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr "  Pre-download next track: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr "  Write current song title to file: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr "  Respond with Embeds: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr "    Footer Text Disabled"
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr "    Footer Text:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr "  Leave servers where Owner is not a member: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr "  Disconnect from inactive channel: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr "  Disconnect at end of queue: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr "  Disconnect when player idles: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr "  Search using reactions: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr "    Results per search: %d"
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr "  Local media files: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr "  Network checking ping tests: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr "  Audio processed with: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr "  Equalize audio level per-track: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr "  HTTP Proxy set to:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr "  User Agent set to:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
@@ -5439,40 +5413,40 @@ msgstr ""
 "channels."
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr "Caller server has a bound channel, caller channel ignored."
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr "Caller server has no bound channel, caller allowed."
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr "Unbound channel (%s) in server:  %s"
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr "Starting Command Tests..."
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr "Buffered command: %(cmd)s"
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5504,30 +5478,30 @@ msgstr ""
 "\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr "You must be in a voice channel to use this command."
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr "AutoPlaylist requested:  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading media data: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading stream data: %(raw_error)s"
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5537,18 +5511,18 @@ msgstr ""
 "with entry info."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr "The playlist does not exist."
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr "Could not process track '%(track)s' due to: %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5631,6 +5605,75 @@ msgid "musicbot module is not importable"
 msgstr "musicbot module is not importable"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr "Updating example config files..."
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr "Search returned no results with %(extractor)s for:  %(url)s"
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr "Invalid positions. Use the queue command to find queue positions."
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr "YTDLP thinks there may be a bug in processing."
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""

--- a/i18n/en_US/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/en_US/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2025-05-02 07:02-0700\n"
@@ -465,20 +465,20 @@ msgstr ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot is requesting to speak in channel: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot does not have permission to speak."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot could not request to speak."
 
@@ -613,7 +613,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Setting URL history guild %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "No thumbnail set for entry with URL: %s"
@@ -697,19 +697,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Looping over player autoplaylist..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Error while processing song \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Error extracting song \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot needs to stop the auto playlist extraction and bail."
 
@@ -1079,7 +1079,7 @@ msgstr "Guild List:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1634,7 +1634,7 @@ msgid "The player is not currently looping."
 msgstr "The player is not currently looping."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Song positions must be integers!"
 
@@ -1656,33 +1656,33 @@ msgid "Local media playback is not enabled."
 msgstr "Local media playback is not enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL is invalid or not currently supported."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Detected a Spotify URL, but Spotify is not enabled."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "You have reached your enqueued song limit (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke mode is enabled, please try again when its disabled!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Issue with extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1692,12 +1692,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "That video cannot be played. Try using the stream command."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1707,7 +1707,7 @@ msgstr ""
 "%(time_per).2f s/song"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1715,104 +1715,104 @@ msgstr ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "Extracted an entry with 'youtube:playlist' as extractor key"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Song duration exceeds limit (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Added song(s) at position %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "Cannot estimate time until playing for position: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "Failed to get info from the stream request: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Streaming playlists is not yet supported."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "You have reached your playlist item limit (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 "Please specify a search query.  Use `help search` for more information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "You cannot search for more than %(max)s videos"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "Waiting for summon lock: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Summon lock acquired for: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "You are not connected to voice. Try joining a voice channel!"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Joining %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot cannot follow a user that is not a member of the server."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Player is not playing."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Nothing in the queue to remove!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nothing found in the queue from user `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1821,38 +1821,38 @@ msgstr ""
 "You must be the one who queued it or have instant skip permissions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Invalid entry number. Use the queue command to find queue positions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Can't skip! The player is not playing!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "You do not have permission to force skip a looped song."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "You do not have permission to force skip."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "You do not have permission to skip a looped song."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` is not a valid number"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1862,7 +1862,7 @@ msgstr ""
 "Volume can only be set from 1 to 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1870,7 +1870,7 @@ msgstr ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1879,28 +1879,28 @@ msgstr ""
 "Use the config command to set a default playback speed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Speed cannot be applied to streamed media."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "You must provide a speed to set."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "The speed you provided is invalid. Use a number between 0.5 and 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Invalid option for command: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1910,28 +1910,28 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "You must supply an alias and a command to alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "You must supply an alias name to remove."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Config cannot use channel and user mentions at the same time."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1941,7 +1941,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1950,17 +1950,17 @@ msgstr ""
 "section and option name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "The option given is ambiguous, please provide a section name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "You must provide a section name and option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1970,97 +1970,97 @@ msgstr ""
 "The available sections are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "The option `%(option)s` is not available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Option `%(option)s` is not editable. Cannot save to disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Failed to save the option:  `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` is not editable, value cannot be displayed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Option `%(option)s` is not editable. Cannot update setting."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "You must provide a section, option, and value for this sub command."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Doing set with on %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` was not updated!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "Option `%(option)s` is not editable. Cannot reset to default."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Resetting %(config)s to default %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` was not reset to default!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "The option command is deprecated, use the config command instead."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Invalid option specified, use: info, update, or clear"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**Failed** to delete cache, check logs for more info..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Queue page argument must be a whole number."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "There are no songs queued! Queue something with a play command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2070,22 +2070,22 @@ msgstr ""
 "There are **%(total)s** pages."
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "Skipped the current playlist entry."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "Not enough entries to paginate the queue."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr "Could not post queue message, no message to add reactions to."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2094,17 +2094,17 @@ msgstr ""
 "If the issue persists, file a bug report."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Cannot use purge on private DM channel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "The given URL was not a valid URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2114,12 +2114,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "This does not seem to be a playlist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2128,17 +2128,17 @@ msgstr ""
 "again."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Could not determine the discord User.  Try again."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Permissions cannot use channel and user mentions at the same time."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2148,23 +2148,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "You must provide a group or option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "You must provide a group, option, and value to set for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "The %(option)s sub-command requires a group and permission name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2174,47 +2174,47 @@ msgstr ""
 "The available groups are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "The permission `%(option)s` is not available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Cannot add group `%(group)s` it already exists."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Cannot remove built-in group."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "The owner group is not editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Failed to save the group:  `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Doing set on %(option)s with value: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` was not updated!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2223,7 +2223,7 @@ msgstr ""
 "Remember name changes are limited to twice per hour.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2233,12 +2233,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Unable to change nickname: no permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2248,12 +2248,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Custom emoji must be from this server to use as a prefix."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2262,28 +2262,28 @@ msgstr ""
 "Use the config command to update the prefix instead."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "This command can only be used in guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "Invalid sub-command given. Use the help command for more information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Cannot set language to `%(locale)s` it is not available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "You must provide a URL or attach a file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2293,63 +2293,63 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot found a %s with no guild!  This could be a problem."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Not currently connected to server `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "You must provide an ID or name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No guild was found with the ID or name `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Activating debug breakpoint ID: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Could not import `objgraph`, is it installed?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Debug code ran with eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Debug code ran with exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "Debug code failed to execute."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2365,54 +2365,54 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Sub-command must be one of: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Could not locate git executable."
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "Failed while checking for updates via git command."
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Package missing meta in pip report."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr "Failed to get pip update status due to some error."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Got a strange voice client entry."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies already enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Could not enable cookies due to error:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2422,154 +2422,154 @@ msgstr ""
 "Cookies temporarily disabled and will be re-enabled on next restart."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 "No attached uploads were found, try again while uploading a cookie file."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "Could not remove old, disabled cookies file:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Error downloading the cookies file from discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Could not save cookies to disk:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Got a message with no channel, somehow:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignoring command from myself (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignoring command from other bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignoring command from channel of type:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Message from %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "This command is not allowed for your permissions group:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "This command requires you to be in a Voice channel."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "Invalid command usage, missing values for params: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Error in %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Exception while handling command: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Cannot generate help for missing command:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Missing help data for command:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Leaving voice channel %s in %s due to inactivity."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot has become connected."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot has become disconnected."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Got a Socket Event:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState updated before on_ready finished"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignoring %s in %s as it is a bound voice channel."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s has been detected as empty. Handling timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "A user joined %s, cancelling timer."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2577,30 +2577,30 @@ msgstr ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "The bot got moved and the voice channel %s is not empty."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "No longer following user %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Following user `%(user)s` to channel:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState disconnect before.channel is None."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2610,97 +2610,97 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Reconnecting to auto-joined guild on channel:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Cannot auto join channel:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Bot has been added to guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Left guild '%s' due to bot owner not found."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Creating data folder for guild %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Bot has been removed from guild: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Updated guild list:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Guild \"%s\" has become available."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Resuming player in \"%s\" due to availability."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Guild \"%s\" has become unavailable."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausing player in \"%s\" due to unavailability."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Guild update for:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Channel update for:  %(channel)s  --  %(changes)s"
@@ -2718,7 +2718,7 @@ msgid "Loading config from:  %s"
 msgstr "Loading config from:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2748,7 +2748,7 @@ msgstr ""
 "  Use the example options as a template or copy it from the repository."
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2758,7 +2758,7 @@ msgstr ""
 "instead."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2767,7 +2767,7 @@ msgstr ""
 " Using default instead."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2786,12 +2786,12 @@ msgstr ""
 "  Make sure the path you configured is a path to a folder / directory."
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "An exception was thrown while validating AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2813,13 +2813,13 @@ msgstr ""
 "  Double check the setting is a valid, accessible directory path."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Audio Cache will be stored in:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2839,7 +2839,7 @@ msgstr ""
 "  Set the Token config option or set environment variable %(env_var)s with an App token."
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2848,7 +2848,7 @@ msgstr ""
 "characters."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2858,17 +2858,17 @@ msgstr ""
 "of %.3f will be limited instead."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Validating options with service data..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "Acquired owner ID via API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2889,12 +2889,12 @@ msgstr ""
 "  Manually set the 'OwnerID' config option or try again later."
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot does not have a user instance, cannot proceed."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2913,12 +2913,12 @@ msgstr ""
 "  Do not use the Bot or App ID in the 'OwnerID' field."
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "Config options file not found. Checking for alternatives..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2928,18 +2928,18 @@ msgstr ""
 "extensions on."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copying existing example options file:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr "Something went wrong while trying to find a config option file."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2961,7 +2961,7 @@ msgstr ""
 "  Verify the config folder and files exist and can be read by MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2985,12 +2985,12 @@ msgstr ""
 "  Copy the example file from the repo if all else fails."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! Config option has getter that is not available."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -2999,43 +2999,43 @@ msgstr ""
 " type."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "Option was missing previously."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Config section not in parsed config! Missing: %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Saved config option: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Failed to save config:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Failed to save default INI file at:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3055,7 +3055,7 @@ msgstr ""
 "  Set %(option)s to a numerical ID or set it to `auto` or `0` for automatic owner binding."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3075,7 +3075,7 @@ msgstr ""
 "  Check the path setting and make sure the file exists and is accessible to MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3095,7 +3095,7 @@ msgstr ""
 "  Ensure all IDs are numerical, and separated only by spaces or commas."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3105,7 +3105,7 @@ msgstr ""
 "%(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3115,7 +3115,7 @@ msgstr ""
 " default instead."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3125,7 +3125,7 @@ msgstr ""
 "(%(value)s) and will be set to %(fallback)s instead."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3133,47 +3133,47 @@ msgstr ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Upgrading config file with renamed options..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "Failed to upgrade config.  You'll need to upgrade it manually."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Block list file not found:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Could not load block list from file:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Could not update the block list file:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Loaded User Block list with %s entries."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "We found a legacy blacklist file, it will be renamed to:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Loaded a Song Block list with %s entries."
@@ -3233,39 +3233,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Forcing YTDLP to use User Agent:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot will use cookies for yt-dlp from:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp will use your configured proxy server."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD seems to have no headers..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr "Checking media headers failed due to timeout."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Failed HEAD request for:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "HEAD Request exception: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3275,84 +3275,84 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Sanitized YTDL Extraction Info (not JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Song info extraction returned no data."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Cannot continue extraction, event loop is closed."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL is invalid or not supported."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Download Error with stream URL"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "Assuming content is a direct stream"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Cannot stream an invalid URL."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Called safe_extract_info with:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "The local media file could not be found."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Missing __input_subject from YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Warning, duration error for: %(url)s"
@@ -4619,13 +4619,13 @@ msgstr ""
 "Check for ffmpeg with your system package manager or build from sources."
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "Less than %sMB of free space remains on this device"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4634,12 +4634,12 @@ msgstr ""
 "Checking for updates to MusicBot or dependencies..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "No MusicBot updates available via `git` command."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4648,23 +4648,23 @@ msgstr ""
 "manually."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "The following packages can be updated:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  to version:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "No dependency updates available via `pip` command."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4673,7 +4673,7 @@ msgstr ""
 "manually."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4683,35 +4683,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "Value is above the maximum limit."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "Value must not be negative."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "Value for Max Logs Kept must be a number from 0 to %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "Log level '%s' is not available."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "Log Level must be one of:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4720,39 +4720,39 @@ msgstr ""
 "ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Available via GitHub:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr "For more help and support with this bot, join our discord:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "This software is provided under the MIT License."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "See the `LICENSE` text file for complete details."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 "Override the default / system detected language for all text in MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr "Use this language for all server-side log messages from MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4761,27 +4761,27 @@ msgstr ""
 "This does not prevent per-guild language selection."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Print the MusicBot version information and exit."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr "Skip all optional startup checks, including the update check."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Skip only the disk space check at startup."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Skip only the update check at startup."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -4790,7 +4790,7 @@ msgstr ""
 "them."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4800,13 +4800,13 @@ msgstr ""
 "%s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr "Override the log level settings set in config. Must be one of: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4816,42 +4816,42 @@ msgstr ""
 "contain values compatible with strftime().  (Default:  '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Version:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "Opened a new MusicBot instance. This terminal can be safely closed!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Loading MusicBot version:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Log opened:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Changing working directory to:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4862,7 +4862,7 @@ msgstr ""
 "location."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4871,7 +4871,7 @@ msgstr ""
 "If you did not use git to clone the repository, you are strongly urged to."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4880,12 +4880,12 @@ msgstr ""
 "exiting."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Here is the exact error, it could be a bug."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4894,7 +4894,7 @@ msgstr ""
 "you can open the failing site in Microsoft Edge or IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -4903,17 +4903,17 @@ msgstr ""
 "instead."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Syntax error (modification detected, did you edit the code?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Syntax error (this is a bug, not your fault)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4934,12 +4934,12 @@ msgstr ""
 "  or launch without `--no-install-deps` and MusicBot will try to install them for you."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "Attempting to install MusicBot dependency packages automatically...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4975,57 +4975,43 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, lets hope installing dependencies worked!"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "The exception which caused the above error: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot is doing a soft restart..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot is doing a full process restart..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Error starting bot"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Closing event loop."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Restarting in %s seconds..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "All done."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "OK, we're closing!"
 
@@ -5046,14 +5032,14 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr "No playlist file exists with the name: `%(playlist)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 "There is nothing currently playing. Play something with a play command."
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
@@ -5061,18 +5047,18 @@ msgstr ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr "OS level error while trying to delete queue file: %(path)s"
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr "Generating new config options files..."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5094,7 +5080,7 @@ msgstr ""
 "  Make sure MusicBot can read and write to your config files.\n"
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5170,7 +5156,7 @@ msgid "Failed to clean up write-test path."
 msgstr "Failed to clean up write-test path."
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5404,7 +5390,7 @@ msgid "  User Agent set to:  %s"
 msgstr "  User Agent set to:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
@@ -5413,17 +5399,17 @@ msgstr ""
 "channels."
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr "Caller server has a bound channel, caller channel ignored."
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr "Caller server has no bound channel, caller allowed."
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr "Unbound channel (%s) in server:  %s"
@@ -5483,25 +5469,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr "You must be in a voice channel to use this command."
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr "AutoPlaylist requested:  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading media data: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading stream data: %(raw_error)s"
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5511,72 +5497,22 @@ msgstr ""
 "with entry info."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr "The playlist does not exist."
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr "Could not process track '%(track)s' due to: %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr "Checking for Python 3.9+"
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr "Python 3.9+ is required. This version is %s"
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr "Attempting to locate Python 3.9..."
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr "Could not execute `py.exe -3.9` "
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr "Trying \"python3.9\""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr "Could not locate python3.9 on path."
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
-msgstr ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 
 #. Used by: critical
 #: run.py:485
@@ -5605,7 +5541,7 @@ msgid "musicbot module is not importable"
 msgstr "musicbot module is not importable"
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr "Updating example config files..."
 
@@ -5619,18 +5555,18 @@ msgstr ""
 "be available."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr "Search returned no results with %(extractor)s for:  %(url)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr "Invalid positions. Use the queue command to find queue positions."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
@@ -5639,7 +5575,7 @@ msgstr ""
 "from the queue.\n"
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5654,26 +5590,146 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr "YTDLP thinks there may be a bug in processing."
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "The exception which caused the above error: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr "Checking for Python 3.9+"
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr "Python 3.9+ is required. This version is %s"
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr "Attempting to locate Python 3.9..."
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr "Could not execute `py.exe -3.9` "
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr "Trying \"python3.9\""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr "Could not locate python3.9 on path."
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"

--- a/i18n/en_US/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/en_US/LC_MESSAGES/musicbot_messages.po
@@ -1,10 +1,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
-"PO-Revision-Date: 2025-03-13 10:11-0700\n"
+"PO-Revision-Date: 2025-05-02 07:02-0700\n"
 "Last-Translator: \n"
 "Language-Team: English\n"
 "Language: en_US\n"
@@ -42,29 +42,29 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Member is not voice-enabled and cannot use this command."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "You cannot use this command when not in the voice channel."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -73,24 +73,24 @@ msgstr ""
 "Try again later, or restart the bot if this continues."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot does not have permission to speak."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot could not request to speak."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -99,12 +99,12 @@ msgstr ""
 "Use the summon command to bring the bot to your voice channel."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Something is wrong, we didn't get the VoiceClient."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -112,31 +112,31 @@ msgstr ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr "Now playing automatically added entry `%(title)s` in %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr "Skipping songs added by %(user)s as they are not in voice!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -148,12 +148,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Tried sending an invalid response object."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -176,13 +176,13 @@ msgstr ""
 "  Check API status at the official site: discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "The requested song `%(subject)s` is blocked by the song block list."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -191,30 +191,30 @@ msgstr ""
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
 "Show usage and description of a command, or list all available commands.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Aliases for this command:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "`%(alias)s` alias of `%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -225,7 +225,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -237,12 +237,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "No such command"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -252,7 +252,7 @@ msgstr ""
 "For a list of all commands, run: %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -274,22 +274,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Block a mentioned user."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Unblock a mentioned user."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Show the block status of a mentioned user."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -298,42 +298,42 @@ msgstr ""
 "Blocked users are forbidden from using all bot commands.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "You must mention a user or provide their ID number."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "Invalid sub-command given. Use `help blockuser` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot could not find the user(s) you specified."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "The owner cannot be added to the block list."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "User block list is currently enabled."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "User block list is currently disabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Cannot add the users you listed, they are already added."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -343,24 +343,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "None of those users are in the blacklist."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "User: `%(user)s` is not blocked.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "User: `%(user)s` is blocked.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -372,7 +372,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -382,7 +382,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -399,23 +399,23 @@ msgstr ""
 "This means adding 'Pie' will match 'cherry Pie' but not 'piecrust' in checks.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "You must provide a song subject if no song is currently playing."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "Invalid sub-command given. Use `help blocksong` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Subject `%(subject)s` is already in the song block list."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -425,12 +425,12 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "The subject is not in the song block list and cannot be removed."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -440,7 +440,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -449,12 +449,12 @@ msgstr ""
 " current playlist.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Adds the entire queue to the guilds playlist.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -463,67 +463,67 @@ msgstr ""
 "playlist.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "The supplied song link is invalid"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "The queue is empty. Add some songs with a play command!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "All songs in the queue are already in the autoplaylist."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "Added %(number)d songs to the autoplaylist."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "Added `%(url)s` to the autoplaylist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "This song is already in the autoplaylist."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "Removed `%(url)s` from the autoplaylist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "This song is not yet in the autoplaylist."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Loaded a fresh copy of the playlist: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "You must provide a playlist filename."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -532,20 +532,20 @@ msgstr ""
 "This playlist is new, you must add songs to save it to disk!"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr "The playlist for this server has been updated to: `%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 "Generate an invite link that can be used to add this bot to another server."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -555,7 +555,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -564,28 +564,28 @@ msgstr ""
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "You are not allowed to request playlists"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "Playlist has too many entries (%(songs)s but max is %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -597,12 +597,12 @@ msgstr ""
 "The limit is %(max)s for your group."
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "Bot was previously paused, resuming playback now."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -619,7 +619,7 @@ msgstr ""
 "MusicBot also supports Spotify URIs and URLs, but audio is fetched from YouTube regardless.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -628,13 +628,13 @@ msgstr ""
 "queue.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "Shuffled playlist items into the queue from `%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -643,7 +643,7 @@ msgstr ""
 "Read help for the play command for information on supported inputs.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -652,7 +652,7 @@ msgstr ""
 "Read help for the play command for information on supported inputs.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -665,33 +665,33 @@ msgstr ""
 "Due to codec specifics in ffmpeg, this may not be accurate.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Cannot use seek if there is nothing playing."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "Cannot use seek on current track, it has an unknown duration."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Seeking is not supported for streams."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "Cannot use seek without a time to position playback."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Could not convert `%(input)s` to a valid time in seconds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -701,7 +701,7 @@ msgstr ""
 " a length of `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -709,7 +709,7 @@ msgstr ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -720,63 +720,63 @@ msgstr ""
 "If no option is provided and the song is already repeating, repeating will be turned off.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr "No songs are currently playing. Play something with a play command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Invalid sub-command. Use the command `help repeat` for usage examples."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "Playlist is now repeating."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "Playlist is no longer repeating."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "Player will now loop the current song."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "Player will no longer loop the current song."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "Player is already looping a song!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "The player is not currently looping."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "Song is no longer repeating."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "Song is now repeating."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    Move song at position FROM to position TO.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -785,22 +785,22 @@ msgstr ""
 "Use the queue command to find track position numbers.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr "There are no songs queued. Play something with a play command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Song positions must be integers!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "You gave a position outside the playlist size!"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -808,7 +808,7 @@ msgstr ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -822,33 +822,33 @@ msgstr ""
 "Do you want to queue the playlist too?"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Local media playback is not enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL is invalid or not currently supported."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Detected a Spotify URL, but Spotify is not enabled."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "You have reached your enqueued song limit (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke mode is enabled, please try again when its disabled!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -858,15 +858,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "That video cannot be played. Try using the stream command."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "YouTube search returned no results for:  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1047,7 +1041,7 @@ msgid "Show information on what is currently playing."
 msgstr "Show information on what is currently playing."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1084,7 +1078,7 @@ msgstr "Progress:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "There are no songs queued! Queue something with a play command."
 
@@ -1189,38 +1183,25 @@ msgstr "Removes all songs currently in the queue."
 msgid "Cleared all songs from the queue."
 msgstr "Cleared all songs from the queue."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Nothing in the queue to remove!"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Removed `%(track)s` added by `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nothing found in the queue from user `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1229,24 +1210,24 @@ msgstr ""
 "You must be the one who queued it or have instant skip permissions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Invalid entry number. Use the queue command to find queue positions."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Removed entry `%(track)s` added by `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Removed entry `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1257,23 +1238,23 @@ msgstr ""
 "If LegacySkip option is enabled, the force parameter can be ignored.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Can't skip! The player is not playing!"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "The next song `%(track)s` is downloading, please wait."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "The next song will be played shortly. Please wait."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1282,7 +1263,7 @@ msgstr ""
 "You might want to restart the bot if it doesn't start working."
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1291,28 +1272,28 @@ msgstr ""
 "You might want to restart the bot if it doesn't start working."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "You do not have permission to force skip a looped song."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Force skipped `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "You do not have permission to force skip."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "You do not have permission to skip a looped song."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1322,12 +1303,12 @@ msgstr ""
 "The vote to skip has been passed.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " Next song coming up!"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1337,7 +1318,7 @@ msgstr ""
 "Need **%(votes)s** more vote(s) to skip this song."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1348,25 +1329,25 @@ msgstr ""
 "The volume setting is retained until MusicBot is restarted.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Current volume: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` is not a valid number"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Updated volume from **%(old)d** to **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1376,7 +1357,7 @@ msgstr ""
 "Volume can only be set from 1 to 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1384,7 +1365,7 @@ msgstr ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1395,7 +1376,7 @@ msgstr ""
 "Streaming playback does not support speed adjustments.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1404,33 +1385,33 @@ msgstr ""
 "Use the config command to set a default playback speed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Speed cannot be applied to streamed media."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "You must provide a speed to set."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "The speed you provided is invalid. Use a number between 0.5 and 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr "Setting playback speed to `%(speed).3f` for current track."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Add an new alias with optional arguments.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1439,23 +1420,23 @@ msgstr ""
 "command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Invalid option for command: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Aliases reloaded from config file."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Aliases saved to config file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1465,40 +1446,40 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "You must supply an alias and a command to alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "You must supply an alias name to remove."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` was removed."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    Shows help text about any missing config options.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1507,32 +1488,32 @@ msgstr ""
 "file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr "    List the available config options and their sections.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Reload the options.ini file from disk.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Shows help text for a specific option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Display the current value of the option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Saves the current value to the options file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1541,32 +1522,32 @@ msgstr ""
 "file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Reset the option to its default value.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Manage options.ini configuration from within Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Config cannot use channel and user mentions at the same time."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*All config options are present and accounted for!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "No config options appear to be changed."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1576,7 +1557,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1592,12 +1573,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "Config options reloaded from file successfully!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1607,7 +1588,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1616,17 +1597,17 @@ msgstr ""
 "section and option name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "The option given is ambiguous, please provide a section name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "You must provide a section name and option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1636,24 +1617,24 @@ msgstr ""
 "The available sections are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "The option `%(option)s` is not available."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr "This option can only be set by editing the config file."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "By default this option is set to: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1667,31 +1648,31 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Option `%(option)s` is not editable. Cannot save to disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Failed to save the option:  `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Successfully saved the option:  `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` is not editable, value cannot be displayed."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1703,24 +1684,24 @@ msgstr ""
 "INI File Value:  `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Option `%(option)s` is not editable. Cannot update setting."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "You must provide a section, option, and value for this sub command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` was not updated!"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1730,19 +1711,19 @@ msgstr ""
 "To save the change use `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "Option `%(option)s` is not editable. Cannot reset to default."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` was not reset to default!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1752,17 +1733,17 @@ msgstr ""
 "To save the change use `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Deprecated command, use the config command instead."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "The option command is deprecated, use the config command instead."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1771,33 +1752,33 @@ msgstr ""
 "Using update option will scan the cache for external changes before displaying details."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Invalid option specified, use: info, update, or clear"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Disabled"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Enabled"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s days"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Unlimited"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1813,22 +1794,22 @@ msgstr ""
 "**Cached Now:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "Cache has been cleared."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**Failed** to delete cache, check logs for more info..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "No cache found to clear."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1837,12 +1818,12 @@ msgstr ""
 "Optional page number shows later entries in the queue.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Queue page argument must be a whole number."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1852,12 +1833,12 @@ msgstr ""
 "There are **%(total)s** pages."
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(unknown duration)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1869,7 +1850,7 @@ msgstr ""
 "Progress: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1883,12 +1864,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Songs in queue"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1897,7 +1878,7 @@ msgstr ""
 "If the issue persists, file a bug report."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1908,38 +1889,38 @@ msgstr ""
 "This command may be slow if larger ranges are given.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "Invalid parameter. Please provide a number of messages to search."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Cannot use purge on private DM channel."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Cleaned up %(number)s message(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Bot does not have permission to manage messages."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Dump the individual URLs of a playlist to a file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "The given URL was not a valid URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1949,18 +1930,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "This does not seem to be a playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Here is the playlist dump for:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1969,19 +1950,19 @@ msgstr ""
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Your user ID is `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "The user ID for `%(username)s` is `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1992,25 +1973,25 @@ msgstr ""
 "This command is deprecated in favor of using Developer mode in Discord clients.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Valid categories: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Here are the IDs you requested:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2019,12 +2000,12 @@ msgstr ""
 "again."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Could not determine the discord User.  Try again."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2038,7 +2019,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2052,62 +2033,62 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Show loaded groups and list permission options.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Reloads permissions from the permissions.ini file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    Add new group with defaults.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Remove existing group.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Show help text for the permission option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Show permission value for given group and permission.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Save permissions group to file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Set permission value for the group.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Manage permissions.ini configuration from within discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Permissions cannot use channel and user mentions at the same time."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "Permissions reloaded from file successfully!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2117,7 +2098,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2131,23 +2112,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "You must provide a group or option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "You must provide a group, option, and value to set for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "The %(option)s sub-command requires a group and permission name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2157,24 +2138,24 @@ msgstr ""
 "The available groups are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "The permission `%(option)s` is not available."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr "This permission can only be set by editing the permissions file."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "By default this permission is set to: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2188,13 +2169,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Cannot add group `%(group)s` it already exists."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2206,12 +2187,12 @@ msgstr ""
 "Make sure to save the new group with:  `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Cannot remove built-in group."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2221,24 +2202,24 @@ msgstr ""
 "Make sure to save this change with:  `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "The owner group is not editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Failed to save the group:  `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Successfully saved the group:  `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2250,13 +2231,13 @@ msgstr ""
 "INI File Value:  `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` was not updated!"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2266,7 +2247,7 @@ msgstr ""
 "To save the change use `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2275,7 +2256,7 @@ msgstr ""
 "Note: The API may limit name changes to twice per hour."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2284,7 +2265,7 @@ msgstr ""
 "Remember name changes are limited to twice per hour.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2294,23 +2275,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Set the bot's username to `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Change the MusicBot's nickname."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Unable to change nickname: no permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2320,23 +2301,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Set the bot's nickname to `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Set a per-server command prefix."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Clear the per-server command prefix."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2345,23 +2326,23 @@ msgstr ""
 "The option EnablePrefixPerGuild must be enabled first."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Custom emoji must be from this server to use as a prefix."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Server command prefix is cleared."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Server command prefix is now:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2370,37 +2351,37 @@ msgstr ""
 "Use the config command to update the prefix instead."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Show language codes available to use.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    Set the desired language for this server.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Reset the server language to bot's default language.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "Manage the language used for messages in the calling server."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "This command can only be used in guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "Invalid sub-command given. Use the help command for more information."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2414,25 +2395,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Cannot set language to `%(locale)s` it is not available."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Language for this server now set to: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Language for this server has been reset to: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2441,12 +2422,12 @@ msgstr ""
 "Attaching a file and omitting the url parameter also works.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "You must provide a URL or attach a file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2456,56 +2437,56 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "Changed the bot's avatar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Force MusicBot to disconnect from the discord server."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Disconnected from server `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Disconnected a playerless voice client? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Not currently connected to server `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr "    Attempt to reload without process restart. The default tion.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr "    Full restart, but attempt to update pip packages before restart.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    Full restart, but update MusicBot source code with git first.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2514,7 +2495,7 @@ msgstr ""
 "restarting.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2527,26 +2508,26 @@ msgstr ""
 "If you have a service manager, we recommend using it instead of this command for restarts.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Restarting current instance..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Restarting bot process..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2554,29 +2535,29 @@ msgstr ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "%(emoji)s Will try to update bot code with git and restart the bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Will try to upgrade everything and restart the bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Disconnect from all voice channels and close the MusicBot process."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Leave the discord server given by name or server ID."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2585,30 +2566,30 @@ msgstr ""
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "You must provide an ID or name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No guild was found with the ID or name `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Unknown"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2617,38 +2598,38 @@ msgstr ""
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Logged breakpoint with ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    View most common types reported by objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    View limited objgraph.show_growth() output.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    View most common types of leaking objects.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    View typestats of leaking objects.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Evaluate the given function and arguments on objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2659,12 +2640,12 @@ msgstr ""
 "Since this method evaluates arbitrary code, it is considered dangerous like the debug command.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Could not import `objgraph`, is it installed?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2689,7 +2670,7 @@ msgstr ""
 "The danger of this command cannot be understated. Do not use it or give access to it if you do not understand the risks!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2705,7 +2686,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2714,23 +2695,23 @@ msgstr ""
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Sub-command must be one of: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Makes default INI files."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Saved the requested INI file to disk. Go check it"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2739,50 +2720,50 @@ msgstr ""
 "dependencies.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Could not locate git executable."
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "No updates in branch `%(branch)s` remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "New commits are available in `%(branch)s` branch remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "Error while checking, see logs for details."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Update for `%(name)s` to version: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "No updates for dependencies found."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "There are updates for MusicBot available for download."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot is totally up-to-date!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2802,53 +2783,53 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "Displays the MusicBot uptime, or time since last start / restart."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s has been online for `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 "Display latency information for Discord API and all connected voice clients."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "No voice clients connected.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Display API latency and Voice latency if MusicBot is connected."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Display MusicBot version number in the chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2858,17 +2839,17 @@ msgstr ""
 "Current version:  `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Update the cookies.txt file using a cookies.txt attachment."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Enable or disable cookies.txt file without deleting it."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2893,28 +2874,28 @@ msgstr ""
 "  feature if you do not understand how to avoid the risks."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies already enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Could not enable cookies due to error:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Cookies have been enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2924,63 +2905,63 @@ msgstr ""
 "Cookies temporarily disabled and will be re-enabled on next restart."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Cookies have been disabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 "No attached uploads were found, try again while uploading a cookie file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Error downloading the cookies file from discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Could not save cookies to disk:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies uploaded and enabled."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "You cannot use this bot in private messages."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "This command is not allowed for your permissions group:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "This command requires you to be in a Voice channel."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Command:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Exception Error"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2990,17 +2971,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "No description given.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "No usage given."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3014,13 +2995,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Leaving voice channel %(channel)s due to inactivity."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Left `%(guild)s` due to bot owner not being found in it."
@@ -3643,24 +3624,24 @@ msgstr ""
 "Leave blank to use default, dynamically generated UA strings."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "Toggle the user block list feature, without emptying the block list."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "Enable the song block list feature, without emptying the block list."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3669,7 +3650,7 @@ msgstr ""
 "Any song title or URL that contains any line in the list will be blocked."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3678,7 +3659,7 @@ msgstr ""
 "Each file should contain a list of playable URLs or terms, one track per line."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3692,7 +3673,7 @@ msgstr ""
 "Maps to:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3701,7 +3682,7 @@ msgstr ""
 "cache for playback."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3713,7 +3694,7 @@ msgstr ""
 "Set to 0 to disable.  Maximum allowed number is %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3726,7 +3707,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3756,7 +3737,7 @@ msgstr ""
 "  Use the example options as a template or copy it from the repository."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3775,7 +3756,7 @@ msgstr ""
 "  Make sure the path you configured is a path to a folder / directory."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3797,7 +3778,7 @@ msgstr ""
 "  Double check the setting is a valid, accessible directory path."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3817,7 +3798,7 @@ msgstr ""
 "  Set the Token config option or set environment variable %(env_var)s with an App token."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3838,7 +3819,7 @@ msgstr ""
 "  Manually set the 'OwnerID' config option or try again later."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3857,7 +3838,7 @@ msgstr ""
 "  Do not use the Bot or App ID in the 'OwnerID' field."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3879,7 +3860,7 @@ msgstr ""
 "  Verify the config folder and files exist and can be read by MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3903,7 +3884,7 @@ msgstr ""
 "  Copy the example file from the repo if all else fails."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3923,7 +3904,7 @@ msgstr ""
 "  Set %(option)s to a numerical ID or set it to `auto` or `0` for automatic owner binding."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3943,7 +3924,7 @@ msgstr ""
 "  Check the path setting and make sure the file exists and is accessible to MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3963,32 +3944,32 @@ msgstr ""
 "  Ensure all IDs are numerical, and separated only by spaces or commas."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD seems to have no headers..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Song info extraction returned no data."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Cannot continue extraction, event loop is closed."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL is invalid or not supported."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Cannot stream an invalid URL."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "The local media file could not be found."
 
@@ -4011,13 +3992,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Download failed due to a yt-dlp error: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "Download failed due to an unhandled exception: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Failed to extract data for the requested media."
 
@@ -4197,28 +4178,28 @@ msgstr ""
 "The yt-dlp extractor `%(extractor)s` is not permitted in your group."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Could not extract information"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "This is a playlist."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Invalid content type `%(type)s` for URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "no duration data"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "no duration data in current entry"
 
@@ -4300,7 +4281,7 @@ msgid "Only dev users can use this command."
 msgstr "Only dev users can use this command."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
@@ -4309,7 +4290,7 @@ msgstr ""
 "files.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
@@ -4318,7 +4299,7 @@ msgstr ""
 "randomized.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4328,13 +4309,13 @@ msgstr ""
 "%(names)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr "No playlist file exists with the name: `%(playlist)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr "The playlist `%(playlist)s` has been cleared."
@@ -4347,22 +4328,22 @@ msgstr ""
 "There is nothing currently playing. Play something with a play command."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr "    Remove an alias with the given name.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr "    Reload or save aliases from/to the config file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr "Command used to automate testing of commands."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4406,61 +4387,61 @@ msgstr ""
 "  Make sure MusicBot can read and write to your config files.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr "Unknown Owner"
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr "## %(title)s\n"
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr "%(content)s\n"
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr "%(url)s\n"
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr "**%(name)s** %(value)s\n"
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr "%(value)s\n"
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr "%(url)s"
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4470,7 +4451,7 @@ msgstr ""
 "%(bitrate)s kbps.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4484,7 +4465,7 @@ msgstr ""
 "Using approximately %(rate).2f %(suffix)s of bandwidth total."
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4516,7 +4497,7 @@ msgstr ""
 "This option will disable speed, volume, and UseExperimentalEqualization options."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
@@ -4525,7 +4506,7 @@ msgstr ""
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
@@ -4534,30 +4515,21 @@ msgstr ""
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
-
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr "You must be in a voice channel to use this command."
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4567,13 +4539,13 @@ msgstr ""
 "Please wait while MusicBot processes the playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr "The playlist has been reloaded from disk."
 
@@ -4601,7 +4573,7 @@ msgstr ""
 "- bb, bili\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4613,7 +4585,7 @@ msgstr ""
 "%(missing)s```"
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4654,25 +4626,110 @@ msgstr ""
 "To allow either IPv4 or v6, set this to:  *"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading media data: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading stream data: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr "The playlist does not exist."
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr "URL:"
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr "Search returned no results with %(extractor)s for:  %(url)s"
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr "    Remove a song at the end of the queue or at [POSITION].\n"
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr "    Remove songs from position FROM to position TO.\n"
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr "    Remove songs added by the mentioned user.\n"
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr "Invalid positions. Use the queue command to find queue positions."
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr "Successfully removed songs %(from)s through %(to)s!"
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""

--- a/i18n/en_US/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/en_US/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2025-05-02 07:02-0700\n"
@@ -790,7 +790,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr "There are no songs queued. Play something with a play command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Song positions must be integers!"
 
@@ -827,28 +827,28 @@ msgid "Local media playback is not enabled."
 msgstr "Local media playback is not enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL is invalid or not currently supported."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Detected a Spotify URL, but Spotify is not enabled."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "You have reached your enqueued song limit (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke mode is enabled, please try again when its disabled!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -858,12 +858,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "That video cannot be played. Try using the stream command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -871,7 +871,7 @@ msgstr ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -881,13 +881,13 @@ msgstr ""
 "Position in queue: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Song duration exceeds limit (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -897,24 +897,24 @@ msgstr ""
 "Position in queue: %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "Playing next!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - estimated time until playing: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - cannot estimate time until playing."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -927,24 +927,24 @@ msgstr ""
 "Note: FFmpeg may drop the stream randomly or if connection hiccups happen.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Streaming playlists is not yet supported."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "Now streaming track `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 "    Search with service for a number of results with the search query.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -953,59 +953,59 @@ msgstr ""
 "    Note: the double-quotes are required in this case.\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "You have reached your playlist item limit (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 "Please specify a search query.  Use `help search` for more information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "You cannot search for more than %(max)s videos"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Searching for videos..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "Search failed due to an error: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "No videos found."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "To select a song, type the corresponding number."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Search results from %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** | %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1014,194 +1014,194 @@ msgstr ""
 "**0**. Cancel"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Pick a song"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Added song [%(track)s](%(url)s) to the queue."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Result %(number)s of %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "Alright, coming right up!"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Show information on what is currently playing."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "Now playing"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Currently streaming:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "Currently playing:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Added By:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Progress:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "There are no songs queued! Queue something with a play command."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Tell MusicBot to join the channel you're in."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "You are not connected to voice. Try joining a voice channel!"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Connected to `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr "Makes MusicBot follow a user when they change channels in a server.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "No longer following user `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Now following user `%(user)s` between voice channels."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot cannot follow a user that is not a member of the server."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "Will follow user `%(user)s` between voice channels."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Pause playback if a track is currently playing."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Paused music in `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Player is not playing."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "Resumes playback if the player was previously paused."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Resumed music in `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Resumed music queue"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Player is not paused."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Shuffle all current tracks in the queue."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Shuffled all songs in the queue."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Removes all songs currently in the queue."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Cleared all songs from the queue."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Nothing in the queue to remove!"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Removed `%(track)s` added by `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nothing found in the queue from user `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1210,24 +1210,24 @@ msgstr ""
 "You must be the one who queued it or have instant skip permissions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Invalid entry number. Use the queue command to find queue positions."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Removed entry `%(track)s` added by `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Removed entry `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1238,23 +1238,23 @@ msgstr ""
 "If LegacySkip option is enabled, the force parameter can be ignored.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Can't skip! The player is not playing!"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "The next song `%(track)s` is downloading, please wait."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "The next song will be played shortly. Please wait."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1263,7 +1263,7 @@ msgstr ""
 "You might want to restart the bot if it doesn't start working."
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1272,28 +1272,28 @@ msgstr ""
 "You might want to restart the bot if it doesn't start working."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "You do not have permission to force skip a looped song."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Force skipped `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "You do not have permission to force skip."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "You do not have permission to skip a looped song."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1303,12 +1303,12 @@ msgstr ""
 "The vote to skip has been passed.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " Next song coming up!"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1318,7 +1318,7 @@ msgstr ""
 "Need **%(votes)s** more vote(s) to skip this song."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1329,25 +1329,25 @@ msgstr ""
 "The volume setting is retained until MusicBot is restarted.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Current volume: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` is not a valid number"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Updated volume from **%(old)d** to **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1357,7 +1357,7 @@ msgstr ""
 "Volume can only be set from 1 to 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1365,7 +1365,7 @@ msgstr ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1376,7 +1376,7 @@ msgstr ""
 "Streaming playback does not support speed adjustments.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1385,33 +1385,33 @@ msgstr ""
 "Use the config command to set a default playback speed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Speed cannot be applied to streamed media."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "You must provide a speed to set."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "The speed you provided is invalid. Use a number between 0.5 and 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr "Setting playback speed to `%(speed).3f` for current track."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Add an new alias with optional arguments.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1420,23 +1420,23 @@ msgstr ""
 "command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Invalid option for command: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Aliases reloaded from config file."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Aliases saved to config file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1446,40 +1446,40 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "You must supply an alias and a command to alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "You must supply an alias name to remove."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` was removed."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    Shows help text about any missing config options.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1488,32 +1488,32 @@ msgstr ""
 "file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr "    List the available config options and their sections.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Reload the options.ini file from disk.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Shows help text for a specific option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Display the current value of the option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Saves the current value to the options file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1522,32 +1522,32 @@ msgstr ""
 "file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Reset the option to its default value.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Manage options.ini configuration from within Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Config cannot use channel and user mentions at the same time."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*All config options are present and accounted for!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "No config options appear to be changed."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1557,7 +1557,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1573,12 +1573,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "Config options reloaded from file successfully!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1588,7 +1588,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1597,17 +1597,17 @@ msgstr ""
 "section and option name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "The option given is ambiguous, please provide a section name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "You must provide a section name and option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1617,24 +1617,24 @@ msgstr ""
 "The available sections are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "The option `%(option)s` is not available."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr "This option can only be set by editing the config file."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "By default this option is set to: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1648,31 +1648,31 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Option `%(option)s` is not editable. Cannot save to disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Failed to save the option:  `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Successfully saved the option:  `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` is not editable, value cannot be displayed."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1684,24 +1684,24 @@ msgstr ""
 "INI File Value:  `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Option `%(option)s` is not editable. Cannot update setting."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "You must provide a section, option, and value for this sub command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` was not updated!"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1711,19 +1711,19 @@ msgstr ""
 "To save the change use `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "Option `%(option)s` is not editable. Cannot reset to default."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` was not reset to default!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1733,17 +1733,17 @@ msgstr ""
 "To save the change use `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Deprecated command, use the config command instead."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "The option command is deprecated, use the config command instead."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1752,33 +1752,33 @@ msgstr ""
 "Using update option will scan the cache for external changes before displaying details."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Invalid option specified, use: info, update, or clear"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Disabled"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Enabled"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s days"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Unlimited"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1794,22 +1794,22 @@ msgstr ""
 "**Cached Now:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "Cache has been cleared."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**Failed** to delete cache, check logs for more info..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "No cache found to clear."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1818,12 +1818,12 @@ msgstr ""
 "Optional page number shows later entries in the queue.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Queue page argument must be a whole number."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1833,12 +1833,12 @@ msgstr ""
 "There are **%(total)s** pages."
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(unknown duration)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1850,7 +1850,7 @@ msgstr ""
 "Progress: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1864,12 +1864,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Songs in queue"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1878,7 +1878,7 @@ msgstr ""
 "If the issue persists, file a bug report."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1889,38 +1889,38 @@ msgstr ""
 "This command may be slow if larger ranges are given.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "Invalid parameter. Please provide a number of messages to search."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Cannot use purge on private DM channel."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Cleaned up %(number)s message(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Bot does not have permission to manage messages."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Dump the individual URLs of a playlist to a file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "The given URL was not a valid URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1930,18 +1930,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "This does not seem to be a playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Here is the playlist dump for:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1950,19 +1950,19 @@ msgstr ""
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Your user ID is `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "The user ID for `%(username)s` is `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1973,25 +1973,25 @@ msgstr ""
 "This command is deprecated in favor of using Developer mode in Discord clients.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Valid categories: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Here are the IDs you requested:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2000,12 +2000,12 @@ msgstr ""
 "again."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Could not determine the discord User.  Try again."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2019,7 +2019,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2033,62 +2033,62 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Show loaded groups and list permission options.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Reloads permissions from the permissions.ini file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    Add new group with defaults.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Remove existing group.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Show help text for the permission option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Show permission value for given group and permission.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Save permissions group to file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Set permission value for the group.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Manage permissions.ini configuration from within discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Permissions cannot use channel and user mentions at the same time."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "Permissions reloaded from file successfully!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2098,7 +2098,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2112,23 +2112,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "You must provide a group or option name for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "You must provide a group, option, and value to set for this command."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "The %(option)s sub-command requires a group and permission name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2138,24 +2138,24 @@ msgstr ""
 "The available groups are:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "The permission `%(option)s` is not available."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr "This permission can only be set by editing the permissions file."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "By default this permission is set to: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2169,13 +2169,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Cannot add group `%(group)s` it already exists."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2187,12 +2187,12 @@ msgstr ""
 "Make sure to save the new group with:  `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Cannot remove built-in group."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2202,24 +2202,24 @@ msgstr ""
 "Make sure to save this change with:  `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "The owner group is not editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Failed to save the group:  `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Successfully saved the group:  `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2231,13 +2231,13 @@ msgstr ""
 "INI File Value:  `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` was not updated!"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2247,7 +2247,7 @@ msgstr ""
 "To save the change use `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2256,7 +2256,7 @@ msgstr ""
 "Note: The API may limit name changes to twice per hour."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2265,7 +2265,7 @@ msgstr ""
 "Remember name changes are limited to twice per hour.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2275,23 +2275,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Set the bot's username to `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Change the MusicBot's nickname."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Unable to change nickname: no permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2301,23 +2301,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Set the bot's nickname to `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Set a per-server command prefix."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Clear the per-server command prefix."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2326,23 +2326,23 @@ msgstr ""
 "The option EnablePrefixPerGuild must be enabled first."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Custom emoji must be from this server to use as a prefix."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Server command prefix is cleared."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Server command prefix is now:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2351,37 +2351,37 @@ msgstr ""
 "Use the config command to update the prefix instead."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Show language codes available to use.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    Set the desired language for this server.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Reset the server language to bot's default language.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "Manage the language used for messages in the calling server."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "This command can only be used in guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "Invalid sub-command given. Use the help command for more information."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2395,25 +2395,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Cannot set language to `%(locale)s` it is not available."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Language for this server now set to: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Language for this server has been reset to: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2422,12 +2422,12 @@ msgstr ""
 "Attaching a file and omitting the url parameter also works.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "You must provide a URL or attach a file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2437,56 +2437,56 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "Changed the bot's avatar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Force MusicBot to disconnect from the discord server."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Disconnected from server `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Disconnected a playerless voice client? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Not currently connected to server `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr "    Attempt to reload without process restart. The default tion.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr "    Full restart, but attempt to update pip packages before restart.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    Full restart, but update MusicBot source code with git first.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2495,7 +2495,7 @@ msgstr ""
 "restarting.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2508,26 +2508,26 @@ msgstr ""
 "If you have a service manager, we recommend using it instead of this command for restarts.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Restarting current instance..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Restarting bot process..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2535,29 +2535,29 @@ msgstr ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "%(emoji)s Will try to update bot code with git and restart the bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Will try to upgrade everything and restart the bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Disconnect from all voice channels and close the MusicBot process."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Leave the discord server given by name or server ID."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2566,12 +2566,12 @@ msgstr ""
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "You must provide an ID or name."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No guild was found with the ID or name `%(input)s`"
@@ -2583,13 +2583,13 @@ msgid "Unknown"
 msgstr "Unknown"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2598,38 +2598,38 @@ msgstr ""
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Logged breakpoint with ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    View most common types reported by objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    View limited objgraph.show_growth() output.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    View most common types of leaking objects.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    View typestats of leaking objects.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Evaluate the given function and arguments on objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2640,12 +2640,12 @@ msgstr ""
 "Since this method evaluates arbitrary code, it is considered dangerous like the debug command.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Could not import `objgraph`, is it installed?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2670,7 +2670,7 @@ msgstr ""
 "The danger of this command cannot be understated. Do not use it or give access to it if you do not understand the risks!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2686,7 +2686,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2695,23 +2695,23 @@ msgstr ""
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Sub-command must be one of: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Makes default INI files."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Saved the requested INI file to disk. Go check it"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2720,50 +2720,50 @@ msgstr ""
 "dependencies.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Could not locate git executable."
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "No updates in branch `%(branch)s` remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "New commits are available in `%(branch)s` branch remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "Error while checking, see logs for details."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Update for `%(name)s` to version: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "No updates for dependencies found."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "There are updates for MusicBot available for download."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot is totally up-to-date!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2783,53 +2783,53 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "Displays the MusicBot uptime, or time since last start / restart."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s has been online for `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 "Display latency information for Discord API and all connected voice clients."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "No voice clients connected.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Display API latency and Voice latency if MusicBot is connected."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Display MusicBot version number in the chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2839,17 +2839,17 @@ msgstr ""
 "Current version:  `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Update the cookies.txt file using a cookies.txt attachment."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Enable or disable cookies.txt file without deleting it."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2874,28 +2874,28 @@ msgstr ""
 "  feature if you do not understand how to avoid the risks."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies already enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Could not enable cookies due to error:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Cookies have been enabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2905,63 +2905,63 @@ msgstr ""
 "Cookies temporarily disabled and will be re-enabled on next restart."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Cookies have been disabled."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 "No attached uploads were found, try again while uploading a cookie file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Error downloading the cookies file from discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Could not save cookies to disk:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies uploaded and enabled."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "You cannot use this bot in private messages."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "This command is not allowed for your permissions group:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "This command requires you to be in a Voice channel."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Command:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Exception Error"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2971,17 +2971,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "No description given.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "No usage given."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2995,13 +2995,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Leaving voice channel %(channel)s due to inactivity."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Left `%(guild)s` due to bot owner not being found in it."
@@ -3124,7 +3124,7 @@ msgstr ""
 "Only used when BindToChannels is missing an ID for a server."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3203,13 +3203,13 @@ msgstr ""
 "You can set this from 0 to 1, or 0% to 100%."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr "Allow MusicBot to keep downloaded media, or delete it right away."
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3219,7 +3219,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3227,7 +3227,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3241,7 +3241,7 @@ msgid "Mention the user who added the song when it is played."
 msgstr "Mention the user who added the song when it is played."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3250,7 +3250,7 @@ msgstr ""
 " bot starts."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3259,12 +3259,12 @@ msgstr ""
 "queue is empty."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "Shuffles the auto playlist tracks before playing them."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3273,7 +3273,7 @@ msgstr ""
 "This only applies to the current playing song if it was added by the auto playlist."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3332,7 +3332,7 @@ msgstr ""
 "Currently this option does not apply to auto playlist or songs added to an empty queue."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3361,14 +3361,14 @@ msgstr ""
 " {p0_url}      = The track URL for the currently playing track."
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr "If enabled, status messages will report info on paused players."
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3405,7 +3405,7 @@ msgstr ""
 "queue."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3414,7 +3414,7 @@ msgstr ""
 "playlist."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr "Display MusicBot config settings in the logs at startup."
 
@@ -3429,7 +3429,7 @@ msgstr ""
 "skips."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3461,14 +3461,14 @@ msgid "Completely remove the footer from embeds."
 msgstr "Completely remove the footer from embeds."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3479,7 +3479,7 @@ msgstr ""
 "Listeners are channel members, excluding bots, who are not deafened."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3488,7 +3488,7 @@ msgstr ""
 "You can set this to a number of seconds or phrase like:  4 hours"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3497,7 +3497,7 @@ msgstr ""
 "is empty."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3545,7 +3545,7 @@ msgstr ""
 "playback for one song per member."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3558,7 +3558,7 @@ msgstr ""
 "By default this is disabled."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3570,7 +3570,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3596,7 +3596,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr "Allow MusicBot to automatically unpause when play commands are used."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3607,7 +3607,7 @@ msgstr ""
 "Leave blank to disable."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3624,24 +3624,24 @@ msgstr ""
 "Leave blank to use default, dynamically generated UA strings."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "Toggle the user block list feature, without emptying the block list."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "Enable the song block list feature, without emptying the block list."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3650,7 +3650,7 @@ msgstr ""
 "Any song title or URL that contains any line in the list will be blocked."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3659,7 +3659,7 @@ msgstr ""
 "Each file should contain a list of playable URLs or terms, one track per line."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3673,7 +3673,7 @@ msgstr ""
 "Maps to:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3682,7 +3682,7 @@ msgstr ""
 "cache for playback."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3694,7 +3694,7 @@ msgstr ""
 "Set to 0 to disable.  Maximum allowed number is %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3707,7 +3707,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3737,7 +3737,7 @@ msgstr ""
 "  Use the example options as a template or copy it from the repository."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3756,7 +3756,7 @@ msgstr ""
 "  Make sure the path you configured is a path to a folder / directory."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3778,7 +3778,7 @@ msgstr ""
 "  Double check the setting is a valid, accessible directory path."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3798,7 +3798,7 @@ msgstr ""
 "  Set the Token config option or set environment variable %(env_var)s with an App token."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3819,7 +3819,7 @@ msgstr ""
 "  Manually set the 'OwnerID' config option or try again later."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3838,7 +3838,7 @@ msgstr ""
 "  Do not use the Bot or App ID in the 'OwnerID' field."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3860,7 +3860,7 @@ msgstr ""
 "  Verify the config folder and files exist and can be read by MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3884,7 +3884,7 @@ msgstr ""
 "  Copy the example file from the repo if all else fails."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3904,7 +3904,7 @@ msgstr ""
 "  Set %(option)s to a numerical ID or set it to `auto` or `0` for automatic owner binding."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3924,7 +3924,7 @@ msgstr ""
 "  Check the path setting and make sure the file exists and is accessible to MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3944,32 +3944,32 @@ msgstr ""
 "  Ensure all IDs are numerical, and separated only by spaces or commas."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD seems to have no headers..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Song info extraction returned no data."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Cannot continue extraction, event loop is closed."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL is invalid or not supported."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Cannot stream an invalid URL."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "The local media file could not be found."
 
@@ -4321,29 +4321,29 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr "The playlist `%(playlist)s` has been cleared."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 "There is nothing currently playing. Play something with a play command."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr "    Remove an alias with the given name.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr "    Reload or save aliases from/to the config file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr "Command used to automate testing of commands."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4387,7 +4387,7 @@ msgstr ""
 "  Make sure MusicBot can read and write to your config files.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr "Unknown Owner"
 
@@ -4441,7 +4441,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4451,7 +4451,7 @@ msgstr ""
 "%(bitrate)s kbps.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4465,7 +4465,7 @@ msgstr ""
 "Using approximately %(rate).2f %(suffix)s of bandwidth total."
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4550,7 +4550,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr "The playlist has been reloaded from disk."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4573,7 +4573,7 @@ msgstr ""
 "- bb, bili\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4585,7 +4585,7 @@ msgstr ""
 "%(missing)s```"
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4602,7 +4602,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr "Command responses will also mention or notify the user."
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4613,7 +4613,7 @@ msgstr ""
 "Some prefix examples:   ytsearch, scsearch, gvsearch, yvsearch, bilisearch, nicosearch"
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4626,26 +4626,26 @@ msgstr ""
 "To allow either IPv4 or v6, set this to:  *"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading media data: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "Error in yt-dlp while downloading stream data: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr "The playlist does not exist."
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr "URL:"
 
@@ -4659,28 +4659,28 @@ msgstr ""
 "Auto playlists use their own queue, only playing when the main queue is empty."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr "Search returned no results with %(extractor)s for:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr "    Remove a song at the end of the queue or at [POSITION].\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr "    Remove songs from position FROM to position TO.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr "    Remove songs added by the mentioned user.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4697,12 +4697,12 @@ msgstr ""
 "However, positions of all songs are changed when a new song starts playing.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr "Invalid positions. Use the queue command to find queue positions."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
@@ -4711,13 +4711,13 @@ msgstr ""
 "from the queue.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr "Successfully removed songs %(from)s through %(to)s!"
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4726,7 +4726,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/es_ES/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/es_ES/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-17 14:03-0800\n"
@@ -480,20 +480,20 @@ msgstr ""
 "reiniciar?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot está solicitando hablar en el canal: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot no tiene permiso para hablar."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot no pudo pedir la palabra."
 
@@ -629,7 +629,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Configurando el guild del historial de URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "No hay miniaturas definidas para la entrada con la URL: %s"
@@ -719,19 +719,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Bucle sobre la lista de reproducción automática..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Error al procesar la canción \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Error al extraer la canción \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot necesita detener la extracción de la lista de reproducción "
@@ -1119,7 +1119,7 @@ msgstr "Lista de Gremio:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1704,7 +1704,7 @@ msgid "The player is not currently looping."
 msgstr "El reproductor no está bucle actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Las posiciones de la canción deben ser enteras!"
 
@@ -1727,35 +1727,35 @@ msgid "Local media playback is not enabled."
 msgstr "La reproducción de medios locales no está habilitada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "La URL de Spotify no es válida o no está soportada actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Se ha detectado una URL de Spotify, pero Spotify no está habilitado."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Has alcanzado el límite de canciones en cola (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "El modo Karaoke está activado, ¡por favor inténtalo de nuevo cuando esté "
 "desactivado!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Problema con extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1765,12 +1765,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Ese video no se puede reproducir. Intenta usar el comando Stream."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1780,7 +1780,7 @@ msgstr ""
 "%(time_per).2f s/canción"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1789,49 +1789,49 @@ msgstr ""
 "máxima (%(max)s segundos)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr ""
 "Extracción de una entrada con 'youtube:playlist' como clave de extractor"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "La duración de la canción excede el límite (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Canción(es) añadidas en la posición %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "No se puede estimar el tiempo hasta jugar para la posición: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "No se pudo obtener información de la solicitud de stream: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Las listas de reproducción de streaming aún no están soportadas."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 "Has alcanzado el límite de elementos de tu lista de reproducción (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -1839,57 +1839,57 @@ msgstr ""
 "información."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "No puedes buscar más de %(max)s vídeos"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "Esperando por invocar bloqueo: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Invocar bloqueo adquirido por: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "No estás conectado a la voz. ¡Prueba a unirte a un canal de voz!"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Uniéndose a %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot no puede seguir a un usuario que no es miembro del servidor."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "El jugador no está reproduciendo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "¡Nada en la cola para eliminar!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "No se ha encontrado nada en la cola del usuario `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1898,40 +1898,40 @@ msgstr ""
 "la puso en cola o tener permisos de omisión instantánea."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Número de entrada no válido. Utilice el comando de cola para encontrar las "
 "posiciones de la cola."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "¡No se puede saltar! ¡El jugador no está jugando!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "No tienes permiso para forzar a saltar una canción en bucle."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "No tienes permiso para forzar saltar."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "No tienes permiso para saltar una canción en bucle."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` no es un número válido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1941,7 +1941,7 @@ msgstr ""
 "El volumen solo puede establecerse de 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1950,7 +1950,7 @@ msgstr ""
 " y 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1959,29 +1959,29 @@ msgstr ""
 "Utilice el comando de configuración para establecer una velocidad de reproducción predeterminada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocidad no se puede aplicar a los medios streamed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Debe proporcionar una velocidad para establecer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocidad que proporcionaste no es válida. Usa un número entre 0.5 y 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opción no válida para el comando: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1991,30 +1991,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Debe proporcionar un alias y un comando para alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Debe proporcionar un nombre de alias para eliminar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "El alias `%(alias)s` no existe."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuración no puede usar las menciones de canal y usuario al mismo "
 "tiempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2024,7 +2024,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2033,19 +2033,19 @@ msgstr ""
 "favor, introduzca un nombre de sección y opción válidos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "La opción dada es ambigua, por favor ingrese un nombre de sección."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Debe proporcionar un nombre de sección y un nombre de opción para este "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2055,32 +2055,32 @@ msgstr ""
 "Las secciones disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "La opción `%(option)s` no está disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede guardar en el disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Error al guardar la opción: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "La opción `%(option)s` no es editable, el valor no se puede mostrar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2088,71 +2088,71 @@ msgstr ""
 "configuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Debe proporcionar una sección, opción y valor para este sub-comando."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Al establecer con %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "¡La opción `%(option)s` no fue actualizada!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede restablecer por defecto."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Restableciendo %(config)s a %(value)s por defecto"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "¡La opción `%(option)s` no se ha restablecido por defecto!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "El comando de opción está obsoleto, utilice el comando de configuración en "
 "su lugar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opción especificada no válida, use: info, actualización o borrado"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Fallo** al eliminar caché, comprueba los registros para más información..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "El argumento de página de cola debe ser un número entero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "No hay canciones en cola! Coloca algo con un comando de reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2162,24 +2162,24 @@ msgstr ""
 "Hay **%(total)s** páginas."
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "Se omitió la entrada de la lista de reproducción actual."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "No hay suficientes entradas para paginar la cola."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "No se pudo publicar el mensaje de cola, no hay mensajes a los que añadir "
 "reacciones."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2188,17 +2188,17 @@ msgstr ""
 "Si el problema persiste, envíe un informe de error."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "No se puede utilizar la purga en el canal DM privado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "La URL dada no era una URL válida."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2208,12 +2208,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Esto no parece ser una lista de reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2222,18 +2222,18 @@ msgstr ""
 "inténtelo de nuevo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "No se pudo determinar el usuario de discord. Inténtalo de nuevo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Los permisos no pueden usar menciones de canal y usuario al mismo tiempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2243,23 +2243,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Debe proporcionar un nombre de grupo o opción para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Debe proporcionar un grupo, opción y valor para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "El subcomando %(option)s requiere un grupo y un nombre de permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2269,47 +2269,47 @@ msgstr ""
 "Los grupos disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "El permiso `%(option)s` no está disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "No se puede agregar el grupo `%(group)s` que ya existe."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "No se puede eliminar el grupo integrado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "El grupo propietario no es editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Error al guardar el grupo: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Al establecer %(option)s con valor: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "¡El permiso `%(option)s` no fue actualizado!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2318,7 +2318,7 @@ msgstr ""
 "Recuerda que los cambios de nombre están limitados a dos veces por hora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2328,12 +2328,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "No se puede cambiar el apodo: no hay permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2343,13 +2343,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Los emoji personalizados deben ser de este servidor para usar como prefijo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2358,29 +2358,29 @@ msgstr ""
 "Utilice el comando de configuración para actualizar el prefijo en su lugar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Este comando sólo puede ser usado en gremios."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sub-comando inválido. Utilice el comando de ayuda para más información."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "No se puede establecer el idioma a `%(locale)s` no está disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Debe proporcionar una URL o adjuntar un archivo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2390,19 +2390,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot encontró un %s sin gremio! Esto podría ser un problema."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Actualmente no conectado al servidor `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2410,44 +2410,44 @@ msgstr ""
 "actualizada o actualizada"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Debe proporcionar un ID o nombre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No se ha encontrado ningún gremio con el ID o nombre `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Activando ID del breakpoint de depuración: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "No se pudo importar `objgraph`, ¿está instalado?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Código de depuración ejecutado con eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Código de depuración ejecutado con exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "Error al ejecutar el código de depuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2463,57 +2463,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "El subcomando debe ser uno de: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "No se pudo encontrar el ejecutable de git."
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "Error al buscar actualizaciones mediante el comando git."
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Paquete que falta meta en el informe pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 "Error al obtener el estado de actualización de pip debido a algún error."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Obtuvo una entrada extraña del cliente de voz."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Las cookies ya están habilitadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Las cookies deben ser subidas para estar habilitadas. (Falta archivo de "
 "cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "No se pudo habilitar las cookies debido a un error:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2523,7 +2523,7 @@ msgstr ""
 "Cookies temporalmente deshabilitadas y serán reactivadas en el siguiente reinicio."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2531,7 +2531,7 @@ msgstr ""
 "archivo de cookies."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
@@ -2539,44 +2539,44 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 "Error al descargar el archivo de cookies desde discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "No se han podido guardar las cookies en el disco:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Obtuviste un mensaje sin canal, de alguna manera:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorando el comando de mí mismo (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignorando comando de otro bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignorando comando del canal de tipo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2584,100 +2584,100 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Mensaje de %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Este comando no está permitido para el grupo de permisos:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Este comando requiere que estés en un canal de Voice."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 "Uso de comandos no válido, faltan valores para los parámetros: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Error en %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Excepción al manejar el comando: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "No se puede generar ayuda para el comando que falta:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Faltan datos de ayuda para el comando:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Dejando el canal de voz %s en %s por inactividad."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot se ha conectado."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot se ha desconectado."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Obtuvo un Evento de Socket:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "Estado de voz actualizado antes de finalizado el on_ready"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorando %s en %s ya que es un canal de voz vinculado."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s ha sido detectado como vacío. Manejo de tiempos de espera."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Un usuario se unió a %s, cancelando temporizador."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2686,30 +2686,30 @@ msgstr ""
 " espera de espera."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "El bot se movió y el canal de voz %s no está vacío."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "Ya no sigue al usuario %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "El siguiente usuario `%(user)s` para el canal:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState se desconecta antes.channel Ninguno."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2719,7 +2719,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2727,90 +2727,90 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "No se puede encontrar el canal auto-unido, ¿fue eliminado? Guild:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Reconectando al gremio auto-unido en el canal:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "No se puede auto unirse al canal:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "El bot ha sido añadido al gremio: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "El gremio izquierdo '%s' debido al propietario del bot no encontrado."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Creando carpeta de datos para guild %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "El bot ha sido eliminado del gremio: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Lista de guild actualizada:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "El gremio \"%s\" está disponible."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Reanudando jugador en \"%s\" debido a la disponibilidad."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "El gremio \"%s\" no está disponible."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausando jugador en \"%s\" debido a la falta de disponibilidad."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Actualización del gremio para:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Atributo del gremio %(attr)s ahora: %(new)s  -- Era: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Actualización del canal para:  %(channel)s  --  %(changes)s"
@@ -2828,7 +2828,7 @@ msgid "Loading config from:  %s"
 msgstr "Cargando configuración de:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2858,7 +2858,7 @@ msgstr ""
 "  Use las opciones de ejemplo como plantilla o cópielas del repositorio."
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2868,7 +2868,7 @@ msgstr ""
 "será limitada en su lugar."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2877,7 +2877,7 @@ msgstr ""
 "rotación de archivos de registro. Usando el valor predeterminado."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2896,12 +2896,12 @@ msgstr ""
 "  Asegúrese de que la ruta que ha configurado es una ruta a una carpeta / directorio."
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Se lanzó una excepción al validar AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2923,13 +2923,13 @@ msgstr ""
 "  Verifique nuevamente que la configuración sea una ruta de directorio válida y accesible."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "La caché de audio se almacenará en:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2949,7 +2949,7 @@ msgstr ""
 "  Establecer la opción de configuración del token o establecer la variable de entorno %(env_var)s con un token de aplicación."
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2958,7 +2958,7 @@ msgstr ""
 "a 128 caracteres."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2968,17 +2968,17 @@ msgstr ""
 " valor de opción de %.3f será limitado en su lugar."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Validando opciones con datos de servicio..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "ID del propietario adquirido a través de API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2999,12 +2999,12 @@ msgstr ""
 "  Establezca manualmente la opción de configuración 'OwnerID' o vuelva a intentarlo más tarde."
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot no tiene una instancia de usuario, no puede continuar."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3023,14 +3023,14 @@ msgstr ""
 "  No utilice el Bot o el ID de la aplicación en el campo OwnerID."
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "Archivo de opciones de configuración no encontrado. Comprobando "
 "alternativas..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3040,20 +3040,20 @@ msgstr ""
 "las extensiones de archivos."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copiando archivo de opciones de ejemplo existente:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Algo salió mal mientras se trataba de encontrar un archivo de opciones de "
 "configuración."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3075,7 +3075,7 @@ msgstr ""
 "  Verifique que la carpeta y los archivos de configuración existan y que MusicBot pueda leerlos."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3099,13 +3099,13 @@ msgstr ""
 "  Copie el archivo de ejemplo del repositorio si todo lo demás falla."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 "Dev Bug! La opción de configuración tiene getter que no está disponible."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3114,12 +3114,12 @@ msgstr ""
 " deben ser del mismo tipo."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "La opción faltaba anteriormente."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
@@ -3127,19 +3127,19 @@ msgstr ""
 "%s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Opción de configuración guardada: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Error al guardar la configuración:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3147,13 +3147,13 @@ msgstr ""
 "está desactivado."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Error al guardar el archivo INI por defecto en:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3173,7 +3173,7 @@ msgstr ""
 "  Establece %(option)s a un ID numérico o establézcalo a `auto` o `0` para vincular al propietario automático."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3193,7 +3193,7 @@ msgstr ""
 "  Comprueba la configuración de ruta y asegúrate de que el archivo existe y es accesible a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3213,7 +3213,7 @@ msgstr ""
 "  Asegúrese de que todos los IDs sean numéricos y separados solo por espacios o comas."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3223,7 +3223,7 @@ msgstr ""
 "%(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3233,7 +3233,7 @@ msgstr ""
 "'%(value)s' usando por defecto en su lugar."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3243,7 +3243,7 @@ msgstr ""
 "(%(value)s) y se establecerá en %(fallback)s en su lugar."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3252,48 +3252,48 @@ msgstr ""
 "%(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Actualizando archivo de configuración con opciones renombradas..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Error al actualizar la configuración. Necesitarás actualizarla manualmente."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Archivo de lista de bloques no encontrado:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "No se pudo cargar la lista de bloqueo del archivo:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "No se pudo actualizar el archivo de lista de bloqueos:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Lista de bloques de usuarios cargada con entradas %s."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "Encontramos un archivo antiguo de lista negra, se renombrará a:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Se cargó una lista de bloques de canciones con entradas %s."
@@ -3361,41 +3361,41 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Obligando a YTDLP a usar el agente de usuario:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot utilizará cookies para yt-dlp de:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp usará su servidor proxy configurado."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD parece no tener cabeceras..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 "La comprobación de las cabeceras de los medios falló debido al tiempo de "
 "espera."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Error de solicitud HEAD para:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "Excepción de solicitud HEAD: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3405,57 +3405,57 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Sanitized YTDL Extraction Info (no JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "La extracción de información de canciones no devolvió datos."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Se llamó a extract_info con: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "No se puede ejecutar la extracción, el bucle está cerrado. (Esto es normal "
 "al apagar)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "No se puede continuar la extracción, el bucle del evento está cerrado."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "La URL de Spotify no es válida o no es compatible."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Error de descarga con la URL del stream"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "Suponiendo que el contenido es un flujo directo"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "No se puede transmitir una URL no válida."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3463,23 +3463,23 @@ msgstr ""
 " puntos con el espacio."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Llamado safe_extract_info con:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "No se ha podido encontrar el archivo de medios locales."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Falta __input_subject de YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3487,7 +3487,7 @@ msgstr ""
 "para evitar esto."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Atención, error de duración para: %(url)s"
@@ -4802,13 +4802,13 @@ msgstr ""
 "Compruebe por ffmpeg con su gestor de paquetes del sistema o compilarlo desde fuentes."
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "Menos de %sMB de espacio libre en este dispositivo"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4817,13 +4817,13 @@ msgstr ""
 "Buscando actualizaciones para MusicBot o dependencias..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ""
 "No hay actualizaciones MusicBot disponibles mediante el comando `git`."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4832,25 +4832,25 @@ msgstr ""
 "revisar manualmente."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "Los siguientes paquetes pueden ser actualizados:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  a la versión:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 "No hay actualizaciones de dependencias disponibles mediante el comando "
 "`pip`."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4859,7 +4859,7 @@ msgstr ""
 "revisar manualmente."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4869,35 +4869,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "El valor está por encima del límite máximo."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "El valor no debe ser negativo."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "El valor máximo de registros guardados debe ser un número de 0 a %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "El nivel de registro '%s' no está disponible."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "El nivel de registro debe ser uno de:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4906,27 +4906,27 @@ msgstr ""
 " youtubeDL y ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Disponible a través de Github:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr "Para más ayuda y apoyo con este bot, únete a nuestra discord:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "Este software se proporciona bajo la Licencia MIT."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "Vea el archivo de texto `LICENSE` para detalles completos."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
@@ -4934,14 +4934,14 @@ msgstr ""
 "MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 "Utilice este idioma para todos los mensajes de registro del lado del "
 "servidor de MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4950,29 +4950,29 @@ msgstr ""
 "Esto no impide la selección de idioma por gremio."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Imprime la información de la versión MusicBot y sale."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 "Omitir todas las comprobaciones opcionales de inicio, incluyendo la "
 "comprobación de actualización."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Omitir sólo la comprobación de espacio en disco al inicio."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Omitir sólo la comprobación de actualización al inicio."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -4981,7 +4981,7 @@ msgstr ""
 "importarlas."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4991,7 +4991,7 @@ msgstr ""
 "(por defecto: %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
@@ -4999,7 +4999,7 @@ msgstr ""
 "configuración. Debe ser una de: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -5010,44 +5010,44 @@ msgstr ""
 "'%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Versión:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Se ha abierto una nueva instancia de MusicBot. ¡Este terminal puede cerrarse"
 " de forma segura!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Cargando versión de MusicBot:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Registro abierto:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Cambiando directorio de trabajo a:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5058,7 +5058,7 @@ msgstr ""
 "nueva ubicación de directorio."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5067,7 +5067,7 @@ msgstr ""
 "Si no utilizó git para clonar el repositorio, se le recomienda encarecidamente que lo haga."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5076,12 +5076,12 @@ msgstr ""
 "certificar y salir."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Aquí está el error exacto, podría ser un error."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5090,7 +5090,7 @@ msgstr ""
 "puede abrir el sitio fallido en Microsoft Edge o IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5099,17 +5099,17 @@ msgstr ""
 "defecto, en su lugar intentando certificfi."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Error de sintaxis (modificación detectada, ¿editaste el código?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Error de sintaxis (esto es un error, no su culpa)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5130,14 +5130,14 @@ msgstr ""
 "  o ejecutar sin `--no-install-deps` y MusicBot intentará instalarlos para ti."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Intentando instalar automáticamente los paquetes de dependencias de "
 "MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5173,57 +5173,43 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "¡Vale, esperemos que la instalación de dependencias funcione!"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot obtuvo un ImportError después de intentar instalar paquetes. "
-"MusicBot debe salir..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "La excepción que causó el error anterior: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot está reiniciando suavemente..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot está reiniciando todo el proceso..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Error al iniciar el bot"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Cerrando bucle de evento."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Reiniciando en %s segundos..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "Todo listo."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "¡Vale, estamos cerrando!"
 
@@ -5246,7 +5232,7 @@ msgstr ""
 "`%(playlist)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
@@ -5254,7 +5240,7 @@ msgstr ""
 "reproducción."
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
@@ -5263,7 +5249,7 @@ msgstr ""
 "en: %(path)s"
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
@@ -5271,12 +5257,12 @@ msgstr ""
 " %(path)s"
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr "Generando nuevos archivos de opciones de configuración..."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5298,7 +5284,7 @@ msgstr ""
 "  Asegúrese de que MusicBot pueda leer y escribir en sus archivos de configuración.\n"
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5378,7 +5364,7 @@ msgid "Failed to clean up write-test path."
 msgstr "No se pudo limpiar la ruta de prueba de escritura."
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5612,24 +5598,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5676,25 +5662,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5702,66 +5688,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5788,7 +5728,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5800,25 +5740,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5831,29 +5771,145 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot obtuvo un ImportError después de intentar instalar paquetes. "
+#~ "MusicBot debe salir..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "La excepción que causó el error anterior: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/es_ES/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/es_ES/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-17 14:03-0800\n"
@@ -161,7 +161,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Excepción no controlada para la tarea:  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify no nos proporcionó un token. Desactivando."
 
@@ -180,65 +180,43 @@ msgstr ""
 "No se pudo iniciar el cliente de Spotify. ¿Es tu ID de cliente y secreto "
 "correcto? Detalles: %s. Continuando de todos modos en 5 segundos..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"La configuración no tenía credenciales de aplicación de Spotify, intentando "
-"usar modo invitado."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Autenticado con Spotify utilizando correctamente el modo invitado."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-"No se pudo iniciar el cliente de Spotify usando el modo invitado. Detalles: "
-"%s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Inicializado, ahora conectándose a la discordia."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Prueba de ping de red está desactivada por configuración."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "La prueba de ping de red se está cerrando."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "No se pudo resolver el objetivo de ping ."
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Prueba de ping de red cancelada."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Las pruebas de red vía HTTP no tienen una sesión para tomar prestado."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "No se pudo localizar el ejecutable `ping` en tu entorno."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -252,7 +230,7 @@ msgstr ""
 "Desactivar alternativamente la comprobación de red a través de la configuración."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -266,7 +244,7 @@ msgstr ""
 "Desactivar alternativamente la comprobación de red a través de la configuración."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -280,28 +258,28 @@ msgstr ""
 "Desactivar alternativamente la comprobación de red a través de la configuración."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "MusicBot detectado red está disponible de nuevo."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "VoiceClient no está conectado, esperando para reanudar MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Reiniciando reproducción del jugador: (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot detectó una interrupción de red."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -310,7 +288,7 @@ msgstr ""
 "%(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -320,19 +298,19 @@ msgstr ""
 "obteniendo:  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "Comprobando canales para autounirse o reanudar..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 "Gremio no disponible, no puede entrar automáticamente:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
@@ -340,7 +318,7 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
@@ -348,122 +326,122 @@ msgstr ""
 "canal:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Dueño encontrado en el canal de voz:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 "Ignorando canal reanudable, Autoinvocar al propietario en el canal:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 "Ignorando el canal de autounión, autoinvocar al propietario en el canal:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Ya conectado al canal:  %(channel)s  en guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Intentando unirse al canal:  %(channel)s  en guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Descartando MusicPlayer y haciendo uno nuevo..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot creará un nuevo MusicPlayer ahora..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr "No unirse a %(guild)s/%(channel)s, no es un canal de voz compatible."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Finalizó la unión de canales configurados."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "El miembro no está habilitado por voz y no puede usar este comando."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "No puedes usar este comando cuando no estás en el canal de voz."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Obteniendo bot aplicación Info."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot no tiene permiso para conectarse en el canal:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot no tiene permiso para conectarse en el canal: `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot no tiene permiso para hablar en el canal:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot no tiene permiso para hablar en el canal: `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Reusando bots VoiceClient del gremio:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "Forzando desconexión en VoiceClient caducado en el gremio:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "¿Desconectar ha fallado o ha sido cancelado?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "MusicBot no puede conectarse al canal en este momento:  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -472,12 +450,12 @@ msgstr ""
 "Inténtalo de nuevo más tarde, o reinicia el bot si esto continúa."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot tiene ahora un cliente de voz..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -487,14 +465,14 @@ msgstr ""
 "(%(attempt)s) mientras intentaba conectar a:  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 "Se ha cancelado el intento de conexión de MusicBot VoiceClient. No hay "
 "reintento."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -502,42 +480,42 @@ msgstr ""
 "reiniciar?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot está solicitando hablar en el canal: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot no tiene permiso para hablar."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot no pudo pedir la palabra."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Desconectando a un MusicPlayer en el gremio:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Desconectando VoiceClient antes de matar a MusicPlayer."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "La desconexión falló o fue cancelada."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -545,18 +523,18 @@ msgstr ""
 "MusicBot tiene un VoiceProtocol que no es un VoiceClient. Desconectando..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Desconectando a un cliente de voz pícaro en el gremio:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Desconectando un cliente de voz que no es hermandad..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -566,7 +544,7 @@ msgstr ""
 "El objeto es realmente de tipo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
@@ -574,13 +552,13 @@ msgstr ""
 "%(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Guild (%(guild)s) quiere un jugador, opcional:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -589,24 +567,24 @@ msgstr ""
 "Probablemente debería reiniciar el bot."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer tiene un cliente de voz que no está conectado."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "Objeto del reproductor de música:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -616,7 +594,7 @@ msgstr ""
 "%(channel)s  Creado: %(create)s  Deserializar:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -626,7 +604,7 @@ msgstr ""
 "con entradas %(number)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -635,86 +613,86 @@ msgstr ""
 "Usa el comando invocar para llevar el bot a tu canal de voz."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Algo está mal, no conseguimos el Cliente de Voice."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "Ejecutando on_player_play"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Configurando el guild del historial de URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "No hay miniaturas definidas para la entrada con la URL: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "no hay canal en el que poner el mensaje en reproducción"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "ignoró el mensaje ahora que ya estaba publicado."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "Ejecutando on_player_resume"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "Ejecutando on_player_pause"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Ejecutando on_player_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Ejecutando on_player_terminado_jugando"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "El bucle del evento está cerrado, nada más que hacer aquí."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Cerrar sesión en curso, ignorando este evento."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 "VoiceClient dice que no está conectado, nada más que podemos hacer aquí."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "Jugador terminado y la cola está vacía, dejando el canal de voz..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 "Bucle sobre la cola para expurgar las canciones con el autor que falta..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -722,312 +700,312 @@ msgstr ""
 "Autor `%(user)s`, se omitió la entrada (eliminada) de la cola:  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 "No hay canciones reproducibles en la lista de reproducción automática del "
 "gremio, deshabilitando."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 "No hay contenido en la lista de reproducción automática actual. Completando "
 "con nueva música..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Bucle sobre la lista de reproducción automática..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Error al procesar la canción \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Error al extraer la canción \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot necesita detener la extracción de la lista de reproducción "
 "automática y la fianza."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 "MusicBot consiguió una excepción no controlada en el evento terminado del "
 "jugador."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 "Expandiendo lista de reproducción automática con entradas extraídas:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "Error al añadir la canción de la lista de reproducción automática: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Datos de excepción para el error anterior:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 "No hay canciones reproducibles en la lista de reproducción automática, "
 "desactivando."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "Ejecutando on_player_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 "Omitiendo automáticamente la entrada de la lista de reproducción automática "
 "para la entrada en cola."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "Excepción MusicPlayer para la entrada: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "Excepción de MusicPlayer."
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 "No se pudo reproducir la pista de lista de reproducción automática:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ""
 "Cerrar sesión en curso, ignorando el evento de actualización de estado."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Actualizar estado del bot:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Serializando cola para %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Deserializando cola para %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Escribiendo canción actual para %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "No se puede enviar objeto no respuesta:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Intentó enviar un objeto de respuesta no válido."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "enviando incrustado a: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "enviando texto a: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "No se puede enviar el mensaje a \"%s\", sin permiso"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "No se puede enviar el mensaje a \"%s\", canal no válido o eliminado"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "El mensaje excede el límite de tamaño del mensaje (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 "No se pudo enviar el mensaje privado, enviando en su lugar un canal de "
 "respaldo."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr "Velocidad de envío de mensajes limitada, reintentando en %s segundos."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Canceló el mensaje de reintento:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 "Valora el mensaje de envío limitado, ¡pero no se puede volver a intentar!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "No se pudo enviar el mensaje en el canal de retroceso."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Error al enviar debido a un error HTTP."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "No se puede eliminar el mensaje \"%s\", sin permiso"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "No se puede eliminar el mensaje \"%s\", mensaje no encontrado"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 "Eliminación de mensajes con tasa limitada, reintentando en %s segundos."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 "Valora la eliminación limitada de mensajes, ¡pero no se puede volver a "
 "intentar!"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Error al eliminar el mensaje"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Obtuvo HTTPException tratando de eliminar el mensaje: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "No se puede editar el mensaje \"%s\", mensaje no encontrado"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Enviando mensaje en su lugar"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 "Califica un mensaje de edición limitado, vuelve a intentarlo en %s segundos."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Edición de mensaje cancelada para:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Error al editar el mensaje"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Obtuvo HTTPException tratando de editar el mensaje %s a: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Cancelada la eliminación del mensaje (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Atrapó una señal del sistema operativo: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Desconectando y cerrando MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "¡Excepción arrojada mientras se maneja la señal de interrupción!"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot ahora está haciendo pasos de cierre..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1050,44 +1028,44 @@ msgstr ""
 "  Comprueba el estado de la API en el sitio oficial: discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "Esperando a que los hilos de descarga terminen..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Esperará la tarea:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Intentará cancelar la tarea:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "Esperando tareas pendientes..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Cerrando Conector HTTP."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Cerrando sesión aiohttp."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "Se ha llamado al cierre de sesión."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1097,63 +1075,63 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Excepción en %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot reanudó una sesión con discord."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Terminar en_listo"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Conectado, ahora teniendo MusicBot listo..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "ClientUser no es de alguna manera ninguna, tenemos la fianza..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Propietario:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Lista de Gremio:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "Abandonar %s debido al dueño del bot no encontrado"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
@@ -1161,18 +1139,18 @@ msgstr ""
 "disponibilidad"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "No se pudo encontrar el propietario en ningún gremio (ID: %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Propietario desconocido, el bot no está en ningún gremio."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1186,228 +1164,228 @@ msgstr ""
 "%s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Ninguno para el canal enlazado con ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "No se puede enlazar al canal no Mensajable con ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Vinculado a canales de texto:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "No vinculado a ningún canal de texto"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "No obtuvo ninguno para auto unirse al canal con ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr "No se puede auto unirse a un canal privado/no gremio con ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr "No se puede auto unirse al canal no conectable con ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Auto unirse a canales de voz:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "No te unes automáticamente a ningún canal de voz"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "Evento on_ready ha disparado %s veces"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Obteniendo información de la aplicación."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "Asegurando la existencia de las carpetas de datos"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Validando configuración"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Validando configuración de permisos"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Activado"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Opción:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Prefijo de comando: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  Volumen predeterminado: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Omitir umbral: %(num)d votos o %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Reproduciendo @menciones: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Lista de reproducción automática: %(status)s (orden: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "aleatorio"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "secuencial"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Pausa automática: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Borrar Mensajes: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Eliminar invocación: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Eliminar reproducción ahora: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Modo de depuración: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  Las canciones descargadas serán %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Eliminar si no se usa durante %d días"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Mensaje de estado: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Integración de Spotify: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Tiempo de espera: %s segundos"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Tiempo de espera: %d segundos"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Auto sordo: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Prefijo de comando por servidor: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Fiesta de Robin: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
@@ -1415,7 +1393,7 @@ msgstr ""
 "de canciones."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
@@ -1423,13 +1401,13 @@ msgstr ""
 "voz..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "Actividad del canal en espera en el gremio: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1438,34 +1416,34 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 "El temporizador de actividad del canal para %s ha caducado. Desconectando."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 "Temporizador de actividad del canal cancelado por: %(channel)s en %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Ignorando inactividad del jugador en el canal auto:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 "Temporizador de actividad del jugador que ya está esperando en el gremio: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1474,14 +1452,14 @@ msgstr ""
 " del canal: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 "El temporizador de actividad del jugador para %s ha caducado. Desconectando."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
@@ -1489,44 +1467,44 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Temporizador de actividad del jugador está siendo reiniciado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "No existe tal comando"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "Debe mencionar a un usuario o proporcionar su número de identidad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "Sub-comando inválido. Usa `help blockuser` para ejemplos de uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot no pudo encontrar el usuario(s) especificado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "El propietario no puede ser añadido a la lista de bloques."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 "No añadiendo usuario a la lista de bloques, ya bloqueados:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
@@ -1534,75 +1512,75 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 "No se pueden agregar los usuarios que has listado, que ya han sido añadidos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Debes proporcionar un tema de canción si ninguna canción se está "
 "reproduciendo actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "Sub-comando inválido. Usa `help blocksong` para ejemplos de uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "El asunto `%(subject)s` ya está en la lista de bloques de canciones."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 "El asunto no está en la lista de bloques de canciones y no puede ser "
 "eliminado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Sub-comando inválido. Usa `help autoplaylist` para los ejemplos de uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "El enlace a la canción suministrada no es válido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "La cola está vacía. ¡Añade algunas canciones con un comando de reproducción!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Esta canción ya está en la lista de reproducción automática."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Esta canción aún no está en la lista de reproducción automática."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Debe proporcionar un nombre de archivo de lista de reproducción."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "No tienes permisos para solicitar listas de reproducción"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
@@ -1610,7 +1588,7 @@ msgstr ""
 " es %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1622,12 +1600,12 @@ msgstr ""
 "El límite es %(max)s para tu grupo."
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Ignorando la pausa automática debido a la interrupción de la red."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1636,12 +1614,12 @@ msgstr ""
 "procesar la pausa automática."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Ya procesando la pausa automática, ignorando este evento."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1651,19 +1629,19 @@ msgstr ""
 "automática en el gremio:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "Se ha cancelado la pausa automática."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 "Un nuevo MusicPlayer está siendo conectado, ignorando el antiguo evento de "
 "la pausa automática."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
@@ -1671,40 +1649,40 @@ msgstr ""
 "gremio: %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "El jugador auto pausado anteriormente está pausado para el gremio: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "No se puede usar seek si no hay nada jugando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "No se puede usar seek en la pista actual, tiene una duración desconocida."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "La búsqueda no es compatible con los streams."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "No se puede usar seek sin tiempo para colocar la reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "No se pudo convertir `%(input)s` a una hora válida en segundos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1714,29 +1692,29 @@ msgstr ""
 " con una longitud de `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Sub-comando no válido. Utilice el comando `help repeat` para ejemplos de "
 "uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "El reproductor no está bucle actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Las posiciones de la canción deben ser enteras!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "¡Has dado una posición fuera del tamaño de la lista de reproducción!"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
@@ -1744,40 +1722,40 @@ msgstr ""
 "mensajes a los que añadir reacciones."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "La reproducción de medios locales no está habilitada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "La URL de Spotify no es válida o no está soportada actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Se ha detectado una URL de Spotify, pero Spotify no está habilitado."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Has alcanzado el límite de canciones en cola (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "El modo Karaoke está activado, ¡por favor inténtalo de nuevo cuando esté "
 "desactivado!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Problema con extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1787,15 +1765,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Ese video no se puede reproducir. Intenta usar el comando Stream."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "La búsqueda en YouTube no devolvió resultados para:  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1906,18 +1878,18 @@ msgid "Player is not playing."
 msgstr "El jugador no está reproduciendo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "¡Nada en la cola para eliminar!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "No se ha encontrado nada en la cola del usuario `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1926,40 +1898,40 @@ msgstr ""
 "la puso en cola o tener permisos de omisión instantánea."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Número de entrada no válido. Utilice el comando de cola para encontrar las "
 "posiciones de la cola."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "¡No se puede saltar! ¡El jugador no está jugando!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "No tienes permiso para forzar a saltar una canción en bucle."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "No tienes permiso para forzar saltar."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "No tienes permiso para saltar una canción en bucle."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` no es un número válido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1969,7 +1941,7 @@ msgstr ""
 "El volumen solo puede establecerse de 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1978,7 +1950,7 @@ msgstr ""
 " y 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1987,29 +1959,29 @@ msgstr ""
 "Utilice el comando de configuración para establecer una velocidad de reproducción predeterminada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocidad no se puede aplicar a los medios streamed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Debe proporcionar una velocidad para establecer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocidad que proporcionaste no es válida. Usa un número entre 0.5 y 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opción no válida para el comando: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2019,30 +1991,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Debe proporcionar un alias y un comando para alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Debe proporcionar un nombre de alias para eliminar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "El alias `%(alias)s` no existe."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuración no puede usar las menciones de canal y usuario al mismo "
 "tiempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2052,7 +2024,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2061,19 +2033,19 @@ msgstr ""
 "favor, introduzca un nombre de sección y opción válidos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "La opción dada es ambigua, por favor ingrese un nombre de sección."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Debe proporcionar un nombre de sección y un nombre de opción para este "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2083,32 +2055,32 @@ msgstr ""
 "Las secciones disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "La opción `%(option)s` no está disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede guardar en el disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Error al guardar la opción: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "La opción `%(option)s` no es editable, el valor no se puede mostrar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2116,71 +2088,71 @@ msgstr ""
 "configuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Debe proporcionar una sección, opción y valor para este sub-comando."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Al establecer con %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "¡La opción `%(option)s` no fue actualizada!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede restablecer por defecto."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Restableciendo %(config)s a %(value)s por defecto"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "¡La opción `%(option)s` no se ha restablecido por defecto!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "El comando de opción está obsoleto, utilice el comando de configuración en "
 "su lugar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opción especificada no válida, use: info, actualización o borrado"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Fallo** al eliminar caché, comprueba los registros para más información..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "El argumento de página de cola debe ser un número entero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "No hay canciones en cola! Coloca algo con un comando de reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2190,24 +2162,24 @@ msgstr ""
 "Hay **%(total)s** páginas."
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "Se omitió la entrada de la lista de reproducción actual."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "No hay suficientes entradas para paginar la cola."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "No se pudo publicar el mensaje de cola, no hay mensajes a los que añadir "
 "reacciones."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2216,17 +2188,17 @@ msgstr ""
 "Si el problema persiste, envíe un informe de error."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "No se puede utilizar la purga en el canal DM privado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "La URL dada no era una URL válida."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2236,12 +2208,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Esto no parece ser una lista de reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2250,18 +2222,18 @@ msgstr ""
 "inténtelo de nuevo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "No se pudo determinar el usuario de discord. Inténtalo de nuevo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Los permisos no pueden usar menciones de canal y usuario al mismo tiempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2271,23 +2243,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Debe proporcionar un nombre de grupo o opción para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Debe proporcionar un grupo, opción y valor para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "El subcomando %(option)s requiere un grupo y un nombre de permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2297,47 +2269,47 @@ msgstr ""
 "Los grupos disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "El permiso `%(option)s` no está disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "No se puede agregar el grupo `%(group)s` que ya existe."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "No se puede eliminar el grupo integrado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "El grupo propietario no es editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Error al guardar el grupo: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Al establecer %(option)s con valor: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "¡El permiso `%(option)s` no fue actualizado!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2346,7 +2318,7 @@ msgstr ""
 "Recuerda que los cambios de nombre están limitados a dos veces por hora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2356,12 +2328,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "No se puede cambiar el apodo: no hay permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2371,13 +2343,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Los emoji personalizados deben ser de este servidor para usar como prefijo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2386,29 +2358,29 @@ msgstr ""
 "Utilice el comando de configuración para actualizar el prefijo en su lugar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Este comando sólo puede ser usado en gremios."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sub-comando inválido. Utilice el comando de ayuda para más información."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "No se puede establecer el idioma a `%(locale)s` no está disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Debe proporcionar una URL o adjuntar un archivo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2418,19 +2390,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot encontró un %s sin gremio! Esto podría ser un problema."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Actualmente no conectado al servidor `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2438,44 +2410,44 @@ msgstr ""
 "actualizada o actualizada"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Debe proporcionar un ID o nombre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No se ha encontrado ningún gremio con el ID o nombre `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Activando ID del breakpoint de depuración: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "No se pudo importar `objgraph`, ¿está instalado?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Código de depuración ejecutado con eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Código de depuración ejecutado con exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "Error al ejecutar el código de depuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2491,57 +2463,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "El subcomando debe ser uno de: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "No se pudo encontrar el ejecutable de git."
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "Error al buscar actualizaciones mediante el comando git."
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Paquete que falta meta en el informe pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 "Error al obtener el estado de actualización de pip debido a algún error."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Obtuvo una entrada extraña del cliente de voz."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Las cookies ya están habilitadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Las cookies deben ser subidas para estar habilitadas. (Falta archivo de "
 "cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "No se pudo habilitar las cookies debido a un error:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2551,7 +2523,7 @@ msgstr ""
 "Cookies temporalmente deshabilitadas y serán reactivadas en el siguiente reinicio."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2559,7 +2531,7 @@ msgstr ""
 "archivo de cookies."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
@@ -2567,44 +2539,44 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 "Error al descargar el archivo de cookies desde discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "No se han podido guardar las cookies en el disco:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Obtuviste un mensaje sin canal, de alguna manera:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorando el comando de mí mismo (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignorando comando de otro bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignorando comando del canal de tipo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2612,100 +2584,100 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Mensaje de %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Este comando no está permitido para el grupo de permisos:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Este comando requiere que estés en un canal de Voice."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 "Uso de comandos no válido, faltan valores para los parámetros: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Error en %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Excepción al manejar el comando: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "No se puede generar ayuda para el comando que falta:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Faltan datos de ayuda para el comando:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Dejando el canal de voz %s en %s por inactividad."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot se ha conectado."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot se ha desconectado."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Obtuvo un Evento de Socket:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "Estado de voz actualizado antes de finalizado el on_ready"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorando %s en %s ya que es un canal de voz vinculado."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s ha sido detectado como vacío. Manejo de tiempos de espera."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Un usuario se unió a %s, cancelando temporizador."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2714,30 +2686,30 @@ msgstr ""
 " espera de espera."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "El bot se movió y el canal de voz %s no está vacío."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "Ya no sigue al usuario %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "El siguiente usuario `%(user)s` para el canal:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState se desconecta antes.channel Ninguno."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2747,7 +2719,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2755,90 +2727,90 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "No se puede encontrar el canal auto-unido, ¿fue eliminado? Guild:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Reconectando al gremio auto-unido en el canal:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "No se puede auto unirse al canal:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "El bot ha sido añadido al gremio: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "El gremio izquierdo '%s' debido al propietario del bot no encontrado."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Creando carpeta de datos para guild %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "El bot ha sido eliminado del gremio: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Lista de guild actualizada:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "El gremio \"%s\" está disponible."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Reanudando jugador en \"%s\" debido a la disponibilidad."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "El gremio \"%s\" no está disponible."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausando jugador en \"%s\" debido a la falta de disponibilidad."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Actualización del gremio para:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Atributo del gremio %(attr)s ahora: %(new)s  -- Era: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Actualización del canal para:  %(channel)s  --  %(changes)s"
@@ -2856,7 +2828,7 @@ msgid "Loading config from:  %s"
 msgstr "Cargando configuración de:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2886,7 +2858,7 @@ msgstr ""
 "  Use las opciones de ejemplo como plantilla o cópielas del repositorio."
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2896,7 +2868,7 @@ msgstr ""
 "será limitada en su lugar."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2905,7 +2877,7 @@ msgstr ""
 "rotación de archivos de registro. Usando el valor predeterminado."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2924,12 +2896,12 @@ msgstr ""
 "  Asegúrese de que la ruta que ha configurado es una ruta a una carpeta / directorio."
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Se lanzó una excepción al validar AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2951,13 +2923,13 @@ msgstr ""
 "  Verifique nuevamente que la configuración sea una ruta de directorio válida y accesible."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "La caché de audio se almacenará en:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2977,7 +2949,7 @@ msgstr ""
 "  Establecer la opción de configuración del token o establecer la variable de entorno %(env_var)s con un token de aplicación."
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2986,7 +2958,7 @@ msgstr ""
 "a 128 caracteres."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2996,17 +2968,17 @@ msgstr ""
 " valor de opción de %.3f será limitado en su lugar."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Validando opciones con datos de servicio..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "ID del propietario adquirido a través de API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3027,12 +2999,12 @@ msgstr ""
 "  Establezca manualmente la opción de configuración 'OwnerID' o vuelva a intentarlo más tarde."
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot no tiene una instancia de usuario, no puede continuar."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3051,14 +3023,14 @@ msgstr ""
 "  No utilice el Bot o el ID de la aplicación en el campo OwnerID."
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "Archivo de opciones de configuración no encontrado. Comprobando "
 "alternativas..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3068,20 +3040,20 @@ msgstr ""
 "las extensiones de archivos."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copiando archivo de opciones de ejemplo existente:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Algo salió mal mientras se trataba de encontrar un archivo de opciones de "
 "configuración."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3103,7 +3075,7 @@ msgstr ""
 "  Verifique que la carpeta y los archivos de configuración existan y que MusicBot pueda leerlos."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3127,13 +3099,13 @@ msgstr ""
 "  Copie el archivo de ejemplo del repositorio si todo lo demás falla."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 "Dev Bug! La opción de configuración tiene getter que no está disponible."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3142,12 +3114,12 @@ msgstr ""
 " deben ser del mismo tipo."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "La opción faltaba anteriormente."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
@@ -3155,19 +3127,19 @@ msgstr ""
 "%s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Opción de configuración guardada: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Error al guardar la configuración:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3175,13 +3147,13 @@ msgstr ""
 "está desactivado."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Error al guardar el archivo INI por defecto en:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3201,7 +3173,7 @@ msgstr ""
 "  Establece %(option)s a un ID numérico o establézcalo a `auto` o `0` para vincular al propietario automático."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3221,7 +3193,7 @@ msgstr ""
 "  Comprueba la configuración de ruta y asegúrate de que el archivo existe y es accesible a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3241,7 +3213,7 @@ msgstr ""
 "  Asegúrese de que todos los IDs sean numéricos y separados solo por espacios o comas."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3251,7 +3223,7 @@ msgstr ""
 "%(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3261,7 +3233,7 @@ msgstr ""
 "'%(value)s' usando por defecto en su lugar."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3271,7 +3243,7 @@ msgstr ""
 "(%(value)s) y se establecerá en %(fallback)s en su lugar."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3280,54 +3252,54 @@ msgstr ""
 "%(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Actualizando archivo de configuración con opciones renombradas..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Error al actualizar la configuración. Necesitarás actualizarla manualmente."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Archivo de lista de bloques no encontrado:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "No se pudo cargar la lista de bloqueo del archivo:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "No se pudo actualizar el archivo de lista de bloqueos:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Lista de bloques de usuarios cargada con entradas %s."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "Encontramos un archivo antiguo de lista negra, se renombrará a:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Se cargó una lista de bloques de canciones con entradas %s."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3335,19 +3307,19 @@ msgstr ""
 " error en el código!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "Ningún archivo para el gremio %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "Cargando datos de guild para guild con ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
@@ -3355,14 +3327,14 @@ msgstr ""
 " del gremio:  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 "Guild %(id)s/%(name)s tiene un prefijo de comando personalizado: %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3370,60 +3342,60 @@ msgstr ""
 "un error en el código!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 "No se pudo guardar datos específicos del gremio debido al error del sistema "
 "operativo."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 "Error al serializar datos específicos del gremio debido a datos no válidos."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Obligando a YTDLP a usar el agente de usuario:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot utilizará cookies para yt-dlp de:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp usará su servidor proxy configurado."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD parece no tener cabeceras..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 "La comprobación de las cabeceras de los medios falló debido al tiempo de "
 "espera."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Error de solicitud HEAD para:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "Excepción de solicitud HEAD: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3433,57 +3405,57 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Sanitized YTDL Extraction Info (no JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "La extracción de información de canciones no devolvió datos."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Se llamó a extract_info con: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "No se puede ejecutar la extracción, el bucle está cerrado. (Esto es normal "
 "al apagar)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "No se puede continuar la extracción, el bucle del evento está cerrado."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "La URL de Spotify no es válida o no es compatible."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Error de descarga con la URL del stream"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "Suponiendo que el contenido es un flujo directo"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "No se puede transmitir una URL no válida."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3491,23 +3463,23 @@ msgstr ""
 " puntos con el espacio."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Llamado safe_extract_info con:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "No se ha podido encontrar el archivo de medios locales."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Falta __input_subject de YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3515,7 +3487,7 @@ msgstr ""
 "para evitar esto."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Atención, error de duración para: %(url)s"
@@ -3561,13 +3533,13 @@ msgstr ""
 "Nombre de la entrada:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 "Los datos de entrada no tienen número de versión, no se pueden deserializar."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 "Los datos de entrada tienen un número de versión incorrecto, no se puede "
@@ -3602,7 +3574,7 @@ msgstr ""
 "la búsqueda!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "No se pudo cargar %s"
@@ -3616,7 +3588,7 @@ msgstr ""
 " %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Preparando la entrada:  %r"
@@ -3638,7 +3610,7 @@ msgid "Download already cached at:  %s"
 msgstr "Descarga ya almacenada en caché en:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3656,7 +3628,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Duración obtenida de %(time)s segundos para el archivo:  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3667,75 +3639,75 @@ msgstr ""
 "para funcionar, pero significará que tus pistas no serán igualadas."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Excepción al comprobar los datos de entrada."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Intentando obtener la duración de pymediainfo para:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "No se pudo obtener la duración a través de pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Intentando obtener la duración a través de ffprobe para:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "¡No se pudo localizar ffprobe en tu ruta!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe devolvió algo que no pudo ser usado."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe no se pudo ejecutar por alguna razón."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Calculando volumen promedio de:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "¡No se pudo localizar ffmpeg en la ruta!"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "No se pudo analizar 'I' en la normalización de json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "No se pudo analizar 'LRA' en la normalización de json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "No se pudo analizar 'TP' en la normalización de json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "No se pudo analizar el 'umbral' en la normalización de json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "No se pudo analizar 'offset' en la normalización de json."
 
@@ -3779,56 +3751,56 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "La descarga falló debido a un error yt-dlp: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "La extracción encontró una excepción no manejada."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "La descarga falló debido a una excepción no controlada: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Descarga fallida:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Error al extraer los datos del medio solicitado."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Descarga completada:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 "El StreamPlaylistEntry Deserializado no puede encontrar el canal con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 "El StreamPlaylistEntry Deserializado tiene el tipo de canal incorrecto:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "El StreamPlaylistEntry Deserializado no puede encontrar el autor con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
@@ -3836,28 +3808,28 @@ msgstr ""
 "para la búsqueda!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 "Deserializado LocalFilePlaylistEntry no puede encontrar el canal con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 "LocalFilePlaylistEntry deserializado tiene el tipo de canal incorrecto:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "Deserializado LocalFilePlaylistEntry no puede encontrar el autor con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3866,7 +3838,7 @@ msgstr ""
 " canal para la búsqueda!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Duración obtenida de %(seconds)s segundos para el archivo:  %(file)s"
@@ -3984,13 +3956,13 @@ msgstr ""
 "Old: %(old)s  New: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Error de argumento de longitud:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -3998,7 +3970,7 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4330,60 +4302,60 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Datos decodificados de ffmpeg: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Añadiendo entrada de stream para URL:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "No se pudo extraer la información"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Esta es una lista de reproducción."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 "La información de la entrada parece ser un flujo, añadiendo entrada de la "
 "corriente..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Tipo de contenido inválido `%(type)s` para la URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 "Obtuvo text/html para el tipo de contenido, esto podría ser un stream."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Tipo de contenido cuestionable \"%(type)s\" para la url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Añadiendo URLPlaylistEntry para: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Añadiendo la lista de reproducción local para: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr ""
@@ -4391,7 +4363,7 @@ msgstr ""
 "%s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4400,7 +4372,7 @@ msgstr ""
 "%(title)s  URL: %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4409,7 +4381,7 @@ msgstr ""
 "máximo permitido."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4417,40 +4389,40 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "No se pudo agregar el artículo"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Artículo: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "Se omitieron %s entradas incorrectas"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Reordenar bucle sobre entradas."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Pre-descargar la siguiente pista:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "sin datos de duración"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "no hay datos de duración en la entrada actual"
 
@@ -5038,44 +5010,44 @@ msgstr ""
 "'%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Versión:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Se ha abierto una nueva instancia de MusicBot. ¡Este terminal puede cerrarse"
 " de forma segura!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Cargando versión de MusicBot:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Registro abierto:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Cambiando directorio de trabajo a:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5086,7 +5058,7 @@ msgstr ""
 "nueva ubicación de directorio."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5095,7 +5067,7 @@ msgstr ""
 "Si no utilizó git para clonar el repositorio, se le recomienda encarecidamente que lo haga."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5104,12 +5076,12 @@ msgstr ""
 "certificar y salir."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Aquí está el error exacto, podría ser un error."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5118,7 +5090,7 @@ msgstr ""
 "puede abrir el sitio fallido en Microsoft Edge o IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5127,17 +5099,17 @@ msgstr ""
 "defecto, en su lugar intentando certificfi."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Error de sintaxis (modificación detectada, ¿editaste el código?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Error de sintaxis (esto es un error, no su culpa)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5158,14 +5130,14 @@ msgstr ""
 "  o ejecutar sin `--no-install-deps` y MusicBot intentará instalarlos para ti."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Intentando instalar automáticamente los paquetes de dependencias de "
 "MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5201,12 +5173,12 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "¡Vale, esperemos que la instalación de dependencias funcione!"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5215,58 +5187,58 @@ msgstr ""
 "MusicBot debe salir..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "La excepción que causó el error anterior: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot está reiniciando suavemente..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot está reiniciando todo el proceso..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Error al iniciar el bot"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Cerrando bucle de evento."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Reiniciando en %s segundos..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "Todo listo."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "¡Vale, estamos cerrando!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr "MusicBot ahora está realizando los pasos de inicio..."
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr "Error al iniciar sesión."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -5299,12 +5271,12 @@ msgstr ""
 " %(path)s"
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr "Generando nuevos archivos de opciones de configuración..."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5326,7 +5298,7 @@ msgstr ""
 "  Asegúrese de que MusicBot pueda leer y escribir en sus archivos de configuración.\n"
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5417,45 +5389,45 @@ msgstr ""
 "MusicBot debe tener permiso para crear este directorio.\n"
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -5467,220 +5439,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5699,30 +5671,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5730,18 +5702,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5816,9 +5788,92 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+#~ "La configuración no tenía credenciales de aplicación de Spotify, intentando "
+#~ "usar modo invitado."
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "Autenticado con Spotify utilizando correctamente el modo invitado."
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+#~ "No se pudo iniciar el cliente de Spotify usando el modo invitado. Detalles: "
+#~ "%s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "La búsqueda en YouTube no devolvió resultados para:  %(url)s"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/es_ES/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/es_ES/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-17 13:56-0800\n"
@@ -819,7 +819,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr "No hay canciones en la cola. Reproduce algo con un comando de juego."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Las posiciones de la canción deben ser enteras!"
 
@@ -857,30 +857,30 @@ msgid "Local media playback is not enabled."
 msgstr "La reproducción de medios locales no está habilitada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "La URL de Spotify no es válida o no está soportada actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Se ha detectado una URL de Spotify, pero Spotify no está habilitado."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Has alcanzado el límite de canciones en cola (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "El modo Karaoke está activado, ¡por favor inténtalo de nuevo cuando esté "
 "desactivado!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -890,12 +890,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Ese video no se puede reproducir. Intenta usar el comando Stream."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -904,7 +904,7 @@ msgstr ""
 "máxima (%(max)s segundos)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -914,13 +914,13 @@ msgstr ""
 "Posición en cola: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "La duración de la canción excede el límite (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -930,24 +930,24 @@ msgstr ""
 "Posición en cola: %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "¡Reproduciendo a continuación!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - tiempo estimado hasta jugar: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - no se puede calcular el tiempo hasta jugar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -960,24 +960,24 @@ msgstr ""
 "Nota: FFmpeg puede interrumpir la transmisión aleatoriamente o si ocurren problemas de conexión.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Las listas de reproducción de streaming aún no están soportadas."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "Ahora la pista de streaming `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 "    Buscar con servicio varios resultados con la consulta de búsqueda.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -986,14 +986,14 @@ msgstr ""
 "    Nota: las comillas dobles son requeridas en este caso.\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 "Has alcanzado el límite de elementos de tu lista de reproducción (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -1001,46 +1001,46 @@ msgstr ""
 "información."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "No puedes buscar más de %(max)s vídeos"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Buscando videos..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "La búsqueda falló debido a un error: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "No se encontraron vídeos."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "Para seleccionar una canción, escriba el número correspondiente."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Resultados de la búsqueda de %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** | %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1049,195 +1049,195 @@ msgstr ""
 "**0**. Cancela"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Elige una canción"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Canción añadida [%(track)s](%(url)s) a la cola."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Resultado %(number)s de %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "Muy bien, ¡vaya!"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Mostrar información sobre lo que se está reproduciendo actualmente."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "Reproduciendo"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Transmisión actual:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "Reproduciendo actualmente:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Añadido por:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Progreso:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "No hay canciones en cola! Coloca algo con un comando de reproducción."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Dile a MusicBot que se una al canal en el que estás."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "No estás conectado a la voz. ¡Prueba a unirte a un canal de voz!"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Conectado a `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 "Hace que MusicBot siga a un usuario cuando cambia de canal en un servidor.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "Ya no sigue al usuario `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Ahora siguiendo al usuario `%(user)s` entre los canales de voz."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot no puede seguir a un usuario que no es miembro del servidor."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "Siguirá al usuario `%(user)s` entre los canales de voz."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Pausar la reproducción si una pista se está reproduciendo."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Música en pausa en `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "El jugador no está reproduciendo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "Reinicia la reproducción si el jugador estaba pausado previamente."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Reanudó la música en `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Cola de música restablecida"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Jugador no está pausado."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Mezclar todos los rastros actuales en cola."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Mezclado todas las canciones en la cola."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Elimina todas las canciones actualmente en cola."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Se borraron todas las canciones de la cola."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "¡Nada en la cola para eliminar!"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Eliminado `%(track)s` añadido por `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "No se ha encontrado nada en la cola del usuario `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1246,26 +1246,26 @@ msgstr ""
 "la puso en cola o tener permisos de omisión instantánea."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Número de entrada no válido. Utilice el comando de cola para encontrar las "
 "posiciones de la cola."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Entrada eliminada `%(track)s` añadida por `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Se ha eliminado la entrada `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1276,23 +1276,23 @@ msgstr ""
 "Si la opción LegacySkip está activada, el parámetro de fuerza puede ser ignorado.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "¡No se puede saltar! ¡El jugador no está jugando!"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "La siguiente canción `%(track)s` está descargando, por favor espere."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "La siguiente canción se reproducirá en breve. Por favor espere."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1301,7 +1301,7 @@ msgstr ""
 "Puede que quieras reiniciar el bot si no empieza a funcionar."
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1310,28 +1310,28 @@ msgstr ""
 "Puede que quieras reiniciar el bot si no empieza a funcionar."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "No tienes permiso para forzar a saltar una canción en bucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Forzar omitido `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "No tienes permiso para forzar saltar."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "No tienes permiso para saltar una canción en bucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1341,12 +1341,12 @@ msgstr ""
 "El voto para saltar ha sido aprobado.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " ¡Próxima canción!"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1356,7 +1356,7 @@ msgstr ""
 "Necesitas **%(votes)s** más votos para saltarte esta canción."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1367,25 +1367,25 @@ msgstr ""
 "La configuración de volumen se conserva hasta que se reinicia MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Volumen actual: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` no es un número válido"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Volumen actualizado de **%(old)d** a **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1395,7 +1395,7 @@ msgstr ""
 "El volumen solo puede establecerse de 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1404,7 +1404,7 @@ msgstr ""
 " y 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1415,7 +1415,7 @@ msgstr ""
 "La reproducción de streaming no soporta ajustes de velocidad.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1424,35 +1424,35 @@ msgstr ""
 "Utilice el comando de configuración para establecer una velocidad de reproducción predeterminada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocidad no se puede aplicar a los medios streamed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Debe proporcionar una velocidad para establecer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocidad que proporcionaste no es válida. Usa un número entre 0.5 y 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Ajustando velocidad de reproducción a `%(speed).3f` para el rastro actual."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Añadir un nuevo alias con argumentos opcionales.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1461,23 +1461,23 @@ msgstr ""
 " ayuda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opción no válida para el comando: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Alias recargados desde archivo de configuración."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Alias guardados al archivo de configuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1487,42 +1487,42 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Debe proporcionar un alias y un comando para alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nuevo alias añadido. `%(alias)s` ahora es un alias de `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Debe proporcionar un nombre de alias para eliminar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "El alias `%(alias)s` no existe."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` fue eliminado."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Muestra texto de ayuda sobre cualquier opción de configuración "
 "faltante.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1531,33 +1531,33 @@ msgstr ""
 " archivo de configuración.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 "    Lista de las opciones de configuración disponibles y sus secciones.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Recargar el archivo options.ini desde el disco.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Muestra texto de ayuda para una opción específica.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Mostrar el valor actual de la opción.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Guarda el valor actual en el archivo de opciones.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1566,35 +1566,35 @@ msgstr ""
 " archivo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Restablecer la opción a su valor predeterminado.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Administrar la configuración options.ini desde dentro de Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuración no puede usar las menciones de canal y usuario al mismo "
 "tiempo."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 "*¡Todas las opciones de configuración están presentes y contabilizadas!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "Ninguna opción de configuración parece ser cambiada."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1604,7 +1604,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1620,12 +1620,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "Opciones de configuración recargadas desde el archivo con éxito!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1635,7 +1635,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1644,19 +1644,19 @@ msgstr ""
 "favor, introduzca un nombre de sección y opción válidos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "La opción dada es ambigua, por favor ingrese un nombre de sección."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Debe proporcionar un nombre de sección y un nombre de opción para este "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1666,25 +1666,25 @@ msgstr ""
 "Las secciones disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "La opción `%(option)s` no está disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Esta opción sólo se puede establecer editando el archivo de configuración."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Por defecto esta opción se establece como: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1698,32 +1698,32 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede guardar en el disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Error al guardar la opción: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Opción guardada con éxito: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "La opción `%(option)s` no es editable, el valor no se puede mostrar."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1735,7 +1735,7 @@ msgstr ""
 "Valor del archivo INI: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1743,18 +1743,18 @@ msgstr ""
 "configuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Debe proporcionar una sección, opción y valor para este sub-comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "¡La opción `%(option)s` no fue actualizada!"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1764,20 +1764,20 @@ msgstr ""
 "Para guardar el cambio use `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede restablecer por defecto."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "¡La opción `%(option)s` no se ha restablecido por defecto!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1787,19 +1787,19 @@ msgstr ""
 "Para guardar el cambio use `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Comando obsoleto, use el comando config en su lugar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "El comando de opción está obsoleto, utilice el comando de configuración en "
 "su lugar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1808,33 +1808,33 @@ msgstr ""
 "Al utilizar la opción de actualización, se escaneará la caché en busca de cambios externos antes de mostrar los detalles."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opción especificada no válida, use: info, actualización o borrado"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Activado"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s días"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Ilimitado"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1850,23 +1850,23 @@ msgstr ""
 "**Cacheo ahora:  %(used)s en archivos %(files)s."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "Se ha borrado la caché."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Fallo** al eliminar caché, comprueba los registros para más información..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "Caché no encontrado para borrar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1875,12 +1875,12 @@ msgstr ""
 "Número de página opcional muestra las entradas posteriores en la cola.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "El argumento de página de cola debe ser un número entero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1890,12 +1890,12 @@ msgstr ""
 "Hay **%(total)s** páginas."
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(duración desconocida)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1907,7 +1907,7 @@ msgstr ""
 "Progreso: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1921,12 +1921,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Canciones en cola"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1935,7 +1935,7 @@ msgstr ""
 "Si el problema persiste, envíe un informe de error."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1946,40 +1946,40 @@ msgstr ""
 "Este comando puede ser lento si se dan rangos más grandes.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Parámetro no válido. Por favor, proporcione un número de mensajes a buscar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "No se puede utilizar la purga en el canal DM privado."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Se han limpiado %(number)s mensaje(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "El bot no tiene permiso para administrar mensajes."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 "Volcar las URLs individuales de una lista de reproducción a un archivo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "La URL dada no era una URL válida."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1989,18 +1989,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Esto no parece ser una lista de reproducción."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Aquí está el volcado de la lista de reproducción para:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2009,19 +2009,19 @@ msgstr ""
 "Este comando está en desuso y se ha sustituido por el modo de desarrollador en los clientes de Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Tu ID de usuario es `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "El ID de usuario para `%(username)s` es `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2032,25 +2032,25 @@ msgstr ""
 "Este comando está obsoleto a favor de usar el modo desarrollador en los clientes de Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Categorías válidas: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Aquí están los IDs que ha solicitado:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 "Obtenga una lista de sus permisos, o los permisos del usuario mencionado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2059,12 +2059,12 @@ msgstr ""
 "inténtelo de nuevo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "No se pudo determinar el usuario de discord. Inténtalo de nuevo."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2078,7 +2078,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2092,63 +2092,63 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Mostrar grupos cargados y listar las opciones de permisos.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Recarga los permisos del archivo permissions.ini.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    Añadir un nuevo grupo por defecto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Eliminar grupo existente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Mostrar texto de ayuda para la opción de permisos.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Mostrar el valor del permiso para un grupo y permiso dado.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Guardar grupo de permisos en el archivo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Establecer el valor del permiso para el grupo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Administrar la configuración permissions.ini desde discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Los permisos no pueden usar menciones de canal y usuario al mismo tiempo."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "¡Permisos recargados desde el archivo con éxito!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2158,7 +2158,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2172,23 +2172,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Debe proporcionar un nombre de grupo o opción para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Debe proporcionar un grupo, opción y valor para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "El subcomando %(option)s requiere un grupo y un nombre de permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2198,25 +2198,25 @@ msgstr ""
 "Los grupos disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "El permiso `%(option)s` no está disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Este permiso sólo se puede establecer editando el archivo de permisos."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Por defecto este permiso está establecido en: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2230,13 +2230,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "No se puede agregar el grupo `%(group)s` que ya existe."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2248,12 +2248,12 @@ msgstr ""
 "Asegúrate de guardar el nuevo grupo con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "No se puede eliminar el grupo integrado."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2263,24 +2263,24 @@ msgstr ""
 "Asegúrese de guardar este cambio con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "El grupo propietario no es editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Error al guardar el grupo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Se ha guardado correctamente el grupo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2292,13 +2292,13 @@ msgstr ""
 "Valor del archivo INI: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "¡El permiso `%(option)s` no fue actualizado!"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2308,7 +2308,7 @@ msgstr ""
 "Para guardar el cambio use `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2317,7 +2317,7 @@ msgstr ""
 "Nota: La API puede limitar los cambios de nombre a dos veces por hora."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2326,7 +2326,7 @@ msgstr ""
 "Recuerda que los cambios de nombre están limitados a dos veces por hora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2336,23 +2336,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Establezca el nombre de usuario del bot a `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Cambiar el apodo de MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "No se puede cambiar el apodo: no hay permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2362,23 +2362,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Establecer el apodo del bot a `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Establecer un prefijo de comando por servidor."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Borrar el prefijo de comando por servidor."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2387,24 +2387,24 @@ msgstr ""
 "La opción EnablePrefixPerGuild debe estar habilitada primero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Los emoji personalizados deben ser de este servidor para usar como prefijo."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Se ha borrado el prefijo del comando del servidor."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "El prefijo del comando del servidor es ahora:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2413,41 +2413,41 @@ msgstr ""
 "Utilice el comando de configuración para actualizar el prefijo en su lugar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Mostrar códigos de idioma disponibles para usar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    Establezca el idioma deseado para este servidor.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 "    Restablecer el idioma del servidor al idioma predeterminado del bot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 "Administrar el idioma utilizado para los mensajes en el servidor de "
 "llamadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Este comando sólo puede ser usado en gremios."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sub-comando inválido. Utilice el comando de ayuda para más información."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2461,25 +2461,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "No se puede establecer el idioma a `%(locale)s` no está disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Idioma para este servidor ahora establecido en: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "El idioma de este servidor se ha restablecido a: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2488,12 +2488,12 @@ msgstr ""
 "Adjuntar un archivo y omitir el parámetro url también funciona.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Debe proporcionar una URL o adjuntar un archivo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2503,61 +2503,61 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "Se ha cambiado el avatar del bot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Forzar a MusicBot a desconectarse del servidor de discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Desconectado del servidor `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "¿Desconectado un cliente de voz sin jugador? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Actualmente no conectado al servidor `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Intento de recargar sin reiniciar el proceso. La opción "
 "predeterminada.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr "    Intentó reiniciar todo el proceso de MusicBot. Recargando todo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Reinicio completo, pero intente actualizar los paquetes pip antes de "
 "reiniciar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Reinicio completo, pero actualiza el código fuente de MusicBot con git "
 "primero.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2566,7 +2566,7 @@ msgstr ""
 "reiniciar por completo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2579,7 +2579,7 @@ msgstr ""
 "Si tiene un administrador de servicios, le recomendamos que lo utilice en lugar de este comando para reiniciar.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2587,19 +2587,19 @@ msgstr ""
 "actualizada o actualizada"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Reiniciando la instancia actual..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Reiniciando el proceso del bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2608,7 +2608,7 @@ msgstr ""
 "bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
@@ -2616,23 +2616,23 @@ msgstr ""
 "bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Intentará actualizar todo y reiniciar el bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Desconecte de todos los canales de voz y cierre el proceso MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Deja el servidor de discord dado por nombre o ID del servidor."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2641,12 +2641,12 @@ msgstr ""
 "Los nombres son sensibles a mayúsculas y minúsculas, por lo que usar un número de ID es más fiable.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Debe proporcionar un ID o nombre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No se ha encontrado ningún gremio con el ID o nombre `%(input)s`"
@@ -2658,14 +2658,14 @@ msgid "Unknown"
 msgstr "Desconocido"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 "Abandonó el gremio: `%(name)s` (Propietario: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2674,38 +2674,38 @@ msgstr ""
 "Puede utilizarse para identificar manualmente los eventos en el archivo de registro de MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Breakpoint registrado con ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Ver los tipos más comunes reportados por el objeto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Ver salida objgraph.show_growth() limitada.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Visualiza los tipos más comunes de objetos de fuego.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Ver tipografías de objetos que filtran.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Evaluar la función y argumentos dados sobre el objeto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2716,12 +2716,12 @@ msgstr ""
 "Dado que este método evalúa código arbitrario, se considera peligroso, al igual que el comando de depuración.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "No se pudo importar `objgraph`, ¿está instalado?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2746,7 +2746,7 @@ msgstr ""
 "El peligro de este comando no se puede subestimar. ¡No lo use ni le dé acceso si no comprende los riesgos!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2762,7 +2762,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2771,23 +2771,23 @@ msgstr ""
 "La salida se utiliza para actualizar las páginas de GitHub y por lo tanto no es adecuada para uso de referencia normal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "El subcomando debe ser uno de: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Crea archivos INI por defecto."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Guardado el archivo INI solicitado en el disco. Compruébalo"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2796,50 +2796,50 @@ msgstr ""
 "MusicBot o dependencias.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "No se pudo encontrar el ejecutable de git."
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "No hay actualizaciones en la rama `%(branch)s` remoto."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nuevos commits están disponibles en `%(branch)srama remota."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "Error al comprobar, vea los registros para más detalles."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Actualizar para `%(name)s` a la versión: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "No se encontraron actualizaciones para dependencias."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "Hay actualizaciones para MusicBot disponibles para su descarga."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot es totalmente fecha!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2859,20 +2859,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Muestra el tiempo de actividad de MusicBot, o la hora desde el último inicio"
 " / reinicio."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s ha estado en línea para `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2880,12 +2880,12 @@ msgstr ""
 "de voz conectados."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "No hay clientes de voz conectados.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 "Mostrar latencia de la API y latencia de voz si MusicBot está conectado."
@@ -2893,23 +2893,23 @@ msgstr ""
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Latencia API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Mostrar el número de versión de MusicBot en el chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2919,18 +2919,18 @@ msgstr ""
 "Versión actual: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 "    Actualice el archivo cookies.txt usando un archivo adjunto cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Activar o desactivar el archivo cookies.txt sin borrarlo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2955,30 +2955,30 @@ msgstr ""
 "  función si no entiendes cómo evitarlos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Las cookies ya están habilitadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Las cookies deben ser subidas para estar habilitadas. (Falta archivo de "
 "cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "No se pudo habilitar las cookies debido a un error:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Las cookies han sido habilitadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2988,12 +2988,12 @@ msgstr ""
 "Cookies temporalmente deshabilitadas y serán reactivadas en el siguiente reinicio."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Las cookies han sido desactivadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -3001,52 +3001,52 @@ msgstr ""
 "archivo de cookies."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 "Error al descargar el archivo de cookies desde discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "No se han podido guardar las cookies en el disco:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies subidas y habilitadas."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "No puedes usar este bot en mensajes privados."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Este comando no está permitido para el grupo de permisos:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Este comando requiere que estés en un canal de Voice."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Comando:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Error de excepción"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3056,17 +3056,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "No se ha dado descripción.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "No se ha dado el uso."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3080,13 +3080,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Dejando el canal de voz %(channel)s debido a la inactividad."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3210,7 +3210,7 @@ msgstr ""
 "solo se usa cuando BindToChannels no tiene un ID para un servidor."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3293,7 +3293,7 @@ msgstr ""
 "Puede configurarlo de 0 a 1, o de 0 % a 100 %."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 "Permitir a MusicBot mantener los medios descargados o eliminarlos de "
@@ -3301,7 +3301,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3311,7 +3311,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3320,7 +3320,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3334,7 +3334,7 @@ msgid "Mention the user who added the song when it is played."
 msgstr "Mencionar al usuario que agregó la canción cuando se reproduce."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3343,7 +3343,7 @@ msgstr ""
 "cuando el bot se inicia."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3352,14 +3352,14 @@ msgstr ""
 "reproducción automática cuando la cola está vacía."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 "Mezclar las pistas de lista de reproducción automática antes de "
 "reproducirlas."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3368,7 +3368,7 @@ msgstr ""
 "Esto solo se aplica a la canción que se está reproduciendo actualmente si fue agregada por la lista de reproducción automática."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3427,7 +3427,7 @@ msgstr ""
 "Actualmente esta opción no se aplica a la lista de reproducción automática o a las canciones añadidas a una cola vacía."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3456,7 +3456,7 @@ msgstr ""
 "  {p0_url} = La URL de la pista que se está reproduciendo actualmente."
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 "Si está activado, los mensajes de estado informarán sobre los jugadores en "
@@ -3465,7 +3465,7 @@ msgstr ""
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3503,7 +3503,7 @@ msgstr ""
 "para listar la cola."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3512,7 +3512,7 @@ msgstr ""
 " de la lista de reproducción automática."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 "Mostrar los ajustes de configuración de MusicBot en los registros al inicio."
@@ -3528,7 +3528,7 @@ msgstr ""
 "saltado y saltar la fuerza."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3560,14 +3560,14 @@ msgid "Completely remove the footer from embeds."
 msgstr "Elimina completamente el pie de página de las incrustaciones."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 "MusicBot automáticamente se ensordece cuando entra en un canal de voz."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3578,7 +3578,7 @@ msgstr ""
 "Los oyentes son miembros del canal, excluidos los bots, que no están sordos."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3587,7 +3587,7 @@ msgstr ""
 "Puede configurarlo en una cantidad de segundos o una frase como: 4 horas"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3596,7 +3596,7 @@ msgstr ""
 "canciones esté vacía."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3644,7 +3644,7 @@ msgstr ""
 "organizará la reproducción de una canción por miembro."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3657,7 +3657,7 @@ msgstr ""
 "De forma predeterminada, esta opción está deshabilitada."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3669,7 +3669,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3697,7 +3697,7 @@ msgstr ""
 "reproducción."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3708,7 +3708,7 @@ msgstr ""
 "Deje en blanco para deshabilitarlo."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3725,14 +3725,14 @@ msgstr ""
 "Déjelo en blanco para utilizar cadenas de agente de usuario predeterminadas y generadas dinámicamente."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Cambiar la función de lista de bloques de usuario, sin vaciar la lista de "
 "bloques."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3740,14 +3740,14 @@ msgstr ""
 "Discord, uno por línea."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Activar la función de lista de bloques de canciones, sin vaciar la lista de "
 "bloques."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3756,7 +3756,7 @@ msgstr ""
 "Cualquier título o URL de la canción que contenga cualquier línea de la lista será bloqueada."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3765,7 +3765,7 @@ msgstr ""
 "Cada archivo debe contener una lista de términos o URL reproducibles, una pista por línea."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3779,7 +3779,7 @@ msgstr ""
 "Mapas a:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3788,7 +3788,7 @@ msgstr ""
 " largo plazo para la reproducción."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3800,7 +3800,7 @@ msgstr ""
 "Establezca en 0 para deshabilitarla. La cantidad máxima permitida es %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3813,7 +3813,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3843,7 +3843,7 @@ msgstr ""
 "  Use las opciones de ejemplo como plantilla o cópielas del repositorio."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3862,7 +3862,7 @@ msgstr ""
 "  Asegúrese de que la ruta que ha configurado es una ruta a una carpeta / directorio."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3884,7 +3884,7 @@ msgstr ""
 "  Verifique nuevamente que la configuración sea una ruta de directorio válida y accesible."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3904,7 +3904,7 @@ msgstr ""
 "  Establecer la opción de configuración del token o establecer la variable de entorno %(env_var)s con un token de aplicación."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3925,7 +3925,7 @@ msgstr ""
 "  Establezca manualmente la opción de configuración 'OwnerID' o vuelva a intentarlo más tarde."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3944,7 +3944,7 @@ msgstr ""
 "  No utilice el Bot o el ID de la aplicación en el campo OwnerID."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3966,7 +3966,7 @@ msgstr ""
 "  Verifique que la carpeta y los archivos de configuración existan y que MusicBot pueda leerlos."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3990,7 +3990,7 @@ msgstr ""
 "  Copie el archivo de ejemplo del repositorio si todo lo demás falla."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4010,7 +4010,7 @@ msgstr ""
 "  Establece %(option)s a un ID numérico o establézcalo a `auto` o `0` para vincular al propietario automático."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4030,7 +4030,7 @@ msgstr ""
 "  Comprueba la configuración de ruta y asegúrate de que el archivo existe y es accesible a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4050,33 +4050,33 @@ msgstr ""
 "  Asegúrese de que todos los IDs sean numéricos y separados solo por espacios o comas."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD parece no tener cabeceras..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "La extracción de información de canciones no devolvió datos."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "No se puede continuar la extracción, el bucle del evento está cerrado."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "La URL de Spotify no es válida o no es compatible."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "No se puede transmitir una URL no válida."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "No se ha podido encontrar el archivo de medios locales."
 
@@ -4440,7 +4440,7 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr "Se ha borrado la lista de reproducción `%(playlist)s`."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
@@ -4448,22 +4448,22 @@ msgstr ""
 "reproducción."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr "    Eliminar un alias con el nombre dado.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr "    Recargar o guardar alias desde/hacia el archivo de configuración.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr "Comando utilizado para automatizar la prueba de comandos."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4507,7 +4507,7 @@ msgstr ""
 "  Asegúrese de que MusicBot pueda leer y escribir en sus archivos de configuración.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4561,7 +4561,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4569,7 +4569,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4579,7 +4579,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4648,7 +4648,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4662,7 +4662,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4671,7 +4671,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4685,7 +4685,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4693,7 +4693,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4702,26 +4702,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4733,28 +4733,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4765,25 +4765,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4792,7 +4792,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/es_ES/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/es_ES/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-17 13:56-0800\n"
@@ -42,29 +42,29 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "El miembro no está habilitado por voz y no puede usar este comando."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "No puedes usar este comando cuando no estás en el canal de voz."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot no tiene permiso para conectarse en el canal: `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot no tiene permiso para hablar en el canal: `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -73,7 +73,7 @@ msgstr ""
 "Inténtalo de nuevo más tarde, o reinicia el bot si esto continúa."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -81,17 +81,17 @@ msgstr ""
 "reiniciar?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot no tiene permiso para hablar."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot no pudo pedir la palabra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -100,12 +100,12 @@ msgstr ""
 "Usa el comando invocar para llevar el bot a tu canal de voz."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Algo está mal, no conseguimos el Cliente de Voice."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -114,7 +114,7 @@ msgstr ""
 "está en voz!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
@@ -122,27 +122,27 @@ msgstr ""
 "%(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 "Ahora reproduciendo en %(channel)s: `%(title)s` añadido por %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 "Reproduciendo automáticamente la entrada añadida `%(title)s` en %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr "¡Omitiendo canciones añadidas por %(user)s ya que no están en voz!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -154,12 +154,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Intentó enviar un objeto de respuesta no válido."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -182,7 +182,7 @@ msgstr ""
 "  Comprueba el estado de la API en el sitio oficial: discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
@@ -190,7 +190,7 @@ msgstr ""
 "de canciones."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -199,12 +199,12 @@ msgstr ""
 "Este comando se eliminará en una versión futura y se reemplazará por el comando o los comandos de lista de reproducción automática."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -212,18 +212,18 @@ msgstr ""
 "disponibles.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Alias para este comando:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "`%(alias)s` alias de `%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -234,7 +234,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -246,12 +246,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "No existe tal comando"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -261,7 +261,7 @@ msgstr ""
 "Para una lista de todos los comandos, ejecuta: %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -283,22 +283,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Bloquear a un usuario mencionado."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Desbloquear a un usuario mencionado."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Mostrar el estado del bloque de un usuario mencionado."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -307,43 +307,43 @@ msgstr ""
 "Se prohíbe a los usuarios bloqueados utilizar todos los comandos del bot.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "Debe mencionar a un usuario o proporcionar su número de identidad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "Sub-comando inválido. Usa `help blockuser` para ejemplos de uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot no pudo encontrar el usuario(s) especificado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "El propietario no puede ser añadido a la lista de bloques."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "La lista de bloques de usuarios está habilitada actualmente."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "La lista de bloques de usuarios está actualmente deshabilitada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 "No se pueden agregar los usuarios que has listado, que ya han sido añadidos."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -353,24 +353,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "Ninguno de esos usuarios está en la lista negra."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "Usuario: `%(user)s` no está bloqueado.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "Usuario: `%(user)s` está bloqueado.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -382,7 +382,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -392,7 +392,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -409,25 +409,25 @@ msgstr ""
 "Esto significa que si se agrega \"Pie\", se coincidirá con \"cherry Pie\" pero no con \"piecrust\" en las comprobaciones.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Debes proporcionar un tema de canción si ninguna canción se está "
 "reproduciendo actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "Sub-comando inválido. Usa `help blocksong` para ejemplos de uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "El asunto `%(subject)s` ya está en la lista de bloques de canciones."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -437,14 +437,14 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 "El asunto no está en la lista de bloques de canciones y no puede ser "
 "eliminado."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -454,7 +454,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -463,12 +463,12 @@ msgstr ""
 "actualmente en la lista de reproducción actual.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Añade toda la cola a la lista de reproducción de gremios.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -477,70 +477,70 @@ msgstr ""
 "recarga la lista de reproducción automática.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Sub-comando inválido. Usa `help autoplaylist` para los ejemplos de uso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "El enlace a la canción suministrada no es válido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "La cola está vacía. ¡Añade algunas canciones con un comando de reproducción!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 "Todas las canciones en la cola ya están en la lista de reproducción "
 "automática."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "Añadidas canciones %(number)d a la lista de reproducción automática."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "Añadido `%(url)s` a la lista de reproducción automática."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Esta canción ya está en la lista de reproducción automática."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "Eliminado `%(url)s` de la lista de reproducción automática."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Esta canción aún no está en la lista de reproducción automática."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Se ha cargado una copia fresca de la lista: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Debe proporcionar un nombre de archivo de lista de reproducción."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -549,7 +549,7 @@ msgstr ""
 "Esta lista es nueva, ¡debes añadir canciones para guardarla en disco!"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
@@ -557,7 +557,7 @@ msgstr ""
 "`%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
@@ -565,7 +565,7 @@ msgstr ""
 "otro servidor."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -575,7 +575,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -584,22 +584,22 @@ msgstr ""
 "Grupos con control de permisos BypassKaraokeMode cuyos miembros son miembros de Karaoke.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\Nmodo{OK HAND SIGN} Karaoke ahora está activado."
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\Nmodo{OK HAND SIGN} Karaoke está deshabilitado."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "No tienes permisos para solicitar listas de reproducción"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
@@ -607,7 +607,7 @@ msgstr ""
 " es %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -619,12 +619,12 @@ msgstr ""
 "El límite es %(max)s para tu grupo."
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "El bot estaba pausado previamente, reanudando la reproducción ahora."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -641,7 +641,7 @@ msgstr ""
 "MusicBot también admite URL y URI de Spotify, pero el audio se obtiene de YouTube de todos modos.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -650,7 +650,7 @@ msgstr ""
 "antes de añadirlas a la cola.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
@@ -658,7 +658,7 @@ msgstr ""
 "`%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -667,7 +667,7 @@ msgstr ""
 "Lea la ayuda del comando de reproducción para obtener información sobre las entradas admitidas.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -676,7 +676,7 @@ msgstr ""
 "Lee ayuda para el comando de reproducción para obtener información sobre las entradas soportadas.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -689,34 +689,34 @@ msgstr ""
 "Debido a especificaciones de código en ffmpeg, esto puede no ser preciso.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "No se puede usar seek si no hay nada jugando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "No se puede usar seek en la pista actual, tiene una duración desconocida."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "La búsqueda no es compatible con los streams."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "No se puede usar seek sin tiempo para colocar la reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "No se pudo convertir `%(input)s` a una hora válida en segundos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -726,7 +726,7 @@ msgstr ""
 " con una longitud de `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -735,7 +735,7 @@ msgstr ""
 "actual."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -746,66 +746,66 @@ msgstr ""
 "Si no se proporciona ninguna opción y la canción ya se está repitiendo, la repetición se desactivará.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 "No hay canciones en reproducción actualmente. Reproduce algo con un comando "
 "de reproducción."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Sub-comando no válido. Utilice el comando `help repeat` para ejemplos de "
 "uso."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "La lista de reproducción se está repitiendo."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "La lista de reproducción ya no se repite."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "El reproductor ahora bucle la canción actual."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "El jugador ya no hará el bucle de la canción actual."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "¡El jugador ya está haciendo un bucle de canción!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "El reproductor no está bucle actualmente."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "La canción ya no se repite."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "La canción se está repitiendo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    Mover canción en la posición FROM a la posición de la OS.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -814,22 +814,22 @@ msgstr ""
 "Usa el comando de cola para encontrar números de posición de la pista.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr "No hay canciones en la cola. Reproduce algo con un comando de juego."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Las posiciones de la canción deben ser enteras!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "¡Has dado una posición fuera del tamaño de la lista de reproducción!"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -838,7 +838,7 @@ msgstr ""
 "posición %(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -852,35 +852,35 @@ msgstr ""
 "¿Quieres poner en cola la lista de reproducción también?"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "La reproducción de medios locales no está habilitada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "La URL de Spotify no es válida o no está soportada actualmente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Se ha detectado una URL de Spotify, pero Spotify no está habilitado."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Has alcanzado el límite de canciones en cola (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "El modo Karaoke está activado, ¡por favor inténtalo de nuevo cuando esté "
 "desactivado!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -890,15 +890,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Ese video no se puede reproducir. Intenta usar el comando Stream."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "La búsqueda en YouTube no devolvió resultados para:  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1082,7 +1076,7 @@ msgid "Show information on what is currently playing."
 msgstr "Mostrar información sobre lo que se está reproduciendo actualmente."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1119,7 +1113,7 @@ msgstr "Progreso:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "No hay canciones en cola! Coloca algo con un comando de reproducción."
 
@@ -1225,38 +1219,25 @@ msgstr "Elimina todas las canciones actualmente en cola."
 msgid "Cleared all songs from the queue."
 msgstr "Se borraron todas las canciones de la cola."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Quitar una canción de la cola, opcionalmente en la posición de cola indicada.\n"
-"Si se omite la posición, se elimina la canción que se encuentra al final de la cola.\n"
-"Utilice el comando queue para encontrar el número de posición de su pista.\n"
-"Sin embargo, las posiciones de todas las canciones se modifican cuando comienza a reproducirse una nueva canción.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "¡Nada en la cola para eliminar!"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Eliminado `%(track)s` añadido por `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "No se ha encontrado nada en la cola del usuario `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1265,26 +1246,26 @@ msgstr ""
 "la puso en cola o tener permisos de omisión instantánea."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Número de entrada no válido. Utilice el comando de cola para encontrar las "
 "posiciones de la cola."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Entrada eliminada `%(track)s` añadida por `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Se ha eliminado la entrada `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1295,23 +1276,23 @@ msgstr ""
 "Si la opción LegacySkip está activada, el parámetro de fuerza puede ser ignorado.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "¡No se puede saltar! ¡El jugador no está jugando!"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "La siguiente canción `%(track)s` está descargando, por favor espere."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "La siguiente canción se reproducirá en breve. Por favor espere."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1320,7 +1301,7 @@ msgstr ""
 "Puede que quieras reiniciar el bot si no empieza a funcionar."
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1329,28 +1310,28 @@ msgstr ""
 "Puede que quieras reiniciar el bot si no empieza a funcionar."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "No tienes permiso para forzar a saltar una canción en bucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Forzar omitido `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "No tienes permiso para forzar saltar."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "No tienes permiso para saltar una canción en bucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1360,12 +1341,12 @@ msgstr ""
 "El voto para saltar ha sido aprobado.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " ¡Próxima canción!"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1375,7 +1356,7 @@ msgstr ""
 "Necesitas **%(votes)s** más votos para saltarte esta canción."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1386,25 +1367,25 @@ msgstr ""
 "La configuración de volumen se conserva hasta que se reinicia MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Volumen actual: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` no es un número válido"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Volumen actualizado de **%(old)d** a **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1414,7 +1395,7 @@ msgstr ""
 "El volumen solo puede establecerse de 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1423,7 +1404,7 @@ msgstr ""
 " y 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1434,7 +1415,7 @@ msgstr ""
 "La reproducción de streaming no soporta ajustes de velocidad.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1443,35 +1424,35 @@ msgstr ""
 "Utilice el comando de configuración para establecer una velocidad de reproducción predeterminada."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocidad no se puede aplicar a los medios streamed."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Debe proporcionar una velocidad para establecer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocidad que proporcionaste no es válida. Usa un número entre 0.5 y 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Ajustando velocidad de reproducción a `%(speed).3f` para el rastro actual."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Añadir un nuevo alias con argumentos opcionales.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1480,23 +1461,23 @@ msgstr ""
 " ayuda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opción no válida para el comando: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Alias recargados desde archivo de configuración."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Alias guardados al archivo de configuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1506,42 +1487,42 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Debe proporcionar un alias y un comando para alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nuevo alias añadido. `%(alias)s` ahora es un alias de `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Debe proporcionar un nombre de alias para eliminar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "El alias `%(alias)s` no existe."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` fue eliminado."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Muestra texto de ayuda sobre cualquier opción de configuración "
 "faltante.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1550,33 +1531,33 @@ msgstr ""
 " archivo de configuración.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 "    Lista de las opciones de configuración disponibles y sus secciones.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Recargar el archivo options.ini desde el disco.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Muestra texto de ayuda para una opción específica.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Mostrar el valor actual de la opción.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Guarda el valor actual en el archivo de opciones.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1585,35 +1566,35 @@ msgstr ""
 " archivo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Restablecer la opción a su valor predeterminado.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Administrar la configuración options.ini desde dentro de Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuración no puede usar las menciones de canal y usuario al mismo "
 "tiempo."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 "*¡Todas las opciones de configuración están presentes y contabilizadas!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "Ninguna opción de configuración parece ser cambiada."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1623,7 +1604,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1639,12 +1620,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "Opciones de configuración recargadas desde el archivo con éxito!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1654,7 +1635,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1663,19 +1644,19 @@ msgstr ""
 "favor, introduzca un nombre de sección y opción válidos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "La opción dada es ambigua, por favor ingrese un nombre de sección."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Debe proporcionar un nombre de sección y un nombre de opción para este "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1685,25 +1666,25 @@ msgstr ""
 "Las secciones disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "La opción `%(option)s` no está disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Esta opción sólo se puede establecer editando el archivo de configuración."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Por defecto esta opción se establece como: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1717,32 +1698,32 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede guardar en el disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Error al guardar la opción: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Opción guardada con éxito: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "La opción `%(option)s` no es editable, el valor no se puede mostrar."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1754,7 +1735,7 @@ msgstr ""
 "Valor del archivo INI: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1762,18 +1743,18 @@ msgstr ""
 "configuración."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Debe proporcionar una sección, opción y valor para este sub-comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "¡La opción `%(option)s` no fue actualizada!"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1783,20 +1764,20 @@ msgstr ""
 "Para guardar el cambio use `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "La opción `%(option)s` no es editable. No se puede restablecer por defecto."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "¡La opción `%(option)s` no se ha restablecido por defecto!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1806,19 +1787,19 @@ msgstr ""
 "Para guardar el cambio use `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Comando obsoleto, use el comando config en su lugar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "El comando de opción está obsoleto, utilice el comando de configuración en "
 "su lugar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1827,33 +1808,33 @@ msgstr ""
 "Al utilizar la opción de actualización, se escaneará la caché en busca de cambios externos antes de mostrar los detalles."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opción especificada no válida, use: info, actualización o borrado"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Deshabilitado"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Activado"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s días"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Ilimitado"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1869,23 +1850,23 @@ msgstr ""
 "**Cacheo ahora:  %(used)s en archivos %(files)s."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "Se ha borrado la caché."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Fallo** al eliminar caché, comprueba los registros para más información..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "Caché no encontrado para borrar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1894,12 +1875,12 @@ msgstr ""
 "Número de página opcional muestra las entradas posteriores en la cola.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "El argumento de página de cola debe ser un número entero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1909,12 +1890,12 @@ msgstr ""
 "Hay **%(total)s** páginas."
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(duración desconocida)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1926,7 +1907,7 @@ msgstr ""
 "Progreso: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1940,12 +1921,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Canciones en cola"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1954,7 +1935,7 @@ msgstr ""
 "Si el problema persiste, envíe un informe de error."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1965,40 +1946,40 @@ msgstr ""
 "Este comando puede ser lento si se dan rangos más grandes.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Parámetro no válido. Por favor, proporcione un número de mensajes a buscar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "No se puede utilizar la purga en el canal DM privado."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Se han limpiado %(number)s mensaje(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "El bot no tiene permiso para administrar mensajes."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 "Volcar las URLs individuales de una lista de reproducción a un archivo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "La URL dada no era una URL válida."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2008,18 +1989,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Esto no parece ser una lista de reproducción."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Aquí está el volcado de la lista de reproducción para:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2028,19 +2009,19 @@ msgstr ""
 "Este comando está en desuso y se ha sustituido por el modo de desarrollador en los clientes de Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Tu ID de usuario es `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "El ID de usuario para `%(username)s` es `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2051,25 +2032,25 @@ msgstr ""
 "Este comando está obsoleto a favor de usar el modo desarrollador en los clientes de Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Categorías válidas: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Aquí están los IDs que ha solicitado:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 "Obtenga una lista de sus permisos, o los permisos del usuario mencionado."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2078,12 +2059,12 @@ msgstr ""
 "inténtelo de nuevo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "No se pudo determinar el usuario de discord. Inténtalo de nuevo."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2097,7 +2078,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2111,63 +2092,63 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Mostrar grupos cargados y listar las opciones de permisos.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Recarga los permisos del archivo permissions.ini.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    Añadir un nuevo grupo por defecto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Eliminar grupo existente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Mostrar texto de ayuda para la opción de permisos.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Mostrar el valor del permiso para un grupo y permiso dado.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Guardar grupo de permisos en el archivo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Establecer el valor del permiso para el grupo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Administrar la configuración permissions.ini desde discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Los permisos no pueden usar menciones de canal y usuario al mismo tiempo."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "¡Permisos recargados desde el archivo con éxito!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2177,7 +2158,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2191,23 +2172,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Debe proporcionar un nombre de grupo o opción para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Debe proporcionar un grupo, opción y valor para este comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "El subcomando %(option)s requiere un grupo y un nombre de permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2217,25 +2198,25 @@ msgstr ""
 "Los grupos disponibles son:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "El permiso `%(option)s` no está disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Este permiso sólo se puede establecer editando el archivo de permisos."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Por defecto este permiso está establecido en: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2249,13 +2230,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "No se puede agregar el grupo `%(group)s` que ya existe."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2267,12 +2248,12 @@ msgstr ""
 "Asegúrate de guardar el nuevo grupo con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "No se puede eliminar el grupo integrado."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2282,24 +2263,24 @@ msgstr ""
 "Asegúrese de guardar este cambio con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "El grupo propietario no es editable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Error al guardar el grupo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Se ha guardado correctamente el grupo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2311,13 +2292,13 @@ msgstr ""
 "Valor del archivo INI: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "¡El permiso `%(option)s` no fue actualizado!"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2327,7 +2308,7 @@ msgstr ""
 "Para guardar el cambio use `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2336,7 +2317,7 @@ msgstr ""
 "Nota: La API puede limitar los cambios de nombre a dos veces por hora."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2345,7 +2326,7 @@ msgstr ""
 "Recuerda que los cambios de nombre están limitados a dos veces por hora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2355,23 +2336,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Establezca el nombre de usuario del bot a `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Cambiar el apodo de MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "No se puede cambiar el apodo: no hay permiso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2381,23 +2362,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Establecer el apodo del bot a `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Establecer un prefijo de comando por servidor."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Borrar el prefijo de comando por servidor."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2406,24 +2387,24 @@ msgstr ""
 "La opción EnablePrefixPerGuild debe estar habilitada primero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Los emoji personalizados deben ser de este servidor para usar como prefijo."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Se ha borrado el prefijo del comando del servidor."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "El prefijo del comando del servidor es ahora:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2432,41 +2413,41 @@ msgstr ""
 "Utilice el comando de configuración para actualizar el prefijo en su lugar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Mostrar códigos de idioma disponibles para usar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    Establezca el idioma deseado para este servidor.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 "    Restablecer el idioma del servidor al idioma predeterminado del bot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 "Administrar el idioma utilizado para los mensajes en el servidor de "
 "llamadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Este comando sólo puede ser usado en gremios."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sub-comando inválido. Utilice el comando de ayuda para más información."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2480,25 +2461,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "No se puede establecer el idioma a `%(locale)s` no está disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Idioma para este servidor ahora establecido en: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "El idioma de este servidor se ha restablecido a: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2507,12 +2488,12 @@ msgstr ""
 "Adjuntar un archivo y omitir el parámetro url también funciona.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Debe proporcionar una URL o adjuntar un archivo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2522,61 +2503,61 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "Se ha cambiado el avatar del bot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Forzar a MusicBot a desconectarse del servidor de discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Desconectado del servidor `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "¿Desconectado un cliente de voz sin jugador? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Actualmente no conectado al servidor `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Intento de recargar sin reiniciar el proceso. La opción "
 "predeterminada.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr "    Intentó reiniciar todo el proceso de MusicBot. Recargando todo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Reinicio completo, pero intente actualizar los paquetes pip antes de "
 "reiniciar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Reinicio completo, pero actualiza el código fuente de MusicBot con git "
 "primero.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2585,7 +2566,7 @@ msgstr ""
 "reiniciar por completo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2598,7 +2579,7 @@ msgstr ""
 "Si tiene un administrador de servicios, le recomendamos que lo utilice en lugar de este comando para reiniciar.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2606,19 +2587,19 @@ msgstr ""
 "actualizada o actualizada"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Reiniciando la instancia actual..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Reiniciando el proceso del bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2627,7 +2608,7 @@ msgstr ""
 "bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
@@ -2635,23 +2616,23 @@ msgstr ""
 "bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Intentará actualizar todo y reiniciar el bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Desconecte de todos los canales de voz y cierre el proceso MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Deja el servidor de discord dado por nombre o ID del servidor."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2660,31 +2641,31 @@ msgstr ""
 "Los nombres son sensibles a mayúsculas y minúsculas, por lo que usar un número de ID es más fiable.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Debe proporcionar un ID o nombre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "No se ha encontrado ningún gremio con el ID o nombre `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Desconocido"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 "Abandonó el gremio: `%(name)s` (Propietario: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2693,38 +2674,38 @@ msgstr ""
 "Puede utilizarse para identificar manualmente los eventos en el archivo de registro de MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Breakpoint registrado con ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Ver los tipos más comunes reportados por el objeto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Ver salida objgraph.show_growth() limitada.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Visualiza los tipos más comunes de objetos de fuego.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Ver tipografías de objetos que filtran.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Evaluar la función y argumentos dados sobre el objeto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2735,12 +2716,12 @@ msgstr ""
 "Dado que este método evalúa código arbitrario, se considera peligroso, al igual que el comando de depuración.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "No se pudo importar `objgraph`, ¿está instalado?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2765,7 +2746,7 @@ msgstr ""
 "El peligro de este comando no se puede subestimar. ¡No lo use ni le dé acceso si no comprende los riesgos!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2781,7 +2762,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2790,23 +2771,23 @@ msgstr ""
 "La salida se utiliza para actualizar las páginas de GitHub y por lo tanto no es adecuada para uso de referencia normal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "El subcomando debe ser uno de: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Crea archivos INI por defecto."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Guardado el archivo INI solicitado en el disco. Compruébalo"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2815,50 +2796,50 @@ msgstr ""
 "MusicBot o dependencias.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "No se pudo encontrar el ejecutable de git."
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "No hay actualizaciones en la rama `%(branch)s` remoto."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nuevos commits están disponibles en `%(branch)srama remota."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "Error al comprobar, vea los registros para más detalles."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Actualizar para `%(name)s` a la versión: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "No se encontraron actualizaciones para dependencias."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "Hay actualizaciones para MusicBot disponibles para su descarga."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot es totalmente fecha!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2878,20 +2859,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Muestra el tiempo de actividad de MusicBot, o la hora desde el último inicio"
 " / reinicio."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s ha estado en línea para `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2899,12 +2880,12 @@ msgstr ""
 "de voz conectados."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "No hay clientes de voz conectados.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 "Mostrar latencia de la API y latencia de voz si MusicBot está conectado."
@@ -2912,23 +2893,23 @@ msgstr ""
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Latencia API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Mostrar el número de versión de MusicBot en el chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2938,18 +2919,18 @@ msgstr ""
 "Versión actual: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 "    Actualice el archivo cookies.txt usando un archivo adjunto cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Activar o desactivar el archivo cookies.txt sin borrarlo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2974,30 +2955,30 @@ msgstr ""
 "  función si no entiendes cómo evitarlos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Las cookies ya están habilitadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Las cookies deben ser subidas para estar habilitadas. (Falta archivo de "
 "cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "No se pudo habilitar las cookies debido a un error:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Las cookies han sido habilitadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -3007,12 +2988,12 @@ msgstr ""
 "Cookies temporalmente deshabilitadas y serán reactivadas en el siguiente reinicio."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Las cookies han sido desactivadas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -3020,52 +3001,52 @@ msgstr ""
 "archivo de cookies."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 "Error al descargar el archivo de cookies desde discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "No se han podido guardar las cookies en el disco:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies subidas y habilitadas."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "No puedes usar este bot en mensajes privados."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Este comando no está permitido para el grupo de permisos:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Este comando requiere que estés en un canal de Voice."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Comando:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Error de excepción"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3075,17 +3056,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "No se ha dado descripción.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "No se ha dado el uso."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3099,13 +3080,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Dejando el canal de voz %(channel)s debido a la inactividad."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3744,14 +3725,14 @@ msgstr ""
 "Déjelo en blanco para utilizar cadenas de agente de usuario predeterminadas y generadas dinámicamente."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Cambiar la función de lista de bloques de usuario, sin vaciar la lista de "
 "bloques."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3759,14 +3740,14 @@ msgstr ""
 "Discord, uno por línea."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Activar la función de lista de bloques de canciones, sin vaciar la lista de "
 "bloques."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3775,7 +3756,7 @@ msgstr ""
 "Cualquier título o URL de la canción que contenga cualquier línea de la lista será bloqueada."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3784,7 +3765,7 @@ msgstr ""
 "Cada archivo debe contener una lista de términos o URL reproducibles, una pista por línea."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3798,7 +3779,7 @@ msgstr ""
 "Mapas a:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3807,7 +3788,7 @@ msgstr ""
 " largo plazo para la reproducción."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3819,7 +3800,7 @@ msgstr ""
 "Establezca en 0 para deshabilitarla. La cantidad máxima permitida es %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3832,7 +3813,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3862,7 +3843,7 @@ msgstr ""
 "  Use las opciones de ejemplo como plantilla o cópielas del repositorio."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3881,7 +3862,7 @@ msgstr ""
 "  Asegúrese de que la ruta que ha configurado es una ruta a una carpeta / directorio."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3903,7 +3884,7 @@ msgstr ""
 "  Verifique nuevamente que la configuración sea una ruta de directorio válida y accesible."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3923,7 +3904,7 @@ msgstr ""
 "  Establecer la opción de configuración del token o establecer la variable de entorno %(env_var)s con un token de aplicación."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3944,7 +3925,7 @@ msgstr ""
 "  Establezca manualmente la opción de configuración 'OwnerID' o vuelva a intentarlo más tarde."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3963,7 +3944,7 @@ msgstr ""
 "  No utilice el Bot o el ID de la aplicación en el campo OwnerID."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3985,7 +3966,7 @@ msgstr ""
 "  Verifique que la carpeta y los archivos de configuración existan y que MusicBot pueda leerlos."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -4009,7 +3990,7 @@ msgstr ""
 "  Copie el archivo de ejemplo del repositorio si todo lo demás falla."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4029,7 +4010,7 @@ msgstr ""
 "  Establece %(option)s a un ID numérico o establézcalo a `auto` o `0` para vincular al propietario automático."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4049,7 +4030,7 @@ msgstr ""
 "  Comprueba la configuración de ruta y asegúrate de que el archivo existe y es accesible a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4069,33 +4050,33 @@ msgstr ""
 "  Asegúrese de que todos los IDs sean numéricos y separados solo por espacios o comas."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD parece no tener cabeceras..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "La extracción de información de canciones no devolvió datos."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "No se puede continuar la extracción, el bucle del evento está cerrado."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "La URL de Spotify no es válida o no es compatible."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "No se puede transmitir una URL no válida."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "No se ha podido encontrar el archivo de medios locales."
 
@@ -4120,13 +4101,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "La descarga falló debido a un error yt-dlp: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "La descarga falló debido a una excepción no controlada: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Error al extraer los datos del medio solicitado."
 
@@ -4312,28 +4293,28 @@ msgstr ""
 "El extractor yt-dlp `%(extractor)s` no está permitido en tu grupo."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "No se pudo extraer la información"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Esta es una lista de reproducción."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Tipo de contenido inválido `%(type)s` para la URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "sin datos de duración"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "no hay datos de duración en la entrada actual"
 
@@ -4417,7 +4398,7 @@ msgid "Only dev users can use this command."
 msgstr "Sólo los usuarios dev pueden usar este comando."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
@@ -4426,7 +4407,7 @@ msgstr ""
 " archivos de listas de reproducción existentes.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
@@ -4435,7 +4416,7 @@ msgstr ""
 "pista a menos que esté aleatorizada.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4445,7 +4426,7 @@ msgstr ""
 "%(names)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -4453,7 +4434,7 @@ msgstr ""
 "`%(playlist)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr "Se ha borrado la lista de reproducción `%(playlist)s`."
@@ -4467,22 +4448,22 @@ msgstr ""
 "reproducción."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr "    Eliminar un alias con el nombre dado.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr "    Recargar o guardar alias desde/hacia el archivo de configuración.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr "Comando utilizado para automatizar la prueba de comandos."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4526,61 +4507,61 @@ msgstr ""
 "  Asegúrese de que MusicBot pueda leer y escribir en sus archivos de configuración.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4588,7 +4569,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4598,7 +4579,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4622,40 +4603,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4663,13 +4637,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4688,7 +4662,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4697,7 +4671,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4728,28 +4702,123 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "La búsqueda en YouTube no devolvió resultados para:  %(url)s"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+#~ "Quitar una canción de la cola, opcionalmente en la posición de cola indicada.\n"
+#~ "Si se omite la posición, se elimina la canción que se encuentra al final de la cola.\n"
+#~ "Utilice el comando queue para encontrar el número de posición de su pista.\n"
+#~ "Sin embargo, las posiciones de todas las canciones se modifican cuando comienza a reproducirse una nueva canción.\n"
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/fr_FR/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/fr_FR/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:41\n"
@@ -162,7 +162,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Exception non gérée pour la tâche :  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify ne nous a pas fourni de jeton. Désactivation."
 
@@ -184,65 +184,43 @@ msgstr ""
 "secret sont-ils corrects ? Détails: %s. Continuer quand même dans 5 "
 "secondes..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"La configuration n'a pas les identifiants de l'application Spotify, en "
-"essayant d'utiliser le mode invité."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Authentifié avec Spotify avec succès en mode invité."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-"Impossible de démarrer le client Spotify en utilisant le mode invité. "
-"Détails : %s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Initialisé, se connecte maintenant à discord."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Le test de ping réseau est désactivé via la configuration."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "Le test de ping réseau est en train de se fermer."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "Impossible de résoudre la cible du ping"
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Test de ping réseau annulé."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Le test de réseau via HTTP n'a pas de session à emprunter."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "Impossible de localiser l'exécutable `ping` dans votre environnement."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -256,7 +234,7 @@ msgstr ""
 "Sinon, désactiver la vérification du réseau par le biais de la configuration."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -270,7 +248,7 @@ msgstr ""
 "Sinon, désactiver la vérification du réseau par le biais de la configuration."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -284,29 +262,29 @@ msgstr ""
 "Sinon, désactiver la vérification du réseau par le biais de la configuration."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "Le réseau détecté par MusicBot est à nouveau disponible."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 "VoiceClient n'est pas connecté, en attente de reprise de MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Reprise de la lecture du joueur : (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot a détecté une panne de réseau."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -315,7 +293,7 @@ msgstr ""
 "(%(guild_id)s) %(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -325,12 +303,12 @@ msgstr ""
 "%(required)s) et obtenu :  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "Vérification des salons à rejoindre ou à reprendre automatiquement..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
@@ -338,13 +316,13 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Canal vocal disponible :  %(channel)s  dans la guilde :  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
@@ -352,13 +330,13 @@ msgstr ""
 " le canal :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Propriétaire trouvé dans le salon vocal :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
@@ -366,7 +344,7 @@ msgstr ""
 " le canal :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
@@ -374,30 +352,30 @@ msgstr ""
 "propriétaire du canal :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Déjà connecté au salon :  %(channel)s  dans la guilde :  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 "Tentative de rejoindre le salon :  %(channel)s  dans la guilde :  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Discarding MusicPlayer and making a new on..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot va créer un nouveau MusicPlayer..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
@@ -405,81 +383,81 @@ msgstr ""
 "charge."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Terminé de rejoindre les canaux configurés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 "Le membre n'est pas activé par la voix et ne peut pas utiliser cette "
 "commande."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 "Vous ne pouvez pas utiliser cette commande quand vous n'êtes pas dans le "
 "salon vocal."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Récupération des infos d'application du bot."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot n'a pas la permission de se connecter au salon :  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 "MusicBot n'a pas la permission de se connecter dans le salon : `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot n'a pas la permission de parler dans le canal :  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot n'a pas la permission de parler dans le salon : `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Réutilisation des bots VoiceClient de la guilde :  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 "Forcer la déconnexion sur un VoiceClient obsolète dans la guilde :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "La déconnexion a échoué ou a été annulée ?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 "MusicBot ne peut pas se connecter au salon pour le moment :  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -488,12 +466,12 @@ msgstr ""
 "Réessayez plus tard ou redémarrez le bot si cela continue."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot a maintenant un client vocal..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -503,14 +481,14 @@ msgstr ""
 "tentative de connexion à :  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 "La tentative de connexion de MusicBot VoiceClient a été annulée. Aucune "
 "nouvelle tentative."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -518,42 +496,42 @@ msgstr ""
 "redémarrez-vous?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot demande à parler dans le canal : %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot n'a pas la permission de parler."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot n'a pas pu demander à parler."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Déconnexion d'un MusicPlayer dans la guilde :  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Déconnexion de VoiceClient avant de tuer le MusicPlayer."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "La déconnexion a échoué ou a été annulée."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -562,18 +540,18 @@ msgstr ""
 "quand même..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Déconnexion d'un client vocal immature dans la guilde :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Déconnexion d'un client vocal non-guilde..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -583,7 +561,7 @@ msgstr ""
 "L'objet est en fait de type :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
@@ -591,13 +569,13 @@ msgstr ""
 "%(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Guilde (%(guild)s) veut un joueur, optionnel:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -606,24 +584,24 @@ msgstr ""
 " redémarrer le bot."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer a un Client Voix qui n'est pas connecté."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "Lecteur musical obj:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -633,7 +611,7 @@ msgstr ""
 "%(channel)s  Création : %(create)s  Désérialisation :  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -643,7 +621,7 @@ msgstr ""
 " %(number)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -652,89 +630,89 @@ msgstr ""
 "Utilisez la commande d'invocation pour amener le bot dans votre canal vocal."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Quelque chose ne va pas, nous n'avons pas obtenu le VoiceClient."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "En cours d'exécution sur_player_play"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Définition de l'historique des URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Aucune vignette définie pour l'entrée avec l'URL : %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "aucun canal dans lequel mettre le message en cours de lecture"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "a ignoré le message qui était déjà publié."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "En cours d'exécution sur_player_resume"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "En cours de mise en pause"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Exécution sur_player_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Lancement sur_player_finished_playing"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "La boucle événement est fermée, rien d'autre à faire ici."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Déconnexion en cours, ignorant cet événement."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 "VoiceClient dit qu'il n'est pas connecté, rien d'autre que nous pouvons "
 "faire ici."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr ""
 "Lecteur terminé et la file d'attente est vide, laissant le canal vocal..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 "Bouclage de la file d'attente pour éliminer les chansons avec l'auteur "
 "manquant..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -743,306 +721,306 @@ msgstr ""
 "  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 "Aucune chanson jouable dans la liste de lecture automatique de la Guilde, "
 "désactivée."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 "Aucun contenu dans la liste de lecture automatique actuelle. Remplissage "
 "avec une nouvelle musique..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Bouclage de la liste de lecture automatique du joueur..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Erreur lors du traitement de la chanson \"%(url)s\" :  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Erreur lors de l'extraction de la chanson \"%(url)s\" : %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot a besoin de mettre fin à l'extraction et au sauvetage de la liste "
 "de lecture automatique."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 "MusicBot a obtenu une exception non gérée dans l'événement fini du lecteur."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 "Étendre la liste de lecture automatique avec les entrées extraites de:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 "Erreur lors de l'ajout de la chanson de la liste de lecture automatique : %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Données d'exception pour l'erreur ci-dessus :"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 "Aucune musique jouable dans la liste de lecture automatique, désactivation."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "En cours d'exécution sur_player_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 "Ignorer automatiquement l'entrée de la liste de lecture automatique pour "
 "l'entrée en file d'attente."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "Exception MusicPlayer pour l'entrée : %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "Exception MusicPlayer."
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "Impossible de lire la piste de la liste de lecture automatique : %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "Déconnexion en cours, ignorant la mise à jour de l'événement."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Mettre à jour le statut du bot :  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Sérialisation de la file d'attente pour %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Désérialisation de la file d'attente pour %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Écriture de la chanson actuelle pour %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "Impossible d'envoyer l'objet sans réponse :  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Tentative d'envoi d'un objet de réponse invalide."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "envoi d'intégrations à: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "envoi de texte à: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "Impossible d'envoyer le message à \"%s\", aucune permission"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "Impossible d'envoyer le message à \"%s\", canal invalide ou supprimé"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "Le message dépasse la limite de taille du message (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 "Impossible d'envoyer un message privé, en envoyant un canal de secours à la "
 "place."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr "Noter un message d'envoi limité, nouvel essai dans %s secondes."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Message annulé à nouveau pour :  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "Noter un message d'envoi limité, mais ne peut pas recommencer!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "Impossible d'envoyer le message dans le canal de repli."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Échec de l'envoi en raison d'une erreur HTTP."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "Impossible de supprimer le message \"%s\", aucune permission"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "Impossible de supprimer le message \"%s\", message introuvable"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 "Noter la suppression de messages limités, nouvel essai dans %s secondes."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 "Noter la suppression de messages limités, mais ne peut pas recommencer !"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Échec de la suppression du message"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Erreur HTTPException lors de la suppression du message : %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "Impossible de modifier le message \"%s\", message introuvable"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Envoi du message à la place"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr "Noter le message d'édition limité, nouvel essai dans %s secondes."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Modification du message annulée pour :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Impossible de modifier le message"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Exception HTTPException essayant d'éditer le message %s à: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Suppression du message annulée (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Signal du système d'exploitation attrapé : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Déconnexion et fermeture de MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "Exception lancée lors de la gestion du signal d'interruption !"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot fait maintenant des étapes d'arrêt..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1065,44 +1043,44 @@ msgstr ""
 "  Vérifiez l'état de l'API sur le site officiel : discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "En attente de la fin du téléchargement..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Va attendre la tâche :  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Essaiera d'annuler la tâche :  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "En attente de tâches..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Fermeture du connecteur HTTP."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Fermeture de la session aiohttp."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "La déconnexion a été appelée."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1112,63 +1090,63 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Exception dans %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot a repris une session avec discord."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Terminer le _prêt"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Connecté, maintenant que MusicBot est prêt..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "ClientUser est en quelque sorte aucun, nous devons sauvegarder..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Propriétaire :     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Liste de guilde:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "A quitté %s en raison du propriétaire du bot introuvable"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
@@ -1176,18 +1154,18 @@ msgstr ""
 "indisponibilité"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "Le propriétaire n'a pas pu être trouvé sur une guilde (id : %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Propriétaire inconnu, le bot n'est sur aucune guilde."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1201,42 +1179,42 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Aucun n'a été pour le canal lié avec l'ID :  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "Impossible de se lier à un canal non Messageable avec l'ID :  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Lié aux salons textuels :"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "Non lié à aucun salon textuel"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr ""
 "Aucun n'a été trouvé pour le canal d'accès automatique avec l'ID :  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
@@ -1244,7 +1222,7 @@ msgstr ""
 ":  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
@@ -1252,182 +1230,182 @@ msgstr ""
 "%d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Rejoindre automatiquement les salons vocaux:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "Ne pas rejoindre automatiquement les salons vocaux"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "L'événement on_ready a été déclenché %s fois"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Récupération des informations de l'application."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "S'assurer que les dossiers de données existent"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Validation de la configuration"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Validation de la configuration des permissions"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Activé"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Options :"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Préfixe de commande : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  Volume par défaut : %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Seuil de passage : %(num)d votes ou %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Lecture en cours de @mentions: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Liste de lecture automatique : %(status)s (ordre : %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "Aléatoire"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "séquentielle"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Pause automatique : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Supprimer les messages : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Suppression de l'appel: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Supprimer la lecture en cours : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Mode de débogage : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  Les chansons téléchargées seront %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Supprimer si inutilisé pour %d jours"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Message de statut : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Intégration Spotify : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Délai d'expiration : %s secondes"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Délai d'attente : %d secondes"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Soi-même sourd : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Préfixe de commande par serveur : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Queue de Round Robin: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
@@ -1435,7 +1413,7 @@ msgstr ""
 "chansons."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
@@ -1443,13 +1421,13 @@ msgstr ""
 "dans la voix..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "L'activité du canal est déjà en attente dans la guilde : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1458,13 +1436,13 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "La minuterie d'activité du canal %s a expiré. Déconnexion."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
@@ -1472,20 +1450,20 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Inactivité du joueur ignorée dans le canal auto-rejoint :  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 "La minuterie d'activité du joueur est déjà en attente dans la guilde : %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1494,13 +1472,13 @@ msgstr ""
 "canal : %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "La minuterie d'activité du joueur pour %s a expiré. Déconnexion."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
@@ -1508,40 +1486,40 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Le minuteur d'activité du joueur est en cours de réinitialisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Aucune commande de ce type"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 "Vous devez mentionner un utilisateur ou fournir son numéro d'identité."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez `help blockuser` pour des exemples "
 "d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot n'a pas pu trouver les utilisateurs que vous avez spécifiés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Le propriétaire ne peut pas être ajouté à la liste de blocs."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
@@ -1549,7 +1527,7 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
@@ -1557,85 +1535,85 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 "Impossible d'ajouter les utilisateurs que vous avez listés, ils sont déjà "
 "ajoutés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Vous devez indiquer un sujet si aucune chanson n'est en cours de lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez `help blocksong` pour des exemples "
 "d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Sujet `%(subject)s` est déjà dans la liste de blocage de chansons."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 "Le sujet n'est pas dans la liste des chansons bloquées et ne peut pas être "
 "supprimé."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez `help autoplaylist` pour des exemples "
 "d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Le lien de la chanson fournie n'est pas valide"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "La file d'attente est vide. Ajoutez des morceaux avec une commande de "
 "lecture!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Cette chanson est déjà dans la liste de lecture automatique."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Cette chanson n'est pas encore dans la liste de lecture automatique."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Vous devez fournir un nom de fichier de playlist."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Vous n'êtes pas autorisé à demander des playlists"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "La playlist a trop d'entrées (%(songs)s mais max est %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1647,12 +1625,12 @@ msgstr ""
 "La limite est %(max)s pour votre groupe."
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Ignorer la pause automatique en raison d'une panne de réseau."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1661,12 +1639,12 @@ msgstr ""
 "pas traiter la pause automatique."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Traitement de la pause automatique, ignorant cet événement."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1676,62 +1654,62 @@ msgstr ""
 "automatique dans la guilde :  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "L'attente de pause automatique a été annulée."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 "Un nouveau MusicPlayer est en cours de connexion, ignorant l'ancien "
 "événement de pause automatique."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 "Lecture dans un salon vocal vide, pause automatique pour la guilde : %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "Le joueur en pause automatique est en pause pour la guilde : %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Impossible d'utiliser seek s'il n'y a rien à jouer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Impossible d'utiliser la recherche sur la piste en cours, elle a une durée "
 "inconnue."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "La recherche n'est pas prise en charge pour les flux."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 "Impossible d'utiliser la recherche sans un temps pour positionner la "
 "lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Impossible de convertir `%(input)s` en une heure valide en secondes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1741,29 +1719,29 @@ msgstr ""
 "actuelle avec une longueur de `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez la commande `help repeat` pour des exemples"
 " d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Le joueur n'est pas en boucle."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Les positions de la chanson doivent être des entiers !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Vous avez donné une position en dehors de la taille de la playlist !"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
@@ -1771,40 +1749,40 @@ msgstr ""
 "réactions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "La lecture des médias locaux n'est pas activée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "L'URL Spotify n'est pas valide ou n'est pas prise en charge actuellement."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Une URL Spotify a été détectée, mais Spotify n'est pas activé."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Vous avez atteint votre limite de chansons en attente (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "Le mode Karaoké est activé, veuillez réessayer quand il est désactivé!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Problème avec extract_info() : "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1814,16 +1792,10 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Cette vidéo ne peut pas être lue. Essayez d'utiliser la commande stream."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "La recherche YouTube n'a retourné aucun résultat pour :  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1934,19 +1906,19 @@ msgid "Player is not playing."
 msgstr "Le joueur ne joue pas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Rien dans la file d'attente à supprimer !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 "Rien n'a été trouvé dans la file d'attente de l'utilisateur `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1955,41 +1927,41 @@ msgstr ""
 "Vous devez être celui qui l'a mis en file d'attente ou qui a des permissions de sauter instantanément."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numéro d'entrée invalide. Utilisez la commande file d'attente pour trouver "
 "les positions de la file d'attente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossible de sauter ! Le joueur ne joue pas !"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "Vous n'avez pas la permission de forcer le saut d'une chanson en boucle."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Vous n'avez pas la permission de forcer le saut."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Vous n'avez pas la permission de sauter une chanson en boucle."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` n'est pas un nombre valide"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1999,7 +1971,7 @@ msgstr ""
 "Le volume ne peut être défini que de 1 à 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -2008,7 +1980,7 @@ msgstr ""
 "entre 1 et 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -2017,30 +1989,30 @@ msgstr ""
 "Utilisez la commande de configuration pour définir une vitesse de lecture par défaut."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "La vitesse ne peut pas être appliquée aux médias streamés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Vous devez fournir une vitesse à définir."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La vitesse que vous avez fournie n'est pas valide. Utilisez un nombre entre "
 "0,5 et 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Option invalide pour la commande : `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2050,30 +2022,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Vous devez fournir un alias et une commande à alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Vous devez fournir un nom d'alias à supprimer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` n'existe pas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuration ne peut pas utiliser les mentions du canal et de "
 "l'utilisateur en même temps."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2083,7 +2055,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2092,18 +2064,18 @@ msgstr ""
 "Veuillez fournir un nom de section et d'option valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'option donnée est ambiguë, veuillez fournir un nom de section."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Vous devez fournir un nom de section et un nom d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2113,13 +2085,13 @@ msgstr ""
 "Les sections disponibles sont :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'option `%(option)s` n'est pas disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
@@ -2127,13 +2099,13 @@ msgstr ""
 "disque."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossible d'enregistrer l'option : `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -2141,7 +2113,7 @@ msgstr ""
 "affichée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2149,26 +2121,26 @@ msgstr ""
 "paramètre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Vous devez fournir une section, une option et une valeur pour cette sous-"
 "commande."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Faire avec %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'option `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2176,49 +2148,49 @@ msgstr ""
 " valeur par défaut."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Réinitialisation de %(config)s à %(value)s par défaut"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'option `%(option)s` n'a pas été réinitialisée par défaut!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "La commande d'option est obsolète, utilisez la commande config à la place."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Option non valide spécifiée, utilisez: info, mise à jour ou effacement"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Échec** pour supprimer la cache, vérifiez les logs pour plus d'infos..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "L'argument de la page de file d'attente doit être un nombre entier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Il n'y a pas de chansons en attente ! Mettre en file d'attente quelque chose"
 " avec une commande de lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2228,24 +2200,24 @@ msgstr ""
 "Il y a **%(total)s** pages."
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "L'entrée de la playlist actuelle a été ignorée."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "Pas assez d'entrées pour paginer la file d'attente."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Impossible de poster le message de file d'attente, aucun message à ajouter "
 "des réactions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2254,17 +2226,17 @@ msgstr ""
 "Si le problème persiste, remplissez un rapport de bogue."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossible d'utiliser la purge sur un canal DM privé."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "L'URL donnée n'est pas une URL valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2274,12 +2246,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Cela ne semble pas être une playlist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2288,19 +2260,19 @@ msgstr ""
 "l'ID et réessayer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossible de déterminer l'utilisateur de la discord. Réessayez."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Les permissions ne peuvent pas utiliser les mentions de salon et "
 "d'utilisateurs en même temps."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2310,26 +2282,26 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Vous devez fournir un nom de groupe ou d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Vous devez fournir un groupe, une option et une valeur à définir pour cette "
 "commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 "La sous-commande %(option)s nécessite un nom de groupe et de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2339,47 +2311,47 @@ msgstr ""
 "Les groupes disponibles sont:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "La permission `%(option)s` n'est pas disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossible d'ajouter le groupe `%(group)s` il existe déjà."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Impossible de supprimer le groupe intégré."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Le groupe propriétaire n'est pas modifiable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossible d'enregistrer le groupe: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Faire sur %(option)s avec la valeur : %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2388,7 +2360,7 @@ msgstr ""
 "Rappelez-vous que les changements de nom sont limités à deux fois par heure.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2398,12 +2370,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Impossible de changer le pseudo : pas de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2413,14 +2385,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Les émojis personnalisés doivent provenir de ce serveur pour être utilisés "
 "comme préfixes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2429,31 +2401,31 @@ msgstr ""
 "Utilisez la commande de configuration pour mettre à jour le préfixe à la place."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Cette commande ne peut être utilisée que dans les guildes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sous-commande invalide. Utilisez la commande d'aide pour plus "
 "d'informations."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 "Impossible de définir la langue à `%(locale)s` il n'est pas disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Vous devez fournir une URL ou joindre un fichier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2463,63 +2435,63 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot a trouvé une %s sans guilde! Cela pourrait être un problème."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Pas actuellement connecté au serveur `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Option non valide, utilisez une de : soft, full, upgrade, uppip ou upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Vous devez fournir un ID ou un nom."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Aucune guilde n'a été trouvée avec l'ID ou le nom `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Activation de l'ID du point d'arrêt de débogage : %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossible d'importer `objgraph`, est-il installé ?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Le code de débogage a été exécuté avec eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Le code de débogage a été exécuté avec exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "L'exécution du code de débogage a échoué."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2535,57 +2507,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "La sous-commande doit être une des : %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Impossible de localiser l'exécutable git."
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "Échec de la vérification des mises à jour via la commande git."
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Méta manquante dans le rapport pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 "Impossible d'obtenir le statut de mise à jour de pip en raison d'une erreur."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Vous avez reçu une étrange entrée du client vocal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies déjà activés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Les cookies doivent être téléchargés pour être activés. (Fichier de cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 "Impossible d'activer les cookies en raison d'une erreur :  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2595,7 +2567,7 @@ msgstr ""
 "Cookies temporairement désactivés et seront réactivés au prochain redémarrage."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2603,7 +2575,7 @@ msgstr ""
 "téléchargeant un fichier de cookies."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
@@ -2611,7 +2583,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
@@ -2619,37 +2591,37 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossible d'enregistrer les cookies sur le disque :  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "A reçu un message sans canal, d'une manière ou d'une autre :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Commande ignorée de moi-même (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Commande ignorée par un autre bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Commande ignorée du canal de type :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2657,13 +2629,13 @@ msgstr ""
 " : %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Message de %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
@@ -2671,12 +2643,12 @@ msgstr ""
 "%(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Cette commande nécessite d'être dans un canal vocal."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
@@ -2684,76 +2656,76 @@ msgstr ""
 ": %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Erreur dans %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Exception lors de la gestion de la commande : %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Impossible de générer de l'aide pour la commande manquante :  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Il manque des données d'aide pour la commande :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Quitter le canal vocal %s en %s en raison de l'inactivité."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot est devenu connecté."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot est déconnecté."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "A eu un événement de socket:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState mis à jour avant que le_ready ne soit terminé"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "%s ignoré dans %s car il s'agit d'un salon vocal lié."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s a été détecté comme vide. Délai de manutention expiré."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Un utilisateur a rejoint %s, annulation du délai."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2761,30 +2733,30 @@ msgstr ""
 "Le bot a été déplacé et le canal vocal %s est vide. Délai de manutention."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Le bot a été déplacé et le canal vocal %s n'est pas vide."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "Plus utilisateur suivant %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Utilisateur suivant `%(user)s` pour le salon :  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState déconnexion before.channel est Aucune."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2794,7 +2766,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2802,92 +2774,92 @@ msgstr ""
 "%(type)s  dans la guilde :  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 "Impossible de trouver le canal auto-joint, a-t-il été supprimé? Guilde:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Reconnexion à la guilde automatiquement rejoint sur le canal :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Impossible de rejoindre automatiquement le canal :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Le bot a été ajouté à la guilde : %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "A quitté la guilde '%s' en raison du propriétaire du bot introuvable."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Création du dossier de données pour la guilde %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Le bot a été retiré de la guilde : %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Liste de guilde mise à jour :"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "La guilde «%s» est devenue disponible."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Reprise du joueur dans «%s» en raison de la disponibilité."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "La guilde «%s» est devenue indisponible."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pauser le joueur dans «%s» en raison de l'indisponibilité."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Mise à jour de guilde pour :  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 "L'attribut de guilde %(attr)s est maintenant : %(new)s  -- Était: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Mise à jour du canal pour:  %(channel)s  --  %(changes)s"
@@ -2905,7 +2877,7 @@ msgid "Loading config from:  %s"
 msgstr "Chargement de la configuration depuis :  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2935,7 +2907,7 @@ msgstr ""
 "  Utilisez les options d'exemple comme modèle ou copiez-les à partir du référentiel."
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2945,7 +2917,7 @@ msgstr ""
 "sera limitée à la place."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2954,7 +2926,7 @@ msgstr ""
 "rotation des fichiers journaux. Utiliser par défaut à la place."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2973,12 +2945,12 @@ msgstr ""
 "  Assurez-vous que le chemin que vous avez configuré est un chemin vers un dossier / répertoire."
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Une exception a été levée lors de la validation de AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3000,13 +2972,13 @@ msgstr ""
 "  Double vérifier que la configuration est valide, chemin d'accès au répertoire."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Le cache audio sera stocké dans :  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3026,7 +2998,7 @@ msgstr ""
 "  Définissez l'option de configuration du jeton ou définissez la variable d'environnement %(env_var)s avec un jeton d'application."
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -3035,7 +3007,7 @@ msgstr ""
 " 128 caractères."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -3045,17 +3017,17 @@ msgstr ""
 "valeur d'option %.3f sera limitée à la place."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Validation des options avec les données du service..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "ID de propriétaire acquis via l'API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3076,12 +3048,12 @@ msgstr ""
 "  Définissez manuellement l'option de configuration « OwnerID » ou réessayez plus tard."
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot n'a pas d'instance d'utilisateur, impossible de continuer."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3100,14 +3072,14 @@ msgstr ""
 "  N'utilisez pas le Bot ou l'ID de l'application dans le champ 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "Fichier d'options de configuration introuvable. Vérification des "
 "alternatives..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3117,20 +3089,20 @@ msgstr ""
 "les extensions de fichiers."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copie du fichier d'options d'exemple existant :  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Une erreur s'est produite lors de la recherche d'un fichier d'options de "
 "configuration."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3152,7 +3124,7 @@ msgstr ""
 "  Vérifiez que le dossier de configuration et les fichiers existent et peuvent être lus par MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3176,14 +3148,14 @@ msgstr ""
 "  Copiez le fichier d'exemple du dépôt si tout le reste échoue."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 "L'option Dev Bug ! L'option de configuration a getter qui n'est pas "
 "disponible."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3192,12 +3164,12 @@ msgstr ""
 "doit être le même type."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "L'option était manquante précédemment."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
@@ -3205,19 +3177,19 @@ msgstr ""
 "Manquant : %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Option de configuration enregistrée : %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Impossible d'enregistrer la configuration :  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3225,13 +3197,13 @@ msgstr ""
 " est désactivé."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Impossible d'enregistrer le fichier INI par défaut à:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3251,7 +3223,7 @@ msgstr ""
 "  Définissez %(option)s sur un ID numérique ou mettez-le à `auto` ou `0` pour relier automatiquement le propriétaire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3271,7 +3243,7 @@ msgstr ""
 "  Vérifiez le paramétrage du chemin et assurez-vous que le fichier existe et est accessible à MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3291,7 +3263,7 @@ msgstr ""
 "  S'assurer que tous les identifiants sont numériques, et séparés uniquement par des espaces ou des virgules."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3301,7 +3273,7 @@ msgstr ""
 " %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3311,7 +3283,7 @@ msgstr ""
 "'%(value)s' en utilisant la valeur par défaut."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3321,7 +3293,7 @@ msgstr ""
 "(%(value)s) et sera définie à %(fallback)s à la place."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3330,56 +3302,56 @@ msgstr ""
 "%(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Mise à jour du fichier de configuration avec les options renommées..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Échec de la mise à jour de la configuration. Vous devrez la mettre à jour "
 "manuellement."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Fichier de liste de blocage non trouvé :  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Impossible de charger la liste de blocage du fichier :  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Impossible de mettre à jour le fichier de la liste de blocage :  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Liste de blocage des utilisateurs chargée avec les entrées %s."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Nous avons trouvé un fichier de liste noire hérité, il sera renommé en :  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Une liste de blocs de chansons avec des entrées %s a été chargée."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3387,20 +3359,20 @@ msgstr ""
 "probablement un bug dans le code!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "Aucun fichier pour la guilde %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 "Chargement des données de guilde pour la guilde avec ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
@@ -3408,14 +3380,14 @@ msgstr ""
 "données de guilde :  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 "La guilde %(id)s/%(name)s a un préfixe de commande personnalisé : %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3423,61 +3395,61 @@ msgstr ""
 "probablement un bug dans le code!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 "Impossible d'enregistrer les données spécifiques à la guilde en raison d'une"
 " erreur d'exploitation."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 "Impossible de sérialiser les données spécifiques à la guilde en raison de "
 "données non valides."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Forcer YTDLP à utiliser l'agent utilisateur :  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot utilisera des cookies pour yt-dlp depuis:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp utilisera votre serveur proxy configuré."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD ne semble pas avoir d'en-têtes..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 "La vérification des en-têtes des médias a échoué en raison du délai "
 "d'expiration."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Échec de la requête HEAD pour :  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "Exception de requête HEAD : "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3487,58 +3459,58 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Infos d'extraction YTDL Sanitized (pas JSON) :  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 "L'extraction des informations de la chanson n'a renvoyé aucune donnée."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Extraction appelée avec : '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Impossible d'exécuter l'extraction, la boucle est fermée. (C'est normal lors"
 " des arrêts.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "Impossible de poursuivre l'extraction, la boucle d'événement est fermée."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "L'URL Spotify n'est pas valide ou n'est pas prise en charge."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Erreur de téléchargement avec l'URL du flux"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "En supposant que le contenu est un flux direct"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Impossible de diffuser une URL non valide."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3546,23 +3518,23 @@ msgstr ""
 "deux points par de l'espace."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Appelé safe_extract_info avec :  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Le fichier média local est introuvable."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "__input_subject manquant de YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3570,7 +3542,7 @@ msgstr ""
 "pour éviter cela."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Attention, erreur de durée pour : %(url)s"
@@ -3617,13 +3589,13 @@ msgstr ""
 "Entrée :  %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 "Le numéro de version de l'entrée est manquant, impossible de désérialiser."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 "Les données de saisie ont le mauvais numéro de version, impossible de "
@@ -3658,7 +3630,7 @@ msgstr ""
 "recherche !"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "Impossible de charger %s"
@@ -3672,7 +3644,7 @@ msgstr ""
 "type : %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Préparation de l'entrée :  %r"
@@ -3696,7 +3668,7 @@ msgid "Download already cached at:  %s"
 msgstr "Téléchargement déjà mis en cache à:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3714,7 +3686,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Durée de %(time)s secondes pour le fichier :  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3725,75 +3697,75 @@ msgstr ""
 "à travailler, mais cela signifie que vos pistes ne seront pas égalées."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Exception lors de la vérification des données d'entrée."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Essai d'obtenir la durée via pymediainfo pour:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "Impossible d'obtenir la durée via pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Essai d'obtenir la durée via ffprobe pour:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "Impossible de localiser ffprobe dans votre chemin !"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe a renvoyé quelque chose qui n'a pas pu être utilisé."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe n'a pas pu être exécuté pour une raison quelconque."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Calcul du volume moyen de :  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "Impossible de localiser ffmpeg sur votre chemin !"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "Impossible d'analyser 'I' dans normaliser json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "Impossible d'analyser 'LRA' en normalise json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "Impossible d'analyser 'TP' dans normaliser json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "Impossible d'analyser 'thresh' dans normalise json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "Impossible d'analyser 'offset' dans normalise json."
 
@@ -3840,12 +3812,12 @@ msgstr ""
 "Le téléchargement a échoué à cause d'une erreur yt-dlp : %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "L'extraction a rencontré une exception non gérée."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
@@ -3853,44 +3825,44 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Échec du téléchargement :  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Impossible d'extraire les données pour les médias demandés."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Téléchargement terminé :  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 "StreamPlaylistEntry désérialisé ne peut pas trouver de canal avec l'ID :  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "StreamPlaylistEntry désérialisé a le mauvais type de canal :  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "StreamPlaylistEntry désérialisé ne peut pas trouver l'auteur avec l'ID :  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
@@ -3898,7 +3870,7 @@ msgstr ""
 "rechercher !"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
@@ -3906,13 +3878,13 @@ msgstr ""
 "l'ID :  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr "LocalFilePlaylistEntry désérialisé a le mauvais type de canal :  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
@@ -3920,7 +3892,7 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3929,7 +3901,7 @@ msgstr ""
 "recherche !"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Durée de %(seconds)s secondes pour le fichier :  %(file)s"
@@ -4047,13 +4019,13 @@ msgstr ""
 "Ancien: %(old)s  Nouveau: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Erreur Argument de Langue :  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -4061,7 +4033,7 @@ msgstr ""
 "[%s]  dans:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4397,65 +4369,65 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Données décodées de ffmpeg : %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Ajout de l'entrée de flux pour l'URL :  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Impossible d'extraire les informations"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Ceci est une liste de lecture."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 "Les informations d'entrée semblent être un flux, ajoutant une entrée de "
 "flux..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Type de contenu invalide `%(type)s` pour l'URL : %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "Texte reçu/html pour le type de contenu, il peut s'agir d'un flux."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Type de contenu questionnable «%(type)s» pour url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Ajout d'URLPlaylistEntry pour: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Ajout de LocalFilePlaylistEntry pour : %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "Vidéo ignorée à partir du lien de la playlist composée avec ID:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4464,7 +4436,7 @@ msgstr ""
 "URL  %(title)s  : %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4473,7 +4445,7 @@ msgstr ""
 " maximale autorisée."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4481,40 +4453,40 @@ msgstr ""
 "supprimée :  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "Impossible d'ajouter l'élément"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Objet : %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "A ignoré les entrées incorrectes %s"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Réorganiser la boucle sur les entrées."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Pré-téléchargement de la piste suivante :  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "aucune donnée de durée"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "aucune donnée de durée dans l'entrée actuelle"
 
@@ -5099,44 +5071,44 @@ msgstr ""
 "strftime(). (par défaut: '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Version :  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Ouvert une nouvelle instance de MusicBot. Ce terminal peut être fermé en "
 "toute sécurité!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Chargement de la version de MusicBot :  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Journal ouvert :  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Changement du répertoire de travail en :  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5147,7 +5119,7 @@ msgstr ""
 "pour vérifier un nouvel emplacement de répertoire."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5156,7 +5128,7 @@ msgstr ""
 "Si vous n'avez pas utilisé git pour cloner le dépôt, il vous est fortement recommandé de le faire."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5165,12 +5137,12 @@ msgstr ""
 "de certifi et quittant."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Voici l'erreur exacte, elle pourrait être un bug."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5179,7 +5151,7 @@ msgstr ""
 "vous pouvez ouvrir le site défaillant dans Microsoft Edge ou IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5188,17 +5160,17 @@ msgstr ""
 "confiance par défaut, en essayant de certifi à la place."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Erreur de syntaxe (modification détectée, avez-vous modifié le code?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Erreur de syntaxe (c'est un bug, pas votre faute)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5219,14 +5191,14 @@ msgstr ""
 "  ou lancer sans `--no-install-deps` et MusicBot essayera de les installer pour vous."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Tentative d'installation automatique des paquets de dépendances "
 "MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5262,13 +5234,13 @@ msgstr ""
 "  https://discord.gg/bots."
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 "OK, laissons espérer que l'installation des dépendances a fonctionné !"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5277,58 +5249,58 @@ msgstr ""
 "des paquets. MusicBot doit quitter..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "L'exception qui a causé l'erreur ci-dessus : "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot fait un redémarrage doux..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot effectue un redémarrage complet du processus..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Erreur lors du démarrage du bot"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Fermeture de la boucle d'événements."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Redémarrage dans %s secondes..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "Terminé."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "OK, nous sommes en train de fermer!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -5353,12 +5325,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5372,7 +5344,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5440,45 +5412,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -5490,220 +5462,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5722,30 +5694,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5753,18 +5725,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5839,9 +5811,92 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+#~ "La configuration n'a pas les identifiants de l'application Spotify, en "
+#~ "essayant d'utiliser le mode invité."
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "Authentifié avec Spotify avec succès en mode invité."
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+#~ "Impossible de démarrer le client Spotify en utilisant le mode invité. "
+#~ "Détails : %s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "La recherche YouTube n'a retourné aucun résultat pour :  %(url)s"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/fr_FR/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/fr_FR/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:41\n"
@@ -496,20 +496,20 @@ msgstr ""
 "redémarrez-vous?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot demande à parler dans le canal : %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot n'a pas la permission de parler."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot n'a pas pu demander à parler."
 
@@ -646,7 +646,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Définition de l'historique des URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Aucune vignette définie pour l'entrée avec l'URL : %s"
@@ -740,19 +740,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Bouclage de la liste de lecture automatique du joueur..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Erreur lors du traitement de la chanson \"%(url)s\" :  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Erreur lors de l'extraction de la chanson \"%(url)s\" : %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot a besoin de mettre fin à l'extraction et au sauvetage de la liste "
@@ -1134,7 +1134,7 @@ msgstr "Liste de guilde:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1731,7 +1731,7 @@ msgid "The player is not currently looping."
 msgstr "Le joueur n'est pas en boucle."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Les positions de la chanson doivent être des entiers !"
 
@@ -1754,35 +1754,35 @@ msgid "Local media playback is not enabled."
 msgstr "La lecture des médias locaux n'est pas activée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "L'URL Spotify n'est pas valide ou n'est pas prise en charge actuellement."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Une URL Spotify a été détectée, mais Spotify n'est pas activé."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Vous avez atteint votre limite de chansons en attente (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "Le mode Karaoké est activé, veuillez réessayer quand il est désactivé!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Problème avec extract_info() : "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1792,13 +1792,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Cette vidéo ne peut pas être lue. Essayez d'utiliser la commande stream."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1808,7 +1808,7 @@ msgstr ""
 "%(time_per).2f s/chanson"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1817,47 +1817,47 @@ msgstr ""
 " durée maximale (%(max)s secondes)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "Extrait une entrée avec 'youtube:playlist' comme clé d'extracteur"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "La durée de la musique dépasse la limite (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Chanson(s) ajoutée à la position %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "Impossible d'estimer le temps avant de jouer pour la position : %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "Impossible d'obtenir les informations de la demande de flux: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "La diffusion de listes de lecture n'est pas encore prise en charge."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Vous avez atteint la limite d'élément de votre playlist (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -1865,60 +1865,60 @@ msgstr ""
 "plus d'informations."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Vous ne pouvez pas rechercher plus de vidéos %(max)s"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "En attente d'un verrou d'invocation : %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Verrouillage de convocation acquis pour: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 "Vous n'êtes pas connecté à la voix. Essayez de rejoindre un salon vocal !"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Rejoindre %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 "MusicBot ne peut pas suivre un utilisateur qui n'est pas membre du serveur."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Le joueur ne joue pas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Rien dans la file d'attente à supprimer !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 "Rien n'a été trouvé dans la file d'attente de l'utilisateur `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1927,41 +1927,41 @@ msgstr ""
 "Vous devez être celui qui l'a mis en file d'attente ou qui a des permissions de sauter instantanément."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numéro d'entrée invalide. Utilisez la commande file d'attente pour trouver "
 "les positions de la file d'attente."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossible de sauter ! Le joueur ne joue pas !"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "Vous n'avez pas la permission de forcer le saut d'une chanson en boucle."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Vous n'avez pas la permission de forcer le saut."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Vous n'avez pas la permission de sauter une chanson en boucle."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` n'est pas un nombre valide"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1971,7 +1971,7 @@ msgstr ""
 "Le volume ne peut être défini que de 1 à 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1980,7 +1980,7 @@ msgstr ""
 "entre 1 et 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1989,30 +1989,30 @@ msgstr ""
 "Utilisez la commande de configuration pour définir une vitesse de lecture par défaut."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "La vitesse ne peut pas être appliquée aux médias streamés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Vous devez fournir une vitesse à définir."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La vitesse que vous avez fournie n'est pas valide. Utilisez un nombre entre "
 "0,5 et 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Option invalide pour la commande : `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2022,30 +2022,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Vous devez fournir un alias et une commande à alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Vous devez fournir un nom d'alias à supprimer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` n'existe pas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuration ne peut pas utiliser les mentions du canal et de "
 "l'utilisateur en même temps."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2055,7 +2055,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2064,18 +2064,18 @@ msgstr ""
 "Veuillez fournir un nom de section et d'option valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'option donnée est ambiguë, veuillez fournir un nom de section."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Vous devez fournir un nom de section et un nom d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2085,13 +2085,13 @@ msgstr ""
 "Les sections disponibles sont :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'option `%(option)s` n'est pas disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
@@ -2099,13 +2099,13 @@ msgstr ""
 "disque."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossible d'enregistrer l'option : `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -2113,7 +2113,7 @@ msgstr ""
 "affichée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2121,26 +2121,26 @@ msgstr ""
 "paramètre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Vous devez fournir une section, une option et une valeur pour cette sous-"
 "commande."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Faire avec %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'option `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2148,49 +2148,49 @@ msgstr ""
 " valeur par défaut."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Réinitialisation de %(config)s à %(value)s par défaut"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'option `%(option)s` n'a pas été réinitialisée par défaut!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "La commande d'option est obsolète, utilisez la commande config à la place."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Option non valide spécifiée, utilisez: info, mise à jour ou effacement"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Échec** pour supprimer la cache, vérifiez les logs pour plus d'infos..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "L'argument de la page de file d'attente doit être un nombre entier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Il n'y a pas de chansons en attente ! Mettre en file d'attente quelque chose"
 " avec une commande de lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2200,24 +2200,24 @@ msgstr ""
 "Il y a **%(total)s** pages."
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "L'entrée de la playlist actuelle a été ignorée."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "Pas assez d'entrées pour paginer la file d'attente."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Impossible de poster le message de file d'attente, aucun message à ajouter "
 "des réactions."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2226,17 +2226,17 @@ msgstr ""
 "Si le problème persiste, remplissez un rapport de bogue."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossible d'utiliser la purge sur un canal DM privé."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "L'URL donnée n'est pas une URL valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2246,12 +2246,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Cela ne semble pas être une playlist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2260,19 +2260,19 @@ msgstr ""
 "l'ID et réessayer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossible de déterminer l'utilisateur de la discord. Réessayez."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Les permissions ne peuvent pas utiliser les mentions de salon et "
 "d'utilisateurs en même temps."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2282,26 +2282,26 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Vous devez fournir un nom de groupe ou d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Vous devez fournir un groupe, une option et une valeur à définir pour cette "
 "commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 "La sous-commande %(option)s nécessite un nom de groupe et de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2311,47 +2311,47 @@ msgstr ""
 "Les groupes disponibles sont:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "La permission `%(option)s` n'est pas disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossible d'ajouter le groupe `%(group)s` il existe déjà."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Impossible de supprimer le groupe intégré."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Le groupe propriétaire n'est pas modifiable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossible d'enregistrer le groupe: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Faire sur %(option)s avec la valeur : %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2360,7 +2360,7 @@ msgstr ""
 "Rappelez-vous que les changements de nom sont limités à deux fois par heure.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2370,12 +2370,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Impossible de changer le pseudo : pas de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2385,14 +2385,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Les émojis personnalisés doivent provenir de ce serveur pour être utilisés "
 "comme préfixes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2401,31 +2401,31 @@ msgstr ""
 "Utilisez la commande de configuration pour mettre à jour le préfixe à la place."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Cette commande ne peut être utilisée que dans les guildes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sous-commande invalide. Utilisez la commande d'aide pour plus "
 "d'informations."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 "Impossible de définir la langue à `%(locale)s` il n'est pas disponible."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Vous devez fournir une URL ou joindre un fichier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2435,63 +2435,63 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot a trouvé une %s sans guilde! Cela pourrait être un problème."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Pas actuellement connecté au serveur `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Option non valide, utilisez une de : soft, full, upgrade, uppip ou upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Vous devez fournir un ID ou un nom."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Aucune guilde n'a été trouvée avec l'ID ou le nom `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Activation de l'ID du point d'arrêt de débogage : %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossible d'importer `objgraph`, est-il installé ?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Le code de débogage a été exécuté avec eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Le code de débogage a été exécuté avec exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "L'exécution du code de débogage a échoué."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2507,57 +2507,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "La sous-commande doit être une des : %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Impossible de localiser l'exécutable git."
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "Échec de la vérification des mises à jour via la commande git."
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Méta manquante dans le rapport pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 "Impossible d'obtenir le statut de mise à jour de pip en raison d'une erreur."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Vous avez reçu une étrange entrée du client vocal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies déjà activés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Les cookies doivent être téléchargés pour être activés. (Fichier de cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 "Impossible d'activer les cookies en raison d'une erreur :  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2567,7 +2567,7 @@ msgstr ""
 "Cookies temporairement désactivés et seront réactivés au prochain redémarrage."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2575,7 +2575,7 @@ msgstr ""
 "téléchargeant un fichier de cookies."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
@@ -2583,7 +2583,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
@@ -2591,37 +2591,37 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossible d'enregistrer les cookies sur le disque :  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "A reçu un message sans canal, d'une manière ou d'une autre :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Commande ignorée de moi-même (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Commande ignorée par un autre bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Commande ignorée du canal de type :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2629,13 +2629,13 @@ msgstr ""
 " : %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Message de %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
@@ -2643,12 +2643,12 @@ msgstr ""
 "%(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Cette commande nécessite d'être dans un canal vocal."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
@@ -2656,76 +2656,76 @@ msgstr ""
 ": %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Erreur dans %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Exception lors de la gestion de la commande : %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Impossible de générer de l'aide pour la commande manquante :  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Il manque des données d'aide pour la commande :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Quitter le canal vocal %s en %s en raison de l'inactivité."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot est devenu connecté."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot est déconnecté."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "A eu un événement de socket:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState mis à jour avant que le_ready ne soit terminé"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "%s ignoré dans %s car il s'agit d'un salon vocal lié."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s a été détecté comme vide. Délai de manutention expiré."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Un utilisateur a rejoint %s, annulation du délai."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2733,30 +2733,30 @@ msgstr ""
 "Le bot a été déplacé et le canal vocal %s est vide. Délai de manutention."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Le bot a été déplacé et le canal vocal %s n'est pas vide."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "Plus utilisateur suivant %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Utilisateur suivant `%(user)s` pour le salon :  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState déconnexion before.channel est Aucune."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2766,7 +2766,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2774,92 +2774,92 @@ msgstr ""
 "%(type)s  dans la guilde :  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 "Impossible de trouver le canal auto-joint, a-t-il été supprimé? Guilde:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Reconnexion à la guilde automatiquement rejoint sur le canal :  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Impossible de rejoindre automatiquement le canal :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Le bot a été ajouté à la guilde : %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "A quitté la guilde '%s' en raison du propriétaire du bot introuvable."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Création du dossier de données pour la guilde %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Le bot a été retiré de la guilde : %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Liste de guilde mise à jour :"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "La guilde «%s» est devenue disponible."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Reprise du joueur dans «%s» en raison de la disponibilité."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "La guilde «%s» est devenue indisponible."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pauser le joueur dans «%s» en raison de l'indisponibilité."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Mise à jour de guilde pour :  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 "L'attribut de guilde %(attr)s est maintenant : %(new)s  -- Était: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Mise à jour du canal pour:  %(channel)s  --  %(changes)s"
@@ -2877,7 +2877,7 @@ msgid "Loading config from:  %s"
 msgstr "Chargement de la configuration depuis :  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2907,7 +2907,7 @@ msgstr ""
 "  Utilisez les options d'exemple comme modèle ou copiez-les à partir du référentiel."
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2917,7 +2917,7 @@ msgstr ""
 "sera limitée à la place."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2926,7 +2926,7 @@ msgstr ""
 "rotation des fichiers journaux. Utiliser par défaut à la place."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2945,12 +2945,12 @@ msgstr ""
 "  Assurez-vous que le chemin que vous avez configuré est un chemin vers un dossier / répertoire."
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Une exception a été levée lors de la validation de AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2972,13 +2972,13 @@ msgstr ""
 "  Double vérifier que la configuration est valide, chemin d'accès au répertoire."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Le cache audio sera stocké dans :  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2998,7 +2998,7 @@ msgstr ""
 "  Définissez l'option de configuration du jeton ou définissez la variable d'environnement %(env_var)s avec un jeton d'application."
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -3007,7 +3007,7 @@ msgstr ""
 " 128 caractères."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -3017,17 +3017,17 @@ msgstr ""
 "valeur d'option %.3f sera limitée à la place."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Validation des options avec les données du service..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "ID de propriétaire acquis via l'API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3048,12 +3048,12 @@ msgstr ""
 "  Définissez manuellement l'option de configuration « OwnerID » ou réessayez plus tard."
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot n'a pas d'instance d'utilisateur, impossible de continuer."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3072,14 +3072,14 @@ msgstr ""
 "  N'utilisez pas le Bot ou l'ID de l'application dans le champ 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "Fichier d'options de configuration introuvable. Vérification des "
 "alternatives..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3089,20 +3089,20 @@ msgstr ""
 "les extensions de fichiers."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copie du fichier d'options d'exemple existant :  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Une erreur s'est produite lors de la recherche d'un fichier d'options de "
 "configuration."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3124,7 +3124,7 @@ msgstr ""
 "  Vérifiez que le dossier de configuration et les fichiers existent et peuvent être lus par MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3148,14 +3148,14 @@ msgstr ""
 "  Copiez le fichier d'exemple du dépôt si tout le reste échoue."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 "L'option Dev Bug ! L'option de configuration a getter qui n'est pas "
 "disponible."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3164,12 +3164,12 @@ msgstr ""
 "doit être le même type."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "L'option était manquante précédemment."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
@@ -3177,19 +3177,19 @@ msgstr ""
 "Manquant : %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Option de configuration enregistrée : %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Impossible d'enregistrer la configuration :  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3197,13 +3197,13 @@ msgstr ""
 " est désactivé."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Impossible d'enregistrer le fichier INI par défaut à:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3223,7 +3223,7 @@ msgstr ""
 "  Définissez %(option)s sur un ID numérique ou mettez-le à `auto` ou `0` pour relier automatiquement le propriétaire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3243,7 +3243,7 @@ msgstr ""
 "  Vérifiez le paramétrage du chemin et assurez-vous que le fichier existe et est accessible à MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3263,7 +3263,7 @@ msgstr ""
 "  S'assurer que tous les identifiants sont numériques, et séparés uniquement par des espaces ou des virgules."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3273,7 +3273,7 @@ msgstr ""
 " %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3283,7 +3283,7 @@ msgstr ""
 "'%(value)s' en utilisant la valeur par défaut."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3293,7 +3293,7 @@ msgstr ""
 "(%(value)s) et sera définie à %(fallback)s à la place."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3302,50 +3302,50 @@ msgstr ""
 "%(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Mise à jour du fichier de configuration avec les options renommées..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Échec de la mise à jour de la configuration. Vous devrez la mettre à jour "
 "manuellement."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Fichier de liste de blocage non trouvé :  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Impossible de charger la liste de blocage du fichier :  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Impossible de mettre à jour le fichier de la liste de blocage :  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Liste de blocage des utilisateurs chargée avec les entrées %s."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Nous avons trouvé un fichier de liste noire hérité, il sera renommé en :  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Une liste de blocs de chansons avec des entrées %s a été chargée."
@@ -3415,41 +3415,41 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Forcer YTDLP à utiliser l'agent utilisateur :  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot utilisera des cookies pour yt-dlp depuis:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp utilisera votre serveur proxy configuré."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD ne semble pas avoir d'en-têtes..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 "La vérification des en-têtes des médias a échoué en raison du délai "
 "d'expiration."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Échec de la requête HEAD pour :  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "Exception de requête HEAD : "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3459,58 +3459,58 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Infos d'extraction YTDL Sanitized (pas JSON) :  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 "L'extraction des informations de la chanson n'a renvoyé aucune donnée."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Extraction appelée avec : '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Impossible d'exécuter l'extraction, la boucle est fermée. (C'est normal lors"
 " des arrêts.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "Impossible de poursuivre l'extraction, la boucle d'événement est fermée."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "L'URL Spotify n'est pas valide ou n'est pas prise en charge."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Erreur de téléchargement avec l'URL du flux"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "En supposant que le contenu est un flux direct"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Impossible de diffuser une URL non valide."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3518,23 +3518,23 @@ msgstr ""
 "deux points par de l'espace."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Appelé safe_extract_info avec :  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Le fichier média local est introuvable."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "__input_subject manquant de YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3542,7 +3542,7 @@ msgstr ""
 "pour éviter cela."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Attention, erreur de durée pour : %(url)s"
@@ -4866,13 +4866,13 @@ msgstr ""
 "Vérifiez la présence de ffmpeg avec votre gestionnaire de paquets système ou construisez à partir des sources."
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "Il reste moins de %sMB d'espace libre sur cet appareil"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4881,12 +4881,12 @@ msgstr ""
 "Vérification des mises à jour de MusicBot ou des dépendances..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "Aucune mise à jour de MusicBot disponible via la commande `git`."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4895,23 +4895,23 @@ msgstr ""
 "Vous devriez vérifier manuellement."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "Les paquets suivants peuvent être mis à jour :\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  à la version :  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "Aucune mise à jour des dépendances disponible via la commande `pip`."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4920,7 +4920,7 @@ msgstr ""
 "Vous devriez vérifier manuellement."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4930,35 +4930,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "La valeur est supérieure à la limite maximale."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "La valeur ne doit pas être négative."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "La valeur pour Max Logs Kept doit être un nombre de 0 à %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "Le niveau de log '%s' n'est pas disponible."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "Le niveau de log doit être le :  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4967,27 +4967,27 @@ msgstr ""
 "ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Disponible via Github:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr "Pour plus d'aide et de support avec ce bot, rejoignez notre discord:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "Ce logiciel est fourni sous la licence MIT."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "Voir le fichier texte `LICENSE` pour plus de détails."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
@@ -4995,14 +4995,14 @@ msgstr ""
 "MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 "Utilisez cette langue pour tous les messages de log côté serveur de "
 "MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -5011,29 +5011,29 @@ msgstr ""
 "Cela n'empêche pas la sélection de langue par guilde."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Imprimez les informations de version de MusicBot et quittez."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 "Ignorer toutes les vérifications optionnelles de démarrage, y compris la "
 "vérification de mise à jour."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Ignorer seulement l'espace disque au démarrage."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Ignorer uniquement la vérification des mises à jour au démarrage."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -5042,7 +5042,7 @@ msgstr ""
 "pas les importer."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -5052,7 +5052,7 @@ msgstr ""
 "inclusivement. (par défaut : %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
@@ -5060,7 +5060,7 @@ msgstr ""
 " Doit être l'un des : %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -5071,44 +5071,44 @@ msgstr ""
 "strftime(). (par défaut: '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Version :  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Ouvert une nouvelle instance de MusicBot. Ce terminal peut être fermé en "
 "toute sécurité!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Chargement de la version de MusicBot :  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Journal ouvert :  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Changement du répertoire de travail en :  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5119,7 +5119,7 @@ msgstr ""
 "pour vérifier un nouvel emplacement de répertoire."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5128,7 +5128,7 @@ msgstr ""
 "Si vous n'avez pas utilisé git pour cloner le dépôt, il vous est fortement recommandé de le faire."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5137,12 +5137,12 @@ msgstr ""
 "de certifi et quittant."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Voici l'erreur exacte, elle pourrait être un bug."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5151,7 +5151,7 @@ msgstr ""
 "vous pouvez ouvrir le site défaillant dans Microsoft Edge ou IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5160,17 +5160,17 @@ msgstr ""
 "confiance par défaut, en essayant de certifi à la place."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Erreur de syntaxe (modification détectée, avez-vous modifié le code?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Erreur de syntaxe (c'est un bug, pas votre faute)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5191,14 +5191,14 @@ msgstr ""
 "  ou lancer sans `--no-install-deps` et MusicBot essayera de les installer pour vous."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Tentative d'installation automatique des paquets de dépendances "
 "MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5234,58 +5234,44 @@ msgstr ""
 "  https://discord.gg/bots."
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 "OK, laissons espérer que l'installation des dépendances a fonctionné !"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot a obtenu une erreur d'importation après avoir essayé d'installer "
-"des paquets. MusicBot doit quitter..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "L'exception qui a causé l'erreur ci-dessus : "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot fait un redémarrage doux..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot effectue un redémarrage complet du processus..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Erreur lors du démarrage du bot"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Fermeture de la boucle d'événements."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Redémarrage dans %s secondes..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "Terminé."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "OK, nous sommes en train de fermer!"
 
@@ -5306,31 +5292,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5344,7 +5330,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5404,7 +5390,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5635,24 +5621,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5699,25 +5685,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5725,66 +5711,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5811,7 +5751,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5823,25 +5763,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5854,29 +5794,145 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot a obtenu une erreur d'importation après avoir essayé d'installer "
+#~ "des paquets. MusicBot doit quitter..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "L'exception qui a causé l'erreur ci-dessus : "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/fr_FR/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/fr_FR/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -41,34 +41,34 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 "Le membre n'est pas activé par la voix et ne peut pas utiliser cette "
 "commande."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 "Vous ne pouvez pas utiliser cette commande quand vous n'êtes pas dans le "
 "salon vocal."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 "MusicBot n'a pas la permission de se connecter dans le salon : `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot n'a pas la permission de parler dans le salon : `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -77,7 +77,7 @@ msgstr ""
 "Réessayez plus tard ou redémarrez le bot si cela continue."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -85,17 +85,17 @@ msgstr ""
 "redémarrez-vous?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot n'a pas la permission de parler."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot n'a pas pu demander à parler."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -104,12 +104,12 @@ msgstr ""
 "Utilisez la commande d'invocation pour amener le bot dans votre canal vocal."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Quelque chose ne va pas, nous n'avons pas obtenu le VoiceClient."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -118,7 +118,7 @@ msgstr ""
 "n'est pas dans la voix!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
@@ -126,20 +126,20 @@ msgstr ""
 "%(channel)s !"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 "En cours de lecture en %(channel)s: `%(title)s` ajouté par %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr "Lecture automatique de l'entrée `%(title)s` en %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
@@ -147,7 +147,7 @@ msgstr ""
 "voix!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -159,12 +159,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Tentative d'envoi d'un objet de réponse invalide."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -187,7 +187,7 @@ msgstr ""
 "  Vérifiez l'état de l'API sur le site officiel : discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
@@ -195,7 +195,7 @@ msgstr ""
 "chansons."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -204,12 +204,12 @@ msgstr ""
 "Cette commande sera supprimée dans une version ultérieure, remplacée par les commandes de la liste de lecture automatique."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -217,18 +217,18 @@ msgstr ""
 "les commandes disponibles.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Alias pour cette commande :**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "`%(alias)s` alias de `%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -239,7 +239,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -251,12 +251,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Aucune commande de ce type"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -266,7 +266,7 @@ msgstr ""
 "Pour une liste de toutes les commandes, exécutez : %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -288,22 +288,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Bloquer un utilisateur mentionné."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Débloquer un utilisateur mentionné."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Afficher le statut de bloc d'un utilisateur mentionné."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -312,47 +312,47 @@ msgstr ""
 "Les utilisateurs bloqués ne peuvent pas utiliser toutes les commandes du bot.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 "Vous devez mentionner un utilisateur ou fournir son numéro d'identité."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez `help blockuser` pour des exemples "
 "d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot n'a pas pu trouver les utilisateurs que vous avez spécifiés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Le propriétaire ne peut pas être ajouté à la liste de blocs."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "La liste des utilisateurs bloqués est actuellement activée."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "La liste des utilisateurs bloqués est actuellement désactivée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 "Impossible d'ajouter les utilisateurs que vous avez listés, ils sont déjà "
 "ajoutés."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -362,24 +362,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "Aucun de ces utilisateurs n'est dans la liste noire."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "L'utilisateur : `%(user)s` n'est pas bloqué.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "L'utilisateur : `%(user)s` est bloqué.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -391,7 +391,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -401,7 +401,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -418,26 +418,26 @@ msgstr ""
 "Cela signifie que l'ajout de « Pie » correspondra à « cherry Pie » mais pas à « piecrust » dans les vérifications.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Vous devez indiquer un sujet si aucune chanson n'est en cours de lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez `help blocksong` pour des exemples "
 "d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Sujet `%(subject)s` est déjà dans la liste de blocage de chansons."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -447,14 +447,14 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 "Le sujet n'est pas dans la liste des chansons bloquées et ne peut pas être "
 "supprimé."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -464,7 +464,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -473,12 +473,12 @@ msgstr ""
 " la playlist actuelle.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Ajoute toute la file d'attente à la playlist des guildes.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -487,72 +487,72 @@ msgstr ""
 "playlist automatique de guilde.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez `help autoplaylist` pour des exemples "
 "d'utilisation."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Le lien de la chanson fournie n'est pas valide"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "La file d'attente est vide. Ajoutez des morceaux avec une commande de "
 "lecture!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 "Toutes les chansons dans la file d'attente sont déjà dans la liste de "
 "lecture automatique."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "Ajout des chansons %(number)d à la liste de lecture automatique."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "Ajouté `%(url)s` à la liste de lecture automatique."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Cette chanson est déjà dans la liste de lecture automatique."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "Supprimé `%(url)s` de la liste de lecture automatique."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Cette chanson n'est pas encore dans la liste de lecture automatique."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Une nouvelle copie de la playlist a été chargée : `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Vous devez fournir un nom de fichier de playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -561,13 +561,13 @@ msgstr ""
 "Cette playlist est nouvelle, vous devez ajouter des chansons pour l'enregistrer sur le disque !"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr "La playlist de ce serveur a été mise à jour: `%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
@@ -575,7 +575,7 @@ msgstr ""
 "autre serveur."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -585,7 +585,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -594,28 +594,28 @@ msgstr ""
 "Groupes avec Permissions BypassKaraokeMode contrôlent quels membres sont membres Karaoke.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\NLe mode Karaoké{OK HAND SIGN} est maintenant activé."
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\N{OK HAND SIGN} Le mode Karaoké est maintenant désactivé."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Vous n'êtes pas autorisé à demander des playlists"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "La playlist a trop d'entrées (%(songs)s mais max est %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -627,13 +627,13 @@ msgstr ""
 "La limite est %(max)s pour votre groupe."
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 "Le bot a été précédemment mis en pause, reprenant la lecture maintenant."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -650,7 +650,7 @@ msgstr ""
 "MusicBot prend également en charge les URI et les URL Spotify, mais l'audio est récupéré à partir de YouTube dans tous les cas.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -659,7 +659,7 @@ msgstr ""
 "ajouter à la file d'attente.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
@@ -667,7 +667,7 @@ msgstr ""
 "`%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -676,7 +676,7 @@ msgstr ""
 "Lire de l'aide pour la commande de lecture pour des informations sur les entrées prises en charge.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -685,7 +685,7 @@ msgstr ""
 "Lire de l'aide pour la commande de lecture pour des informations sur les entrées prises en charge.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -698,37 +698,37 @@ msgstr ""
 "En raison des spécificités du codec dans ffmpeg, cela peut ne pas être exact.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Impossible d'utiliser seek s'il n'y a rien à jouer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Impossible d'utiliser la recherche sur la piste en cours, elle a une durée "
 "inconnue."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "La recherche n'est pas prise en charge pour les flux."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 "Impossible d'utiliser la recherche sans un temps pour positionner la "
 "lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Impossible de convertir `%(input)s` en une heure valide en secondes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -738,7 +738,7 @@ msgstr ""
 "actuelle avec une longueur de `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -747,7 +747,7 @@ msgstr ""
 "chanson actuelle."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -758,66 +758,66 @@ msgstr ""
 "Si aucune option n'est fournie et que la chanson est déjà répétitive, la répétition sera désactivée.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 "Aucune musique n'est en cours de lecture. Jouez quelque chose avec une "
 "commande de lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Sous-commande invalide. Utilisez la commande `help repeat` pour des exemples"
 " d'utilisation."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "La playlist se répète."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "La playlist ne se répète plus."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "Le lecteur va maintenant boucler la chanson actuelle."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "Le lecteur ne bouclera plus la chanson actuelle."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "Le lecteur boucle déjà une chanson !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Le joueur n'est pas en boucle."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "La chanson ne se répète plus."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "La chanson se répète."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    Déplacer la chanson à la position À partir de la position TO.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -826,24 +826,24 @@ msgstr ""
 "Utilisez la commande de file d'attente pour trouver les numéros de position de la piste.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 "Il n'y a pas de musique en attente. Jouez quelque chose avec une commande de"
 " lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Les positions de la chanson doivent être des entiers !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Vous avez donné une position en dehors de la taille de la playlist !"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -852,7 +852,7 @@ msgstr ""
 "la position %(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -866,35 +866,35 @@ msgstr ""
 "Voulez-vous également mettre en file d'attente la playlist ?"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "La lecture des médias locaux n'est pas activée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "L'URL Spotify n'est pas valide ou n'est pas prise en charge actuellement."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Une URL Spotify a été détectée, mais Spotify n'est pas activé."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Vous avez atteint votre limite de chansons en attente (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "Le mode Karaoké est activé, veuillez réessayer quand il est désactivé!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -904,16 +904,10 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Cette vidéo ne peut pas être lue. Essayez d'utiliser la commande stream."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "La recherche YouTube n'a retourné aucun résultat pour :  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1097,7 +1091,7 @@ msgid "Show information on what is currently playing."
 msgstr "Afficher des informations sur ce qui est en train de jouer."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1134,7 +1128,7 @@ msgstr "Progression :"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Il n'y a pas de chansons en attente ! Mettre en file d'attente quelque chose"
@@ -1245,39 +1239,26 @@ msgstr "Supprime toutes les chansons actuellement dans la file d'attente."
 msgid "Cleared all songs from the queue."
 msgstr "Toutes les chansons de la file d'attente ont été supprimées."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Supprimez une chanson de la file d'attente, éventuellement à la position de la file d'attente donnée.\n"
-"Si la position est omise, la chanson à la fin de la file d'attente est supprimée.\n"
-"Utilisez la commande queue pour trouver le numéro de position de votre piste.\n"
-"Cependant, les positions de toutes les chansons sont modifiées lorsqu'une nouvelle chanson commence à jouer.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Rien dans la file d'attente à supprimer !"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Supprimé `%(track)s` ajouté par `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 "Rien n'a été trouvé dans la file d'attente de l'utilisateur `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1286,26 +1267,26 @@ msgstr ""
 "Vous devez être celui qui l'a mis en file d'attente ou qui a des permissions de sauter instantanément."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numéro d'entrée invalide. Utilisez la commande file d'attente pour trouver "
 "les positions de la file d'attente."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Entrée supprimée `%(track)s` ajoutée par `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Entrée retirée `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1316,12 +1297,12 @@ msgstr ""
 "Si l'option LegacySkip est activée, le paramètre force peut être ignoré.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossible de sauter ! Le joueur ne joue pas !"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
@@ -1329,12 +1310,12 @@ msgstr ""
 "patienter."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "La prochaine chanson sera jouée sous peu. Veuillez patienter."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1343,7 +1324,7 @@ msgstr ""
 "Vous pouvez redémarrer le bot s'il ne commence pas à fonctionner."
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1352,29 +1333,29 @@ msgstr ""
 "Vous pouvez redémarrer le bot si cela ne fonctionne pas."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "Vous n'avez pas la permission de forcer le saut d'une chanson en boucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Force ignorée `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Vous n'avez pas la permission de forcer le saut."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Vous n'avez pas la permission de sauter une chanson en boucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1384,12 +1365,12 @@ msgstr ""
 "Le vote à passer a été passé.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " Prochaine chanson à venir !"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1399,7 +1380,7 @@ msgstr ""
 "Besoin de **%(votes)s** plus de votes pour sauter cette chanson."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1410,25 +1391,25 @@ msgstr ""
 "Le réglage de volume est conservé jusqu'à ce que MusicBot soit redémarré.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Volume actuel : `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` n'est pas un nombre valide"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Volume mis à jour de **%(old)d** à **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1438,7 +1419,7 @@ msgstr ""
 "Le volume ne peut être défini que de 1 à 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1447,7 +1428,7 @@ msgstr ""
 "entre 1 et 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1458,7 +1439,7 @@ msgstr ""
 "La lecture en continu ne prend pas en charge les réglages de vitesse.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1467,36 +1448,36 @@ msgstr ""
 "Utilisez la commande de configuration pour définir une vitesse de lecture par défaut."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "La vitesse ne peut pas être appliquée aux médias streamés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Vous devez fournir une vitesse à définir."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La vitesse que vous avez fournie n'est pas valide. Utilisez un nombre entre "
 "0,5 et 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Réglage de la vitesse de lecture à `%(speed).3f` pour la piste actuelle."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Ajouter un nouvel alias avec des arguments optionnels.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1505,23 +1486,23 @@ msgstr ""
 "la commande d'aide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Option invalide pour la commande : `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Alias rechargé depuis le fichier de configuration."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Alias enregistrés dans le fichier de configuration."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1531,43 +1512,43 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Vous devez fournir un alias et une commande à alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 "Nouvel alias ajouté. `%(alias)s` est maintenant un alias de `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Vous devez fournir un nom d'alias à supprimer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` n'existe pas."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` a été supprimé."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Affiche le texte d'aide à propos de toutes les options de configuration "
 "manquantes.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1576,32 +1557,32 @@ msgstr ""
 " fichier de configuration.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr "    Liste les options de configuration disponibles et leurs sections.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Recharger le fichier options.ini à partir du disque.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Affiche le texte d'aide pour une option spécifique.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Affiche la valeur actuelle de l'option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Enregistre la valeur actuelle dans le fichier d'options.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1610,35 +1591,35 @@ msgstr ""
 "pour le fichier.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Réinitialiser l'option à sa valeur par défaut.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Gérer la configuration options.ini à partir de Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuration ne peut pas utiliser les mentions du canal et de "
 "l'utilisateur en même temps."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 "*Toutes les options de configuration sont présentes et comptabilisées !*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "Aucune option de configuration ne semble être modifiée."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1648,7 +1629,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1664,14 +1645,14 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 "Les options de configuration ont été rechargées à partir du fichier avec "
 "succès !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1681,7 +1662,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1690,18 +1671,18 @@ msgstr ""
 "Veuillez fournir un nom de section et d'option valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'option donnée est ambiguë, veuillez fournir un nom de section."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Vous devez fournir un nom de section et un nom d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1711,26 +1692,26 @@ msgstr ""
 "Les sections disponibles sont :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'option `%(option)s` n'est pas disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Cette option ne peut être définie qu'en modifiant le fichier de "
 "configuration."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Par défaut, cette option est réglée à : %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1744,7 +1725,7 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
@@ -1752,19 +1733,19 @@ msgstr ""
 "disque."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossible d'enregistrer l'option : `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Option enregistrée avec succès: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -1772,7 +1753,7 @@ msgstr ""
 "affichée."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1784,7 +1765,7 @@ msgstr ""
 "Valeur du fichier INI : `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1792,20 +1773,20 @@ msgstr ""
 "paramètre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Vous devez fournir une section, une option et une valeur pour cette sous-"
 "commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'option `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1815,7 +1796,7 @@ msgstr ""
 "Pour sauvegarder le changement, utilisez `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1823,13 +1804,13 @@ msgstr ""
 " valeur par défaut."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'option `%(option)s` n'a pas été réinitialisée par défaut!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1839,18 +1820,18 @@ msgstr ""
 "Pour sauvegarder le changement, utilisez `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Commande obsolète, utilisez la commande config à la place."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "La commande d'option est obsolète, utilisez la commande config à la place."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1859,34 +1840,34 @@ msgstr ""
 "L'utilisation de l'option de mise à jour analysera le cache à la recherche de modifications externes avant d'afficher les détails."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Option non valide spécifiée, utilisez: info, mise à jour ou effacement"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Activé"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s jours"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Illimité"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1902,23 +1883,23 @@ msgstr ""
 "**Mise en cache Maintenant :  %(used)s dans %(files)s fichier(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "Le cache a été effacé."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Échec** pour supprimer la cache, vérifiez les logs pour plus d'infos..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "Aucune cache trouvée à effacer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1927,12 +1908,12 @@ msgstr ""
 "Le numéro de page facultatif affiche les entrées ultérieures dans la file d'attente.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "L'argument de la page de file d'attente doit être un nombre entier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1942,12 +1923,12 @@ msgstr ""
 "Il y a **%(total)s** pages."
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(durée inconnue)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1959,7 +1940,7 @@ msgstr ""
 "Progression : `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1973,12 +1954,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Chansons en file d'attente"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1987,7 +1968,7 @@ msgstr ""
 "Si le problème persiste, remplissez un rapport de bogue."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1998,39 +1979,39 @@ msgstr ""
 "Cette commande peut être lente si de plus grandes plages sont données.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Paramètre invalide. Veuillez fournir un nombre de messages à rechercher."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossible d'utiliser la purge sur un canal DM privé."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Messagerie %(number)s nettoyée."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Le bot n'a pas la permission de gérer les messages."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Supprime les URLs individuelles d'une playlist dans un fichier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "L'URL donnée n'est pas une URL valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2040,18 +2021,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Cela ne semble pas être une playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Voici le dump de la playlist pour :  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2060,19 +2041,19 @@ msgstr ""
 "Cette commande est obsolète en faveur du mode développeur dans les clients Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Votre ID d'utilisateur est `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "L'ID de l'utilisateur pour `%(username)s` est `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2083,18 +2064,18 @@ msgstr ""
 "Cette commande est dépréciée en faveur de l'utilisation du mode développeur dans les clients Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Catégories valides : %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Voici les identifiants que vous avez demandés :"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
@@ -2102,7 +2083,7 @@ msgstr ""
 "mentionné."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2111,12 +2092,12 @@ msgstr ""
 "l'ID et réessayer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossible de déterminer l'utilisateur de la discord. Réessayez."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2130,7 +2111,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2144,67 +2125,67 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 "    Afficher les groupes chargés et les options de permission de liste.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Recharge les permissions depuis le fichier permissions.ini\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    Ajouter un nouveau groupe par défaut.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Supprimer le groupe existant.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Afficher le texte d'aide pour l'option de permission.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 "    Afficher la valeur de la permission pour un groupe donné et une "
 "autorisation.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Enregistrer le groupe de permissions dans un fichier.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Définir la valeur de permission pour le groupe.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Gérer la configuration permissions.ini depuis le discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Les permissions ne peuvent pas utiliser les mentions de salon et "
 "d'utilisateurs en même temps."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "Permissions rechargées depuis le fichier avec succès !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2214,7 +2195,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2228,26 +2209,26 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Vous devez fournir un nom de groupe ou d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Vous devez fournir un groupe, une option et une valeur à définir pour cette "
 "commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 "La sous-commande %(option)s nécessite un nom de groupe et de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2257,26 +2238,26 @@ msgstr ""
 "Les groupes disponibles sont:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "La permission `%(option)s` n'est pas disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Cette permission ne peut être définie qu'en modifiant le fichier de "
 "permissions."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Par défaut, cette permission est définie à : `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2290,13 +2271,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossible d'ajouter le groupe `%(group)s` il existe déjà."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2308,12 +2289,12 @@ msgstr ""
 "Assurez-vous de sauvegarder le nouveau groupe avec: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Impossible de supprimer le groupe intégré."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2323,24 +2304,24 @@ msgstr ""
 "Assurez-vous de sauvegarder ce changement avec: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Le groupe propriétaire n'est pas modifiable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossible d'enregistrer le groupe: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Le groupe a été enregistré avec succès : `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2352,13 +2333,13 @@ msgstr ""
 "Valeur du fichier INI : `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2368,7 +2349,7 @@ msgstr ""
 "Pour enregistrer le changement, utilisez `setperms enregistrer %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2377,7 +2358,7 @@ msgstr ""
 "Note: L'API peut limiter les changements de nom à deux fois par heure."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2386,7 +2367,7 @@ msgstr ""
 "Rappelez-vous que les changements de nom sont limités à deux fois par heure.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2396,23 +2377,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Le nom d'utilisateur du bot a été défini à `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Changez le surnom du MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Impossible de changer le pseudo : pas de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2422,23 +2403,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Pseudo du bot défini à `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Définissez un préfixe de commande par serveur."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Effacer le préfixe de commande par serveur."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2447,25 +2428,25 @@ msgstr ""
 "L'option EnablePrefixPerGuild doit d'abord être activée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Les émojis personnalisés doivent provenir de ce serveur pour être utilisés "
 "comme préfixes."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Le préfixe de commande du serveur est effacé."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Le préfixe de commande du serveur est maintenant :  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2474,39 +2455,39 @@ msgstr ""
 "Utilisez la commande de configuration pour mettre à jour le préfixe à la place."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Afficher les codes de langue disponibles à utiliser.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    Définissez la langue souhaitée pour ce serveur.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Réinitialiser la langue du serveur à la langue par défaut du bot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "Gérer la langue utilisée pour les messages dans le serveur appelant."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Cette commande ne peut être utilisée que dans les guildes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sous-commande invalide. Utilisez la commande d'aide pour plus "
 "d'informations."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2520,26 +2501,26 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 "Impossible de définir la langue à `%(locale)s` il n'est pas disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "La langue de ce serveur est maintenant définie à : `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "La langue de ce serveur a été réinitialisée à : `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2548,12 +2529,12 @@ msgstr ""
 "Attacher un fichier et omettre le paramètre url fonctionne aussi.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Vous devez fournir une URL ou joindre un fichier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2563,41 +2544,41 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "L'avatar du bot a été modifié."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Forcer MusicBot à se déconnecter du serveur discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Déconnecté du serveur `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Déconnecté un client vocal sans joueur ? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Pas actuellement connecté au serveur `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Tentative de rechargement sans redémarrage du processus. L'option par "
 "défaut.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
@@ -2605,21 +2586,21 @@ msgstr ""
 "tout.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Redémarrage complet, mais essayer de mettre à jour les paquets pip avant"
 " de redémarrer.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Redémarrage complet, mais mettez à jour le code source de MusicBot avec "
 "git d'abord.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2628,7 +2609,7 @@ msgstr ""
 "avant de redémarrer complètement.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2641,26 +2622,26 @@ msgstr ""
 "Si vous disposez d'un gestionnaire de services, nous vous recommandons de l'utiliser à la place de cette commande pour les redémarrages.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Option non valide, utilisez une de : soft, full, upgrade, uppip ou upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Redémarrage de l'instance actuelle..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Le processus de redémarrage du bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2669,7 +2650,7 @@ msgstr ""
 "redémarrer le bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
@@ -2677,25 +2658,25 @@ msgstr ""
 "redémarrer le bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 "%(emoji)s Je vais essayer de tout mettre à niveau et de redémarrer le bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 "Déconnectez de tous les canaux vocaux et fermez le processus MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Laissez le serveur discord donné par le nom ou l'ID du serveur."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2704,30 +2685,30 @@ msgstr ""
 "Les noms sont sensibles à la casse, donc l'utilisation d'un numéro d'identification est plus fiable.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Vous devez fournir un ID ou un nom."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Aucune guilde n'a été trouvée avec l'ID ou le nom `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Inconnu"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "A quitté la guilde : `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2736,38 +2717,38 @@ msgstr ""
 "Peut être utilisé pour identifier manuellement les événements dans le fichier journal MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Point d’arrêt connecté avec ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Voir les types les plus courants signalés par objgraphe.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Voir la sortie objgraph.show_growth() limitée.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Voir les types les plus courants d'objets fuites.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Voir les typestats des objets fuites.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Évaluer la fonction donnée et les arguments sur objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2778,12 +2759,12 @@ msgstr ""
 "Étant donné que cette méthode évalue du code arbitraire, elle est considérée comme dangereuse comme la commande debug.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossible d'importer `objgraph`, est-il installé ?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2808,7 +2789,7 @@ msgstr ""
 "Le danger de cette commande ne peut être sous-estimé. Ne l'utilisez pas et ne lui donnez pas accès si vous ne comprenez pas les risques !\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2824,7 +2805,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2833,24 +2814,24 @@ msgstr ""
 "La sortie est utilisée pour mettre à jour les pages GitHub et n'est donc pas appropriée pour une utilisation normale de référence."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "La sous-commande doit être une des : %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Fait des fichiers INI par défaut."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 "Le fichier INI demandé a été enregistré sur le disque. Allez le vérifier"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2859,53 +2840,53 @@ msgstr ""
 "ou des dépendances.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Impossible de localiser l'exécutable git."
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Aucune mise à jour dans la branche `%(branch)s` distante."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 "De nouveaux commits sont disponibles dans la branche distante `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ""
 "Erreur lors de la vérification, voir les journaux pour plus de détails."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Mise à jour pour `%(name)s` vers la version : `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "Aucune mise à jour pour les dépendances trouvées."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 "Il y a des mises à jour pour MusicBot disponibles pour téléchargement."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot est totalement à jour!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2926,20 +2907,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Affiche le temps de disponibilité de MusicBot, ou le temps écoulé depuis le "
 "dernier démarrage / redémarrage."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s a été en ligne pour `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2947,12 +2928,12 @@ msgstr ""
 "vocaux connectés."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "Aucun client vocal connecté.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 "Afficher la latence de l'API et la latence vocale si MusicBot est connecté."
@@ -2960,23 +2941,23 @@ msgstr ""
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "Automatique"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Latence de l'API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Affiche le numéro de version de MusicBot dans le chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2986,19 +2967,19 @@ msgstr ""
 "Version actuelle : `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 "    Mettre à jour le fichier cookies.txt en utilisant une pièce jointe de "
 "cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Activer ou désactiver le fichier cookies.txt sans le supprimer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -3023,30 +3004,30 @@ msgstr ""
 "  fonctionnalité si vous ne savez pas comment éviter les risques."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies déjà activés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Les cookies doivent être téléchargés pour être activés. (Fichier de cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 "Impossible d'activer les cookies en raison d'une erreur :  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Les cookies ont été activés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -3056,12 +3037,12 @@ msgstr ""
 "Cookies temporairement désactivés et seront réactivés au prochain redémarrage."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Les cookies ont été désactivés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -3069,7 +3050,7 @@ msgstr ""
 "téléchargeant un fichier de cookies."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
@@ -3077,23 +3058,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossible d'enregistrer les cookies sur le disque :  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies téléchargés et activés."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "Vous ne pouvez pas utiliser ce bot dans des messages privés."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
@@ -3101,23 +3082,23 @@ msgstr ""
 "%(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Cette commande nécessite d'être dans un canal vocal."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Commande:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Erreur d'exception"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3127,17 +3108,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "Aucune description donnée.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "Aucune utilisation donnée."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3151,13 +3132,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Quitter le salon vocal %(channel)s en raison de l'inactivité."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3796,14 +3777,14 @@ msgstr ""
 "Laisser blank to use default, dynamically generated UA strings."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Activer/désactiver la fonctionnalité de la liste des utilisateurs, sans "
 "vider la liste des blocs."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3811,14 +3792,14 @@ msgstr ""
 "d'utilisateur Discord, un par ligne."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Activer la fonctionnalité de liste de chansons bloquées, sans vider la liste"
 " de blocs."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3827,7 +3808,7 @@ msgstr ""
 "Tout titre de chanson ou URL contenant une ligne de la liste sera bloqué."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3836,7 +3817,7 @@ msgstr ""
 "Chaque fichier doit contenir une liste d'URL ou de termes lisibles, une piste par ligne."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3850,7 +3831,7 @@ msgstr ""
 "Correspond à : %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3859,7 +3840,7 @@ msgstr ""
 "court pour la lecture."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3871,7 +3852,7 @@ msgstr ""
 "Réglez sur 0 pour désactiver. Le nombre maximal autorisé est %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3884,7 +3865,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3914,7 +3895,7 @@ msgstr ""
 "  Utilisez les options d'exemple comme modèle ou copiez-les à partir du référentiel."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3933,7 +3914,7 @@ msgstr ""
 "  Assurez-vous que le chemin que vous avez configuré est un chemin vers un dossier / répertoire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3955,7 +3936,7 @@ msgstr ""
 "  Double vérifier que la configuration est valide, chemin d'accès au répertoire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3975,7 +3956,7 @@ msgstr ""
 "  Définissez l'option de configuration du jeton ou définissez la variable d'environnement %(env_var)s avec un jeton d'application."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3996,7 +3977,7 @@ msgstr ""
 "  Définissez manuellement l'option de configuration « OwnerID » ou réessayez plus tard."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4015,7 +3996,7 @@ msgstr ""
 "  N'utilisez pas le Bot ou l'ID de l'application dans le champ 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -4037,7 +4018,7 @@ msgstr ""
 "  Vérifiez que le dossier de configuration et les fichiers existent et peuvent être lus par MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -4061,7 +4042,7 @@ msgstr ""
 "  Copiez le fichier d'exemple du dépôt si tout le reste échoue."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4081,7 +4062,7 @@ msgstr ""
 "  Définissez %(option)s sur un ID numérique ou mettez-le à `auto` ou `0` pour relier automatiquement le propriétaire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4101,7 +4082,7 @@ msgstr ""
 "  Vérifiez le paramétrage du chemin et assurez-vous que le fichier existe et est accessible à MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4121,34 +4102,34 @@ msgstr ""
 "  S'assurer que tous les identifiants sont numériques, et séparés uniquement par des espaces ou des virgules."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD ne semble pas avoir d'en-têtes..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 "L'extraction des informations de la chanson n'a renvoyé aucune donnée."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "Impossible de poursuivre l'extraction, la boucle d'événement est fermée."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "L'URL Spotify n'est pas valide ou n'est pas prise en charge."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Impossible de diffuser une URL non valide."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Le fichier média local est introuvable."
 
@@ -4175,7 +4156,7 @@ msgstr ""
 "Le téléchargement a échoué à cause d'une erreur yt-dlp : %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
@@ -4183,7 +4164,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Impossible d'extraire les données pour les médias demandés."
 
@@ -4369,28 +4350,28 @@ msgstr ""
 "L'extracteur yt-dlp `%(extractor)s` n'est pas autorisé dans votre groupe."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Impossible d'extraire les informations"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Ceci est une liste de lecture."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Type de contenu invalide `%(type)s` pour l'URL : %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "aucune donnée de durée"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "aucune donnée de durée dans l'entrée actuelle"
 
@@ -4475,21 +4456,21 @@ msgid "Only dev users can use this command."
 msgstr "Seuls les utilisateurs de dev peuvent utiliser cette commande."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4497,13 +4478,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -4515,22 +4496,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4558,61 +4539,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4620,7 +4601,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4630,7 +4611,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4654,40 +4635,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4695,13 +4669,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4720,7 +4694,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4729,7 +4703,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4760,28 +4734,123 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "La recherche YouTube n'a retourné aucun résultat pour :  %(url)s"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+#~ "Supprimez une chanson de la file d'attente, éventuellement à la position de la file d'attente donnée.\n"
+#~ "Si la position est omise, la chanson à la fin de la file d'attente est supprimée.\n"
+#~ "Utilisez la commande queue pour trouver le numéro de position de votre piste.\n"
+#~ "Cependant, les positions de toutes les chansons sont modifiées lorsqu'une nouvelle chanson commence à jouer.\n"
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/fr_FR/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/fr_FR/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -833,7 +833,7 @@ msgstr ""
 " lecture."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Les positions de la chanson doivent être des entiers !"
 
@@ -871,30 +871,30 @@ msgid "Local media playback is not enabled."
 msgstr "La lecture des médias locaux n'est pas activée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "L'URL Spotify n'est pas valide ou n'est pas prise en charge actuellement."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Une URL Spotify a été détectée, mais Spotify n'est pas activé."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Vous avez atteint votre limite de chansons en attente (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 "Le mode Karaoké est activé, veuillez réessayer quand il est désactivé!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -904,13 +904,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Cette vidéo ne peut pas être lue. Essayez d'utiliser la commande stream."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -919,7 +919,7 @@ msgstr ""
 " durée maximale (%(max)s secondes)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -929,13 +929,13 @@ msgstr ""
 "Position dans la file d'attente : %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "La durée de la musique dépasse la limite (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -945,24 +945,24 @@ msgstr ""
 "Position dans la file d'attente : %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "Joue ensuite!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - Temps estimé avant de jouer : `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - impossible d'estimer le temps avant de jouer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -975,25 +975,25 @@ msgstr ""
 "Remarque : FFmpeg peut abandonner le flux de manière aléatoire ou en cas d'instabilité de la connexion.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "La diffusion de listes de lecture n'est pas encore prise en charge."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "Streaming en continu `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 "    Recherche avec service pour un certain nombre de résultats avec la "
 "requête de recherche.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -1002,13 +1002,13 @@ msgstr ""
 "    Note: les guillemets doubles sont requis dans ce cas.\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Vous avez atteint la limite d'élément de votre playlist (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -1016,46 +1016,46 @@ msgstr ""
 "plus d'informations."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Vous ne pouvez pas rechercher plus de vidéos %(max)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Recherche de vidéos..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "La recherche a échoué en raison d'une erreur : %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "Aucune vidéo trouvée."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "Pour sélectionner une chanson, tapez le numéro correspondant."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Résultats de la recherche à partir de %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** | %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1064,201 +1064,201 @@ msgstr ""
 "**0**. Annuler"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Choisir une chanson"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Ajout de la chanson [%(track)s](%(url)s) à la file d'attente."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Résultat %(number)s de %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "D'accord, venez tout droit !"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Afficher des informations sur ce qui est en train de jouer."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "En cours de lecture"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Actuellement en streaming:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "En cours de lecture :"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Ajouté par:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Progression :"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Il n'y a pas de chansons en attente ! Mettre en file d'attente quelque chose"
 " avec une commande de lecture."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Dites à MusicBot de rejoindre la chaîne dans laquelle vous êtes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 "Vous n'êtes pas connecté à la voix. Essayez de rejoindre un salon vocal !"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Connecté à `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 "Permet à MusicBot de suivre un utilisateur lorsqu'il change de canal sur un "
 "serveur.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "Plus utilisateur suivant `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Maintenant, l'utilisateur suivant `%(user)s` entre les salons vocaux."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 "MusicBot ne peut pas suivre un utilisateur qui n'est pas membre du serveur."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "Suivra l'utilisateur `%(user)s` entre les salons vocaux."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Mettre en pause la lecture si une piste est en cours de lecture."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Musique en pause dans `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Le joueur ne joue pas."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "Reprend la lecture si le lecteur a été mis en pause précédemment."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Reprise de la musique dans `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Reprise de la file d'attente musicale"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Le lecteur n'est pas mis en pause."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Mélanger toutes les pistes en cours dans la file d'attente."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Mélange toutes les chansons dans la file d'attente."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Supprime toutes les chansons actuellement dans la file d'attente."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Toutes les chansons de la file d'attente ont été supprimées."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Rien dans la file d'attente à supprimer !"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Supprimé `%(track)s` ajouté par `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 "Rien n'a été trouvé dans la file d'attente de l'utilisateur `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1267,26 +1267,26 @@ msgstr ""
 "Vous devez être celui qui l'a mis en file d'attente ou qui a des permissions de sauter instantanément."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numéro d'entrée invalide. Utilisez la commande file d'attente pour trouver "
 "les positions de la file d'attente."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Entrée supprimée `%(track)s` ajoutée par `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Entrée retirée `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1297,12 +1297,12 @@ msgstr ""
 "Si l'option LegacySkip est activée, le paramètre force peut être ignoré.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossible de sauter ! Le joueur ne joue pas !"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
@@ -1310,12 +1310,12 @@ msgstr ""
 "patienter."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "La prochaine chanson sera jouée sous peu. Veuillez patienter."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1324,7 +1324,7 @@ msgstr ""
 "Vous pouvez redémarrer le bot s'il ne commence pas à fonctionner."
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1333,29 +1333,29 @@ msgstr ""
 "Vous pouvez redémarrer le bot si cela ne fonctionne pas."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "Vous n'avez pas la permission de forcer le saut d'une chanson en boucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Force ignorée `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Vous n'avez pas la permission de forcer le saut."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Vous n'avez pas la permission de sauter une chanson en boucle."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1365,12 +1365,12 @@ msgstr ""
 "Le vote à passer a été passé.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " Prochaine chanson à venir !"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1380,7 +1380,7 @@ msgstr ""
 "Besoin de **%(votes)s** plus de votes pour sauter cette chanson."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1391,25 +1391,25 @@ msgstr ""
 "Le réglage de volume est conservé jusqu'à ce que MusicBot soit redémarré.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Volume actuel : `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` n'est pas un nombre valide"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Volume mis à jour de **%(old)d** à **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1419,7 +1419,7 @@ msgstr ""
 "Le volume ne peut être défini que de 1 à 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1428,7 +1428,7 @@ msgstr ""
 "entre 1 et 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1439,7 +1439,7 @@ msgstr ""
 "La lecture en continu ne prend pas en charge les réglages de vitesse.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1448,36 +1448,36 @@ msgstr ""
 "Utilisez la commande de configuration pour définir une vitesse de lecture par défaut."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "La vitesse ne peut pas être appliquée aux médias streamés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Vous devez fournir une vitesse à définir."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La vitesse que vous avez fournie n'est pas valide. Utilisez un nombre entre "
 "0,5 et 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Réglage de la vitesse de lecture à `%(speed).3f` pour la piste actuelle."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Ajouter un nouvel alias avec des arguments optionnels.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1486,23 +1486,23 @@ msgstr ""
 "la commande d'aide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Option invalide pour la commande : `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Alias rechargé depuis le fichier de configuration."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Alias enregistrés dans le fichier de configuration."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1512,43 +1512,43 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Vous devez fournir un alias et une commande à alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 "Nouvel alias ajouté. `%(alias)s` est maintenant un alias de `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Vous devez fournir un nom d'alias à supprimer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` n'existe pas."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` a été supprimé."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Affiche le texte d'aide à propos de toutes les options de configuration "
 "manquantes.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1557,32 +1557,32 @@ msgstr ""
 " fichier de configuration.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr "    Liste les options de configuration disponibles et leurs sections.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Recharger le fichier options.ini à partir du disque.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Affiche le texte d'aide pour une option spécifique.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Affiche la valeur actuelle de l'option.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Enregistre la valeur actuelle dans le fichier d'options.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1591,35 +1591,35 @@ msgstr ""
 "pour le fichier.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Réinitialiser l'option à sa valeur par défaut.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Gérer la configuration options.ini à partir de Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configuration ne peut pas utiliser les mentions du canal et de "
 "l'utilisateur en même temps."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 "*Toutes les options de configuration sont présentes et comptabilisées !*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "Aucune option de configuration ne semble être modifiée."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1629,7 +1629,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1645,14 +1645,14 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 "Les options de configuration ont été rechargées à partir du fichier avec "
 "succès !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1662,7 +1662,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1671,18 +1671,18 @@ msgstr ""
 "Veuillez fournir un nom de section et d'option valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'option donnée est ambiguë, veuillez fournir un nom de section."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Vous devez fournir un nom de section et un nom d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1692,26 +1692,26 @@ msgstr ""
 "Les sections disponibles sont :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'option `%(option)s` n'est pas disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Cette option ne peut être définie qu'en modifiant le fichier de "
 "configuration."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Par défaut, cette option est réglée à : %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1725,7 +1725,7 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
@@ -1733,19 +1733,19 @@ msgstr ""
 "disque."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossible d'enregistrer l'option : `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Option enregistrée avec succès: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -1753,7 +1753,7 @@ msgstr ""
 "affichée."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1765,7 +1765,7 @@ msgstr ""
 "Valeur du fichier INI : `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1773,20 +1773,20 @@ msgstr ""
 "paramètre."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Vous devez fournir une section, une option et une valeur pour cette sous-"
 "commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'option `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1796,7 +1796,7 @@ msgstr ""
 "Pour sauvegarder le changement, utilisez `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1804,13 +1804,13 @@ msgstr ""
 " valeur par défaut."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'option `%(option)s` n'a pas été réinitialisée par défaut!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1820,18 +1820,18 @@ msgstr ""
 "Pour sauvegarder le changement, utilisez `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Commande obsolète, utilisez la commande config à la place."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "La commande d'option est obsolète, utilisez la commande config à la place."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1840,34 +1840,34 @@ msgstr ""
 "L'utilisation de l'option de mise à jour analysera le cache à la recherche de modifications externes avant d'afficher les détails."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Option non valide spécifiée, utilisez: info, mise à jour ou effacement"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Désactivé"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Activé"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s jours"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Illimité"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1883,23 +1883,23 @@ msgstr ""
 "**Mise en cache Maintenant :  %(used)s dans %(files)s fichier(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "Le cache a été effacé."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Échec** pour supprimer la cache, vérifiez les logs pour plus d'infos..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "Aucune cache trouvée à effacer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1908,12 +1908,12 @@ msgstr ""
 "Le numéro de page facultatif affiche les entrées ultérieures dans la file d'attente.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "L'argument de la page de file d'attente doit être un nombre entier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1923,12 +1923,12 @@ msgstr ""
 "Il y a **%(total)s** pages."
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(durée inconnue)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1940,7 +1940,7 @@ msgstr ""
 "Progression : `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1954,12 +1954,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Chansons en file d'attente"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1968,7 +1968,7 @@ msgstr ""
 "Si le problème persiste, remplissez un rapport de bogue."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1979,39 +1979,39 @@ msgstr ""
 "Cette commande peut être lente si de plus grandes plages sont données.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Paramètre invalide. Veuillez fournir un nombre de messages à rechercher."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossible d'utiliser la purge sur un canal DM privé."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Messagerie %(number)s nettoyée."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Le bot n'a pas la permission de gérer les messages."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Supprime les URLs individuelles d'une playlist dans un fichier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "L'URL donnée n'est pas une URL valide."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2021,18 +2021,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Cela ne semble pas être une playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Voici le dump de la playlist pour :  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2041,19 +2041,19 @@ msgstr ""
 "Cette commande est obsolète en faveur du mode développeur dans les clients Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Votre ID d'utilisateur est `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "L'ID de l'utilisateur pour `%(username)s` est `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2064,18 +2064,18 @@ msgstr ""
 "Cette commande est dépréciée en faveur de l'utilisation du mode développeur dans les clients Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Catégories valides : %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Voici les identifiants que vous avez demandés :"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
@@ -2083,7 +2083,7 @@ msgstr ""
 "mentionné."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2092,12 +2092,12 @@ msgstr ""
 "l'ID et réessayer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossible de déterminer l'utilisateur de la discord. Réessayez."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2111,7 +2111,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2125,67 +2125,67 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 "    Afficher les groupes chargés et les options de permission de liste.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Recharge les permissions depuis le fichier permissions.ini\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    Ajouter un nouveau groupe par défaut.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Supprimer le groupe existant.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Afficher le texte d'aide pour l'option de permission.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 "    Afficher la valeur de la permission pour un groupe donné et une "
 "autorisation.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Enregistrer le groupe de permissions dans un fichier.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Définir la valeur de permission pour le groupe.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Gérer la configuration permissions.ini depuis le discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Les permissions ne peuvent pas utiliser les mentions de salon et "
 "d'utilisateurs en même temps."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "Permissions rechargées depuis le fichier avec succès !"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2195,7 +2195,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2209,26 +2209,26 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Vous devez fournir un nom de groupe ou d'option pour cette commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Vous devez fournir un groupe, une option et une valeur à définir pour cette "
 "commande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 "La sous-commande %(option)s nécessite un nom de groupe et de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2238,26 +2238,26 @@ msgstr ""
 "Les groupes disponibles sont:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "La permission `%(option)s` n'est pas disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Cette permission ne peut être définie qu'en modifiant le fichier de "
 "permissions."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Par défaut, cette permission est définie à : `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2271,13 +2271,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossible d'ajouter le groupe `%(group)s` il existe déjà."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2289,12 +2289,12 @@ msgstr ""
 "Assurez-vous de sauvegarder le nouveau groupe avec: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Impossible de supprimer le groupe intégré."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2304,24 +2304,24 @@ msgstr ""
 "Assurez-vous de sauvegarder ce changement avec: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Le groupe propriétaire n'est pas modifiable."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossible d'enregistrer le groupe: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Le groupe a été enregistré avec succès : `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2333,13 +2333,13 @@ msgstr ""
 "Valeur du fichier INI : `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Permission `%(option)s` n'a pas été mise à jour !"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2349,7 +2349,7 @@ msgstr ""
 "Pour enregistrer le changement, utilisez `setperms enregistrer %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2358,7 +2358,7 @@ msgstr ""
 "Note: L'API peut limiter les changements de nom à deux fois par heure."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2367,7 +2367,7 @@ msgstr ""
 "Rappelez-vous que les changements de nom sont limités à deux fois par heure.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2377,23 +2377,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Le nom d'utilisateur du bot a été défini à `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Changez le surnom du MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Impossible de changer le pseudo : pas de permission."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2403,23 +2403,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Pseudo du bot défini à `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Définissez un préfixe de commande par serveur."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Effacer le préfixe de commande par serveur."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2428,25 +2428,25 @@ msgstr ""
 "L'option EnablePrefixPerGuild doit d'abord être activée."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Les émojis personnalisés doivent provenir de ce serveur pour être utilisés "
 "comme préfixes."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Le préfixe de commande du serveur est effacé."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Le préfixe de commande du serveur est maintenant :  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2455,39 +2455,39 @@ msgstr ""
 "Utilisez la commande de configuration pour mettre à jour le préfixe à la place."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Afficher les codes de langue disponibles à utiliser.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    Définissez la langue souhaitée pour ce serveur.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Réinitialiser la langue du serveur à la langue par défaut du bot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "Gérer la langue utilisée pour les messages dans le serveur appelant."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Cette commande ne peut être utilisée que dans les guildes."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sous-commande invalide. Utilisez la commande d'aide pour plus "
 "d'informations."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2501,26 +2501,26 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 "Impossible de définir la langue à `%(locale)s` il n'est pas disponible."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "La langue de ce serveur est maintenant définie à : `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "La langue de ce serveur a été réinitialisée à : `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2529,12 +2529,12 @@ msgstr ""
 "Attacher un fichier et omettre le paramètre url fonctionne aussi.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Vous devez fournir une URL ou joindre un fichier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2544,41 +2544,41 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "L'avatar du bot a été modifié."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Forcer MusicBot à se déconnecter du serveur discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Déconnecté du serveur `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Déconnecté un client vocal sans joueur ? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Pas actuellement connecté au serveur `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Tentative de rechargement sans redémarrage du processus. L'option par "
 "défaut.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
@@ -2586,21 +2586,21 @@ msgstr ""
 "tout.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Redémarrage complet, mais essayer de mettre à jour les paquets pip avant"
 " de redémarrer.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Redémarrage complet, mais mettez à jour le code source de MusicBot avec "
 "git d'abord.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2609,7 +2609,7 @@ msgstr ""
 "avant de redémarrer complètement.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2622,26 +2622,26 @@ msgstr ""
 "Si vous disposez d'un gestionnaire de services, nous vous recommandons de l'utiliser à la place de cette commande pour les redémarrages.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Option non valide, utilisez une de : soft, full, upgrade, uppip ou upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Redémarrage de l'instance actuelle..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Le processus de redémarrage du bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2650,7 +2650,7 @@ msgstr ""
 "redémarrer le bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
@@ -2658,25 +2658,25 @@ msgstr ""
 "redémarrer le bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 "%(emoji)s Je vais essayer de tout mettre à niveau et de redémarrer le bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 "Déconnectez de tous les canaux vocaux et fermez le processus MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Laissez le serveur discord donné par le nom ou l'ID du serveur."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2685,12 +2685,12 @@ msgstr ""
 "Les noms sont sensibles à la casse, donc l'utilisation d'un numéro d'identification est plus fiable.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Vous devez fournir un ID ou un nom."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Aucune guilde n'a été trouvée avec l'ID ou le nom `%(input)s`"
@@ -2702,13 +2702,13 @@ msgid "Unknown"
 msgstr "Inconnu"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "A quitté la guilde : `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2717,38 +2717,38 @@ msgstr ""
 "Peut être utilisé pour identifier manuellement les événements dans le fichier journal MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Point d’arrêt connecté avec ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Voir les types les plus courants signalés par objgraphe.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Voir la sortie objgraph.show_growth() limitée.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Voir les types les plus courants d'objets fuites.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Voir les typestats des objets fuites.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Évaluer la fonction donnée et les arguments sur objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2759,12 +2759,12 @@ msgstr ""
 "Étant donné que cette méthode évalue du code arbitraire, elle est considérée comme dangereuse comme la commande debug.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossible d'importer `objgraph`, est-il installé ?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2789,7 +2789,7 @@ msgstr ""
 "Le danger de cette commande ne peut être sous-estimé. Ne l'utilisez pas et ne lui donnez pas accès si vous ne comprenez pas les risques !\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2805,7 +2805,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2814,24 +2814,24 @@ msgstr ""
 "La sortie est utilisée pour mettre à jour les pages GitHub et n'est donc pas appropriée pour une utilisation normale de référence."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "La sous-commande doit être une des : %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Fait des fichiers INI par défaut."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 "Le fichier INI demandé a été enregistré sur le disque. Allez le vérifier"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2840,53 +2840,53 @@ msgstr ""
 "ou des dépendances.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Impossible de localiser l'exécutable git."
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Aucune mise à jour dans la branche `%(branch)s` distante."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 "De nouveaux commits sont disponibles dans la branche distante `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ""
 "Erreur lors de la vérification, voir les journaux pour plus de détails."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Mise à jour pour `%(name)s` vers la version : `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "Aucune mise à jour pour les dépendances trouvées."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 "Il y a des mises à jour pour MusicBot disponibles pour téléchargement."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot est totalement à jour!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2907,20 +2907,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Affiche le temps de disponibilité de MusicBot, ou le temps écoulé depuis le "
 "dernier démarrage / redémarrage."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s a été en ligne pour `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2928,12 +2928,12 @@ msgstr ""
 "vocaux connectés."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "Aucun client vocal connecté.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 "Afficher la latence de l'API et la latence vocale si MusicBot est connecté."
@@ -2941,23 +2941,23 @@ msgstr ""
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "Automatique"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Latence de l'API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Affiche le numéro de version de MusicBot dans le chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2967,19 +2967,19 @@ msgstr ""
 "Version actuelle : `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 "    Mettre à jour le fichier cookies.txt en utilisant une pièce jointe de "
 "cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Activer ou désactiver le fichier cookies.txt sans le supprimer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -3004,30 +3004,30 @@ msgstr ""
 "  fonctionnalité si vous ne savez pas comment éviter les risques."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies déjà activés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Les cookies doivent être téléchargés pour être activés. (Fichier de cookies)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 "Impossible d'activer les cookies en raison d'une erreur :  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Les cookies ont été activés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -3037,12 +3037,12 @@ msgstr ""
 "Cookies temporairement désactivés et seront réactivés au prochain redémarrage."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Les cookies ont été désactivés."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -3050,7 +3050,7 @@ msgstr ""
 "téléchargeant un fichier de cookies."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
@@ -3058,23 +3058,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossible d'enregistrer les cookies sur le disque :  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies téléchargés et activés."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "Vous ne pouvez pas utiliser ce bot dans des messages privés."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
@@ -3082,23 +3082,23 @@ msgstr ""
 "%(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Cette commande nécessite d'être dans un canal vocal."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Commande:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Erreur d'exception"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3108,17 +3108,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "Aucune description donnée.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "Aucune utilisation donnée."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3132,13 +3132,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Quitter le salon vocal %(channel)s en raison de l'inactivité."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3262,7 +3262,7 @@ msgstr ""
 "Utilisé uniquement lorsque BindToChannels manque un ID pour un serveur."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3343,7 +3343,7 @@ msgstr ""
 "Vous pouvez définir ceci de 0 à 1, ou de 0 % à 100 %."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 "Permettre à MusicBot de garder les médias téléchargés, ou de les supprimer "
@@ -3351,7 +3351,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3361,7 +3361,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3370,7 +3370,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3385,7 +3385,7 @@ msgstr ""
 "Mentionnez l'utilisateur qui a ajouté la chanson quand elle est jouée."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3394,7 +3394,7 @@ msgstr ""
 " accessible au démarrage du bot."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3403,13 +3403,13 @@ msgstr ""
 "liste de lecture automatique lorsque la file d'attente est vide."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 "Mélange les pistes de la liste de lecture automatique avant de les lire."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3418,7 +3418,7 @@ msgstr ""
 "Cela s'applique uniquement à la chanson en cours de lecture si elle a été ajoutée par la liste de lecture automatique."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3477,7 +3477,7 @@ msgstr ""
 "Actuellement, cette option ne s'applique pas à la liste de lecture automatique ou aux chansons ajoutées à une file d'attente vide."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3506,7 +3506,7 @@ msgstr ""
 " {p0_url} = L'URL de la piste en cours de lecture."
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 "Si cette option est activée, les messages d'état signaleront les "
@@ -3515,7 +3515,7 @@ msgstr ""
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3554,7 +3554,7 @@ msgstr ""
 " q pour lister la file d'attente."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3563,7 +3563,7 @@ msgstr ""
 " liste de lecture automatique."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 "Afficher les paramètres de configuration de MusicBot dans les journaux au "
@@ -3580,7 +3580,7 @@ msgstr ""
 "vote et de forcer les sauts."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3612,14 +3612,14 @@ msgid "Completely remove the footer from embeds."
 msgstr "Retirer complètement le pied de page des embeds."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 "MusicBot sera automatiquement sourd quand il entrera dans un canal vocal."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3630,7 +3630,7 @@ msgstr ""
 "Les auditeurs sont des membres du canal, excluant les bots, qui ne sont pas assourdis."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3639,7 +3639,7 @@ msgstr ""
 "Vous pouvez définir ceci à un nombre de secondes ou une phrase comme : 4 heures"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3648,7 +3648,7 @@ msgstr ""
 "d'attente est vide."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3696,7 +3696,7 @@ msgstr ""
 "la lecture pour une chanson par membre."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3709,7 +3709,7 @@ msgstr ""
 "Par défaut, cette option est désactivée."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3721,7 +3721,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3749,7 +3749,7 @@ msgstr ""
 "commandes de lecture sont utilisées."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3760,7 +3760,7 @@ msgstr ""
 "Laisser vide pour désactiver."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3777,14 +3777,14 @@ msgstr ""
 "Laisser blank to use default, dynamically generated UA strings."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Activer/désactiver la fonctionnalité de la liste des utilisateurs, sans "
 "vider la liste des blocs."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3792,14 +3792,14 @@ msgstr ""
 "d'utilisateur Discord, un par ligne."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Activer la fonctionnalité de liste de chansons bloquées, sans vider la liste"
 " de blocs."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3808,7 +3808,7 @@ msgstr ""
 "Tout titre de chanson ou URL contenant une ligne de la liste sera bloqué."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3817,7 +3817,7 @@ msgstr ""
 "Chaque fichier doit contenir une liste d'URL ou de termes lisibles, une piste par ligne."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3831,7 +3831,7 @@ msgstr ""
 "Correspond à : %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3840,7 +3840,7 @@ msgstr ""
 "court pour la lecture."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3852,7 +3852,7 @@ msgstr ""
 "Réglez sur 0 pour désactiver. Le nombre maximal autorisé est %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3865,7 +3865,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3895,7 +3895,7 @@ msgstr ""
 "  Utilisez les options d'exemple comme modèle ou copiez-les à partir du référentiel."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3914,7 +3914,7 @@ msgstr ""
 "  Assurez-vous que le chemin que vous avez configuré est un chemin vers un dossier / répertoire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3936,7 +3936,7 @@ msgstr ""
 "  Double vérifier que la configuration est valide, chemin d'accès au répertoire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3956,7 +3956,7 @@ msgstr ""
 "  Définissez l'option de configuration du jeton ou définissez la variable d'environnement %(env_var)s avec un jeton d'application."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3977,7 +3977,7 @@ msgstr ""
 "  Définissez manuellement l'option de configuration « OwnerID » ou réessayez plus tard."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3996,7 +3996,7 @@ msgstr ""
 "  N'utilisez pas le Bot ou l'ID de l'application dans le champ 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -4018,7 +4018,7 @@ msgstr ""
 "  Vérifiez que le dossier de configuration et les fichiers existent et peuvent être lus par MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -4042,7 +4042,7 @@ msgstr ""
 "  Copiez le fichier d'exemple du dépôt si tout le reste échoue."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4062,7 +4062,7 @@ msgstr ""
 "  Définissez %(option)s sur un ID numérique ou mettez-le à `auto` ou `0` pour relier automatiquement le propriétaire."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4082,7 +4082,7 @@ msgstr ""
 "  Vérifiez le paramétrage du chemin et assurez-vous que le fichier existe et est accessible à MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4102,34 +4102,34 @@ msgstr ""
 "  S'assurer que tous les identifiants sont numériques, et séparés uniquement par des espaces ou des virgules."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD ne semble pas avoir d'en-têtes..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 "L'extraction des informations de la chanson n'a renvoyé aucune donnée."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 "Impossible de poursuivre l'extraction, la boucle d'événement est fermée."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "L'URL Spotify n'est pas valide ou n'est pas prise en charge."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Impossible de diffuser une URL non valide."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Le fichier média local est introuvable."
 
@@ -4490,28 +4490,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4539,7 +4539,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4593,7 +4593,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4601,7 +4601,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4611,7 +4611,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4680,7 +4680,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4694,7 +4694,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4703,7 +4703,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4717,7 +4717,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4725,7 +4725,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4734,26 +4734,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4765,28 +4765,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4797,25 +4797,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4824,7 +4824,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/hi_IN/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/hi_IN/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -129,7 +129,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr ""
 
@@ -146,61 +146,43 @@ msgid ""
 "Details: %s. Continuing anyway in 5 seconds..."
 msgstr ""
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr ""
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -210,7 +192,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -220,7 +202,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -230,35 +212,35 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -266,155 +248,155 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -422,65 +404,65 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -488,36 +470,36 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -525,7 +507,7 @@ msgid ""
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -533,364 +515,364 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -904,44 +886,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -949,80 +931,80 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1032,348 +1014,348 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1382,24 +1364,24 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1407,55 +1389,55 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1463,59 +1445,59 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1523,7 +1505,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -1623,56 +1605,56 @@ msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1680,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1718,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1747,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1772,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1870,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1910,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1949,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2004,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2017,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2042,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2108,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2163,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2347,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2448,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2456,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2475,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2494,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2513,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2528,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2551,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2576,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2591,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2651,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2664,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2677,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2685,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2693,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2701,120 +2683,120 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2822,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -2934,12 +2916,12 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 
@@ -2956,13 +2938,13 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr ""
@@ -2984,7 +2966,7 @@ msgid "Download already cached at:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -2999,50 +2981,50 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr ""
 
@@ -3084,60 +3066,60 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr ""
@@ -3206,7 +3188,7 @@ msgid "Cache level requires cleanup. %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -3482,104 +3464,104 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -4088,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4131,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4187,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4213,55 +4195,55 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr ""
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4279,117 +4261,111 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: noise
@@ -4417,19 +4393,19 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4437,34 +4413,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4478,7 +4454,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4496,12 +4472,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4514,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4526,7 +4502,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4535,31 +4511,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4583,7 +4559,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -4591,50 +4567,50 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
@@ -4680,13 +4656,13 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4764,13 +4740,13 @@ msgid "Deserialize returned an object that is not a MusicPlayer:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4826,45 +4802,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -4876,220 +4852,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5108,30 +5084,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5139,18 +5115,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5225,9 +5201,88 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/hi_IN/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/hi_IN/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -416,13 +416,13 @@ msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr ""
 
@@ -615,13 +615,13 @@ msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr ""
@@ -1455,7 +1455,7 @@ msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -1476,28 +1476,28 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1505,12 +1505,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1518,143 +1518,143 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1662,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1700,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1729,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1754,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1852,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1892,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1931,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1986,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1999,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2024,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2090,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2145,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2329,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2438,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2457,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2476,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2495,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2510,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2533,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2558,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2573,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2633,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2646,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2659,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2667,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2675,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2683,30 +2683,30 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
@@ -2764,39 +2764,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2804,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -3892,55 +3892,55 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr ""
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
 msgstr ""
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr ""
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr ""
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -3948,107 +3948,107 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr ""
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr ""
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
 msgstr ""
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr ""
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr ""
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
 msgstr ""
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
 msgstr ""
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4056,13 +4056,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4070,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4113,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4169,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4195,55 +4195,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr ""
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4261,7 +4249,7 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
@@ -4274,13 +4262,13 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
@@ -4364,48 +4352,48 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4413,34 +4401,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4454,7 +4442,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4472,12 +4460,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4490,7 +4478,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4502,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4511,31 +4499,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4794,7 +4782,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5025,24 +5013,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5089,25 +5077,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5115,66 +5103,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5201,7 +5143,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5213,25 +5155,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5244,29 +5186,143 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr ""
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/hi_IN/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/hi_IN/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -19,95 +19,95 @@ msgstr ""
 "X-Crowdin-Project-ID: 734017\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -116,12 +116,12 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -135,36 +135,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -173,7 +173,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -182,12 +182,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -195,7 +195,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -209,64 +209,64 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -274,24 +274,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -300,7 +300,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -319,18 +319,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -338,12 +338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -351,104 +351,104 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -456,35 +456,35 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -493,39 +493,39 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -534,33 +534,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -568,14 +568,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -583,84 +583,84 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -670,28 +670,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -860,7 +860,7 @@ msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
@@ -1002,58 +1002,49 @@ msgstr ""
 msgid "Cleared all songs from the queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1061,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1120,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1133,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1141,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1167,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1182,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1241,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1336,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1347,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1360,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1385,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1412,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1445,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1470,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1490,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1544,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1579,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1593,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1603,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1623,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1657,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1695,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1721,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1731,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1796,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1820,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1847,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1866,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1892,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1906,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1921,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1945,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2011,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2075,110 +2066,110 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2186,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2206,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2217,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2296,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2349,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2374,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2403,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2466,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2486,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2941,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2981,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2997,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3006,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3018,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3032,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3045,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3059,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3074,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3087,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3100,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3113,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3155,13 +3146,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
@@ -3287,22 +3278,22 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -3385,32 +3376,32 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -3418,19 +3409,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -3441,21 +3432,15 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
@@ -3472,50 +3457,50 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3523,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3532,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3579,42 +3564,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -3657,7 +3642,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3671,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3689,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3702,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3749,7 +3734,7 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
@@ -3762,61 +3747,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3824,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3834,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -3858,40 +3843,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -3899,13 +3877,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -3924,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3933,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3964,28 +3942,119 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/hi_IN/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/hi_IN/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -650,7 +650,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -675,23 +675,23 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,19 +699,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -719,13 +719,13 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -733,24 +733,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -759,292 +759,292 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1052,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1111,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1124,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1132,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1158,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1173,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1232,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1327,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1338,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1351,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1376,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1403,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1436,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1461,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1481,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1535,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1570,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1584,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1594,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1614,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1648,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1686,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1712,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1722,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1787,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1811,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1838,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1857,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1883,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1897,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1912,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1936,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2002,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2066,66 +2066,66 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
@@ -2137,39 +2137,39 @@ msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2177,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2197,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2208,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2287,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2340,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2365,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2394,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2457,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2477,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2575,7 +2575,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -2637,13 +2637,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -2651,14 +2651,14 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -2670,26 +2670,26 @@ msgid "Mention the user who added the song when it is played."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -2736,14 +2736,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -2769,7 +2769,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 
@@ -2782,7 +2782,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -2808,13 +2808,13 @@ msgid "Completely remove the footer from embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -2822,21 +2822,21 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -2873,7 +2873,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -2882,7 +2882,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -2892,7 +2892,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -2913,7 +2913,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -2921,7 +2921,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -2932,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2972,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2988,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -2997,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3009,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3023,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3036,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3050,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3065,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3078,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3091,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3104,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3439,68 +3439,68 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3508,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3517,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3564,56 +3564,56 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3635,14 +3635,14 @@ msgid "Allow MusicBot to format its messages as embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3656,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3674,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3687,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3747,7 +3747,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -3801,7 +3801,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3809,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3819,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -3888,7 +3888,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -3902,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3911,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3925,7 +3925,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -3933,7 +3933,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -3942,26 +3942,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -3973,28 +3973,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4005,25 +4005,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4032,7 +4032,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/it_IT/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/it_IT/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:41\n"
@@ -483,20 +483,20 @@ msgstr ""
 "riavviare?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot sta chiedendo di parlare nel canale: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot non ha il permesso di parlare."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot non può richiedere di parlare."
 
@@ -632,7 +632,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Impostazione della gilda cronologia URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Nessuna miniatura impostata per la voce con URL: %s"
@@ -721,19 +721,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Caricamento sopra la playlist del giocatore..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Errore durante l'elaborazione del brano \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Errore nell'estrarre il brano \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot ha bisogno di fermare l'estrazione della playlist automatica e la "
@@ -1111,7 +1111,7 @@ msgstr "Lista Gilda:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1693,7 +1693,7 @@ msgid "The player is not currently looping."
 msgstr "Il giocatore non si sta caricando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Le posizioni brano devono essere intere!"
 
@@ -1716,33 +1716,33 @@ msgid "Local media playback is not enabled."
 msgstr "La riproduzione multimediale locale non è abilitata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "L'URL di Spotify non è valido o non è attualmente supportato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Rilevato un URL Spotify, ma Spotify non è abilitato."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Hai raggiunto il limite di canzone in coda (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "La modalità Karaoke è abilitata, riprova quando è disabilitata!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Problema con extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1752,13 +1752,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Questo video non può essere riprodotto. Prova a usare il comando streaming."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1768,7 +1768,7 @@ msgstr ""
 "%(time_per).2f s/song"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1777,105 +1777,105 @@ msgstr ""
 " secondi)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "Estratto una voce con 'youtube:playlist' come chiave estrattore"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "La durata del brano supera il limite (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Aggiunti brani alla posizione %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "Impossibile stimare il tempo di riproduzione per la posizione: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 "Recupero delle informazioni dalla richiesta dello stream non riuscito: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Le playlist in streaming non sono ancora supportate."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Hai raggiunto il limite di elementi della playlist (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 "Specifica una query di ricerca. Usa `help search` per maggiori informazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Non puoi cercare più di %(max)s video"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "In attesa del blocco della voce: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Evoca blocco acquisito per: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "Non sei connesso alla voce. Prova ad unirti a un canale vocale!"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Entrare In %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot non può seguire un utente che non è un membro del server."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Il giocatore non sta giocando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Niente nella coda da rimuovere!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Niente trovato nella coda dall'utente `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1884,40 +1884,40 @@ msgstr ""
 "Devi essere colui che l'ha accodata o che ha i permessi di salto istantanei."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numero di voce non valido. Usa il comando coda per trovare le posizioni "
 "della coda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossibile saltare! Il giocatore non sta giocando!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "Non hai il permesso di forzare un brano in loop."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Non hai il permesso di forzare il salto."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Non hai il permesso di saltare una canzone in loop."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` non è un numero valido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1927,7 +1927,7 @@ msgstr ""
 "Il volume può essere impostato solo da 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1936,7 +1936,7 @@ msgstr ""
 " 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1945,29 +1945,29 @@ msgstr ""
 "Utilizzare il comando di configurazione per impostare una velocità di riproduzione predefinita."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocità non può essere applicata ai media in streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Devi fornire una velocità da impostare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocità fornita non è valida. Usa un numero compreso tra 0.5 e 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opzione non valida per il comando: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1977,30 +1977,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Devi fornire un alias e un comando all'alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Devi fornire un nome alias da rimuovere."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` non esiste."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configurazione non può usare le menzioni del canale e dell'utente allo "
 "stesso tempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2010,7 +2010,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2019,18 +2019,18 @@ msgstr ""
 "di fornire una sezione e un nome di opzione validi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'opzione data è ambigua, si prega di fornire un nome di sezione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Devi fornire un nome di sezione e un nome di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2040,26 +2040,26 @@ msgstr ""
 "Le sezioni disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'opzione `%(option)s` non è disponibile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "L'opzione `%(option)s` non è modificabile. Impossibile salvare sul disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossibile salvare l'opzione: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -2067,7 +2067,7 @@ msgstr ""
 "visualizzato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2075,25 +2075,25 @@ msgstr ""
 "l'impostazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Devi fornire una sezione, un'opzione e un valore per questo sottocomando."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Impostazione con %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'opzione `%(option)s` non è stata aggiornata!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2101,49 +2101,49 @@ msgstr ""
 "valore predefinito."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Ripristino %(config)s a predefinito %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'opzione `%(option)s` non è stata ripristinata al predefinito!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "Il comando opzione è deprecato, utilizza invece il comando di "
 "configurazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opzione specificata non valida, usa: info, aggiornamento o cancella"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Non riuscito** per eliminare la cache, controlla i log per ulteriori "
 "informazioni..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "L'argomento pagina coda deve essere un numero intero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Non ci sono brani in coda! Coda qualcosa con un comando di riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2153,24 +2153,24 @@ msgstr ""
 "Ci sono ** pagine%(total)s**."
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "Ha saltato la voce attuale della scaletta."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "Non ci sono abbastanza voci per paginare la coda."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Impossibile postare il messaggio in coda, nessun messaggio a cui aggiungere "
 "reazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2179,17 +2179,17 @@ msgstr ""
 "Se il problema persiste, file una segnalazione di bug."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossibile usare lo spurgo sul canale DM privato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "L'URL fornito non era un URL valido."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2199,12 +2199,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Questa non sembra essere una playlist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2213,19 +2213,19 @@ msgstr ""
 " e riprovare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossibile determinare l'utente discord. Riprova."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Le autorizzazioni non possono usare le menzioni del canale e dell'utente "
 "allo stesso tempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2235,25 +2235,25 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Devi fornire un nome di gruppo o di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Devi fornire un gruppo, un'opzione e un valore da impostare per questo "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Il sottocomando %(option)s richiede un nome di gruppo e di permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2263,47 +2263,47 @@ msgstr ""
 "I gruppi disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Il permesso `%(option)s` non è disponibile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossibile aggiungere il gruppo `%(group)s` che esiste già."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Impossibile rimuovere il gruppo integrato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Il gruppo proprietario non è modificabile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossibile salvare il gruppo: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Impostazione %(option)s con valore: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Il permesso `%(option)s` non è stato aggiornato!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2312,7 +2312,7 @@ msgstr ""
 "Ricorda che i cambiamenti di nome sono limitati a due volte all'ora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2322,12 +2322,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Impossibile cambiare il soprannome: nessun permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2337,14 +2337,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Le emoji personalizzate devono provenire da questo server per essere "
 "utilizzate come prefisso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2353,30 +2353,30 @@ msgstr ""
 "Usa il comando di configurazione per aggiornare il prefisso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Questo comando può essere usato solo nelle gilde."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sottocomando fornito non valido. Utilizzare il comando help per ulteriori "
 "informazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Impossibile impostare la lingua su `%(locale)s` non è disponibile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "È necessario fornire un URL o allegare un file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2386,64 +2386,64 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 "MusicBot ha trovato un %s senza gilda! Questo potrebbe essere un problema."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Attualmente non connesso al server `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Opzione fornita non valida, usa una di: soft, full, upgrade, uppip, or upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Devi fornire un ID o un nome."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nessuna gilda trovata con l'ID o il nome `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Attivazione ID breakpoint di debug: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossibile importare `objgraph`, è installato?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Codice di debug eseguito con eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Il codice di debug è funzionato con exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "Impossibile eseguire il codice di debug."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2459,57 +2459,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Il sottocomando deve essere uno di: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Impossibile individuare git eseguibile."
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "Impossibile controllare gli aggiornamenti tramite il comando git."
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Pacchetto meta mancante nel rapporto pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 "Impossibile ottenere lo stato di aggiornamento dei pip a causa di qualche "
 "errore."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Ottenuto una strana voce client vocale."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookie già abilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "I cookie devono essere caricati per essere abilitati. (File dei cookie)."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Impossibile abilitare i cookie a causa di errore:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2519,7 +2519,7 @@ msgstr ""
 "I cookie sono temporaneamente disabilitati e saranno riattivati al prossimo riavvio."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2527,50 +2527,50 @@ msgstr ""
 "di un file di cookie."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 "Impossibile rimuovere il vecchio file cookie disabilitato:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Errore nel scaricare il file dei cookie da discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossibile salvare i cookie sul disco:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Hai un messaggio senza canale, in qualche modo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorare il comando da me stesso (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignora il comando da un altro bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignora il comando dal canale di tipo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2578,101 +2578,101 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Messaggio da %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 "Questo comando non è consentito per il tuo gruppo di permessi:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Questo comando richiede di essere in un canale vocale."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 "Utilizzo del comando non valido, valori mancanti per i parametri: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Errore in %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Eccezione durante la gestione del comando: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Impossibile generare l'aiuto per il comando mancante:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Dati di aiuto mancanti per il comando:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Lasciare il canale vocale %s in %s a causa di inattività."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot si è connesso."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot è stato disconnesso."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Ottenuto un Evento Socket:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "Stato vocale aggiornato prima del termine _pronto"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorare %s in %s in quanto è un canale vocale collegato."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s è stato rilevato come timeout vuoto."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Un utente si è unito %s, annullando il timer."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2680,30 +2680,30 @@ msgstr ""
 "Il bot è stato spostato e il canale vocale %s è vuoto. Timeout gestione."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Il bot è stato spostato e il canale vocale %s non è vuoto."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "Non più seguendo l'utente %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Seguire l'utente `%(user)s` al canale:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState disconnetti before.channel non è nessuno."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2713,7 +2713,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2721,7 +2721,7 @@ msgstr ""
 "  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
@@ -2729,84 +2729,84 @@ msgstr ""
 "Gilda:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Riconnessione alla gilda auto-entrata sul canale:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Impossibile entrare automaticamente nel canale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Il bot è stato aggiunto alla gilda: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Gilda sinistra '%s' a causa del proprietario del bot non trovato."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Creazione cartella dati per la gilda %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Il bot è stato rimosso dalla gilda: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Lista gilda aggiornata:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Gilda \"%s\" è diventato disponibile."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Riprendere il giocatore in \"%s\" a causa della disponibilità."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Gilda \"%s\" non è disponibile."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausa giocatore in \"%s\" a causa di indisponibilità."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Aggiornamento gilda per:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "L'attributo della Gilda %(attr)s è ora: %(new)s  -- Era %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Aggiornamento canale per:  %(channel)s  --  %(changes)s"
@@ -2824,7 +2824,7 @@ msgid "Loading config from:  %s"
 msgstr "Caricamento configurazione da:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2854,7 +2854,7 @@ msgstr ""
 "  Utilizzare le opzioni di esempio come modello o copiarlo dal repository."
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2864,7 +2864,7 @@ msgstr ""
 "limitata."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2873,7 +2873,7 @@ msgstr ""
 "rotazione del file di registro. Usando invece predefinito."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2892,12 +2892,12 @@ msgstr ""
 "  Assicurati che il percorso configurato sia un percorso per una cartella / directory."
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "È stata lanciata un'eccezione durante la convalida di AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2919,13 +2919,13 @@ msgstr ""
 "  Doppio controllo l'impostazione è valida, percorso directory accessibile."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "La cache audio sarà memorizzata in:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2945,7 +2945,7 @@ msgstr ""
 "  Imposta l'opzione di configurazione Token o imposta la variabile di ambiente %(env_var)s con un token App."
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2954,7 +2954,7 @@ msgstr ""
 "128 caratteri."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2964,17 +2964,17 @@ msgstr ""
 "100.0. Il valore di opzione di %.3f sarà limitato."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Validazione delle opzioni con i dati del servizio..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "ID proprietario acquisito tramite API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2995,12 +2995,12 @@ msgstr ""
 "  Imposta manualmente l'opzione di configurazione 'OwnerID' o riprova più tardi."
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot non ha un'istanza utente, non può procedere."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3019,14 +3019,14 @@ msgstr ""
 "  Non utilizzare il Bot o l'App ID nel campo 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "File delle opzioni di configurazione non trovato. Verifica la presenza di "
 "alternative..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3036,20 +3036,20 @@ msgstr ""
 " estensioni dei file."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copia del file delle opzioni di esempio esistenti:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Qualcosa è andato storto durante il tentativo di trovare un file di opzione "
 "di configurazione."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3071,7 +3071,7 @@ msgstr ""
 "  Verifica che la cartella di configurazione e i file esistano e possono essere letti da MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3095,12 +3095,12 @@ msgstr ""
 "  Copiare il file di esempio dal repo se tutto il resto fallisce."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! L'opzione di configurazione ha getter che non è disponibile."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3109,31 +3109,31 @@ msgstr ""
 "predefinito deve essere lo stesso tipo."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "L'opzione mancava in precedenza."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 "Sezione di configurazione non in configurazione analizzata! Mancante: %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Opzione di configurazione salvata: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Salvataggio della configurazione non riuscito:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3141,13 +3141,13 @@ msgstr ""
 "disabilitato."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Impossibile salvare il file INI predefinito in:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3167,7 +3167,7 @@ msgstr ""
 "  Imposta %(option)s su un ID numerico o impostalo su `auto` o `0` per il binding automatico del proprietario."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3187,7 +3187,7 @@ msgstr ""
 "  Controlla l'impostazione del percorso e assicurati che il file esista ed sia accessibile a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3207,7 +3207,7 @@ msgstr ""
 "  Assicurati che tutti gli ID siano numerici e separati solo da spazi o virgole."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3217,7 +3217,7 @@ msgstr ""
 "%(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3227,7 +3227,7 @@ msgstr ""
 "'%(value)s' usando invece predefinito."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3237,7 +3237,7 @@ msgstr ""
 "(%(value)s) e sarà invece impostato su %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3246,49 +3246,49 @@ msgstr ""
 "%(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Aggiornamento file di configurazione con opzioni rinominate..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Impossibile aggiornare la configurazione. Dovrai aggiornarla manualmente."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "File elenco blocco non trovato:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Impossibile caricare l'elenco dei blocchi dal file:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Impossibile aggiornare il file elenco blocchi:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Lista Blocco utente caricata con voci %s."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Abbiamo trovato un file di blacklist legacy, che verrà rinominato in:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Caricato un elenco di blocchi brani con voci %s."
@@ -3356,39 +3356,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Forzare YTDLP per utilizzare l'agente utente:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot utilizzerà i cookie per yt-dlp da:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp userà il tuo server proxy configurato."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD sembra non avere intestazioni..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr "Controllo intestazioni multimediali non riuscito a causa del timeout."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Richiesta HEAD non riuscita per:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "Richiesta di eccezione HEAD: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3398,56 +3398,56 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Informazioni Di Estrazione Ytdl Sanitizzate (non Json):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "L'estrazione di informazioni brano non ha restituito dati."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Chiamato extract_info con: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Impossibile eseguire l'estrazione, il ciclo è chiuso. (Questo è normale in "
 "caso di arresti)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Impossibile continuare l'estrazione, il ciclo dell'evento è chiuso."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL non è valido o non supportato."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Errore di download con URL dello stream"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "Supponendo che il contenuto sia uno stream diretto"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Impossibile trasmettere un URL non valido."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3455,23 +3455,23 @@ msgstr ""
 "spazio."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Chiamato safe_extract_info con:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Impossibile trovare il file multimediale locale."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Manca __input_subject da YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3479,7 +3479,7 @@ msgstr ""
 "evitare questo."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Attenzione, errore di durata per: %(url)s"
@@ -4791,13 +4791,13 @@ msgstr ""
 "Verifica la presenza di ffmpeg con il gestore dei pacchetti di sistema o compila da sorgenti."
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "Rimangono meno di %sMB di spazio libero su questo dispositivo"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4806,12 +4806,12 @@ msgstr ""
 "Verifica aggiornamenti a MusicBot o dipendenze..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "Nessun aggiornamento MusicBot disponibile tramite il comando `git`."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4820,24 +4820,24 @@ msgstr ""
 "controllare manualmente."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "I seguenti pacchetti possono essere aggiornati:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  alla versione:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 "Nessun aggiornamento delle dipendenze disponibile tramite il comando `pip`."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4846,7 +4846,7 @@ msgstr ""
 "controllare manualmente."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4856,35 +4856,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "Il valore è superiore al limite massimo."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "Il valore non deve essere negativo."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "Valore per Max Logs Kept deve essere un numero da 0 a %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "Il livello di log '%s' non è disponibile."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "Il livello di log deve essere uno di:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4893,28 +4893,28 @@ msgstr ""
 " discord.py, youtubeDL, e ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Disponibile tramite Github:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 "Per più aiuto e supporto con questo bot, unisciti alla nostra discorda:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "Questo software è fornito sotto la licenza MIT."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "Vedere il file di testo `LICENSE` per dettagli completi."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
@@ -4922,13 +4922,13 @@ msgstr ""
 "in MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 "Usa questa lingua per tutti i messaggi di registro del server da MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4937,29 +4937,29 @@ msgstr ""
 "Questo non impedisce la selezione della lingua per gilda."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Stampare le informazioni sulla versione di MusicBot ed uscire."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 "Salta tutti i controlli di avvio opzionali, incluso il controllo di "
 "aggiornamento."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Salta solo il controllo dello spazio su disco all'avvio."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Salta solo il controllo di aggiornamento all'avvio."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -4968,7 +4968,7 @@ msgstr ""
 " importarle."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4978,7 +4978,7 @@ msgstr ""
 "(Predefinito: %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
@@ -4986,7 +4986,7 @@ msgstr ""
 "configurazione. Deve essere una di: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4997,44 +4997,44 @@ msgstr ""
 "(Predefinito: '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Versione:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Apri una nuova istanza di MusicBot. Questo terminale può essere chiuso in "
 "sicurezza!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Caricamento versione MusicBot:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Log aperto:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Modifica della directory di lavoro in:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5045,7 +5045,7 @@ msgstr ""
 " una nuova posizione della directory."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5054,7 +5054,7 @@ msgstr ""
 "Se non hai usato git per clonare il repository, sei fortemente sollecitato."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5063,12 +5063,12 @@ msgstr ""
 "certifi e di uscita."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Ecco l'errore esatto, potrebbe essere un bug."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5077,7 +5077,7 @@ msgstr ""
 "è possibile aprire il sito fallito in Microsoft Edge o IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5086,17 +5086,17 @@ msgstr ""
 "predefinito, tentando invece il certificifi."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Errore di sintassi (modifica rilevata, hai modificato il codice?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Errore di sintassi (questo è un bug, non colpa tua)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5117,14 +5117,14 @@ msgstr ""
 "  o lanciare senza `--no-install-deps` e MusicBot proverà ad installarli per te."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Tentativo di installare automaticamente i pacchetti di dipendenza di "
 "MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5160,57 +5160,43 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, lascia funzionare la speranza di installare dipendenze!"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot ha ottenuto un ImportError dopo aver provato a installare i "
-"pacchetti. MusicBot deve uscire..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "L'eccezione che ha causato l'errore sopra: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot sta facendo un riavvio morbido..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot sta facendo un riavvio completo..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Errore nell'avvio del bot"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Ciclo dell'evento di chiusura."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Riavvio in %s secondi..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "Tutto fatto."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "OK, stiamo chiudendo!"
 
@@ -5231,31 +5217,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5269,7 +5255,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5329,7 +5315,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5560,24 +5546,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5624,25 +5610,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5650,66 +5636,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5736,7 +5676,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5748,25 +5688,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5779,29 +5719,145 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot ha ottenuto un ImportError dopo aver provato a installare i "
+#~ "pacchetti. MusicBot deve uscire..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "L'eccezione che ha causato l'errore sopra: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/it_IT/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/it_IT/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:41\n"
@@ -159,7 +159,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Eccezione non gestita per l'attività:  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify non ci ha fornito un token. Disattivazione."
 
@@ -179,65 +179,43 @@ msgstr ""
 "Impossibile avviare il client Spotify. Il tuo ID client e segreto sono "
 "corretti? Dettagli: %s. Continuare comunque in 5 secondi..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"La configurazione non ha le credenziali dell'applicazione Spotify, tentando "
-"di utilizzare la modalità ospite."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Autenticato con Spotify con successo utilizzando la modalità ospite."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-"Impossibile avviare il client Spotify usando la modalità ospite. Dettagli: "
-"%s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Inizializzato, ora si collega alla discordia."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Il test di rete ping è disabilitato tramite config."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "Test ping di rete si sta chiudendo."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "Impossibile risolvere il ping target."
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Test ping di rete annullato."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Il test di rete tramite HTTP non ha una sessione in prestito."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "Impossibile trovare l'eseguibile `ping` nel tuo ambiente."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -251,7 +229,7 @@ msgstr ""
 "In alternativa disabilita il controllo di rete tramite config."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -265,7 +243,7 @@ msgstr ""
 "In alternativa disabilita il controllo di rete tramite config."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -279,28 +257,28 @@ msgstr ""
 "In alternativa disabilita il controllo di rete tramite config."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "MusicBot rilevato rete è nuovamente disponibile."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "VoiceClient non è connesso, in attesa di riprendere MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Riprendendo la riproduzione del giocatore: (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot ha rilevato un'interruzione di rete."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -309,7 +287,7 @@ msgstr ""
 "%(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -319,26 +297,26 @@ msgstr ""
 "%(required)s) e ottiene:  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "Controllo della presenza di canali da auto-entrare o riprendere..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 "Gilda non disponibile, impossibile entrare automaticamente:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 "Trovato canale vocale riproducibile:  %(channel)s  nella gilda:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
@@ -346,20 +324,20 @@ msgstr ""
 "nel canale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Trovato proprietario nel canale vocale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 "Ignorando il canale riattivabile, AutoSummon al proprietario nel canale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
@@ -367,98 +345,98 @@ msgstr ""
 "canale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Già connesso al canale:  %(channel)s  nella gilda:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 "Tentativo di entrare nel canale:  %(channel)s  nella gilda:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Scartare MusicPlayer e crearne uno nuovo..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot renderà un nuovo MusicPlayer ora..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 "Non entrando in %(guild)s/%(channel)s, non è un canale vocale supportato."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Completato il collegamento ai canali configurati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Il membro non è abilitato alla voce e non può usare questo comando."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Non puoi usare questo comando quando non è nel canale vocale."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Ottenere bot Application Info."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot non ha il permesso di connettersi nel canale:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot non ha il permesso di connettersi nel canale: `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot non ha il permesso di parlare nel canale:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot non ha il permesso di parlare nel canale: `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Riutilizzo di bot VoiceClient dalla gilda:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "Forzare la disconnessione su VoiceClient obsoleto nella gilda:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "Disconnessione fallita o annullata?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
@@ -466,7 +444,7 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -475,12 +453,12 @@ msgstr ""
 "Riprova più tardi, o riavvia il bot se continua."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot ha un VoiceClient ora..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -490,14 +468,14 @@ msgstr ""
 "tentativo di connettersi a:  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 "Il tentativo di connessione MusicBot VoiceClient è stato annullato. Nessun "
 "riprovo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -505,42 +483,42 @@ msgstr ""
 "riavviare?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot sta chiedendo di parlare nel canale: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot non ha il permesso di parlare."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot non può richiedere di parlare."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Disconnettere un musicista nella gilda:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Scollegare VoiceClient prima di uccidere MusicPlayer."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "La disconnessione non è riuscita o è stata annullata."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -549,18 +527,18 @@ msgstr ""
 "comunque..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Disconnettere un VoiceClient canaglia nella gilda:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Disconnettere un non-guild VoiceClient..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -570,20 +548,20 @@ msgstr ""
 "L'oggetto è in realtà di tipo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 "Abbiamo ancora un lettore musicale nella gilda (%(guild_id)s):  %(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Gilda (%(guild)s) vuole un giocatore, opzionale:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -592,24 +570,24 @@ msgstr ""
 "dovresti riavviare il bot."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer ha un VoiceClient che non è connesso."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "MusicPlayer obj:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -619,7 +597,7 @@ msgstr ""
 "Crea: %(create)s  Deserializza:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -629,7 +607,7 @@ msgstr ""
 "voci %(number)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -638,388 +616,388 @@ msgstr ""
 "Usa il comando summon per portare il bot sul tuo canale vocale."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Qualcosa è sbagliato, non abbiamo ottenuto il VoiceClient."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "Esecuzione on_player_play"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Impostazione della gilda cronologia URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Nessuna miniatura impostata per la voce con URL: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "nessun canale in cui inserire il messaggio in riproduzione"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 "ignorato il messaggio in riproduzione ora come era già stato pubblicato."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "Esecuzione on_player_resume"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "Esecuzione on_player_pause"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Esecuzione on_player_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Esecuzione on_player_finished_playing"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "Il ciclo di eventi è chiuso, nient'altro da fare qui."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Logout in corso, ignorando questo evento."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 "VoiceClient dice che non è connesso, niente altro che possiamo fare qui."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "Il giocatore finito e la coda è vuota, lasciando il canale vocale..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 "Caricando sopra la coda per ripulire le canzoni con l'autore mancante..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr "Autore `%(user)s` assente, saltato (cancellato) dalla coda:  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 "Nessun brano riproducibile nella lista di riproduzione automatica della "
 "gilda, disabilitata."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 "Nessun contenuto nella playlist automatica. Riempimento con nuova musica..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Caricamento sopra la playlist del giocatore..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Errore durante l'elaborazione del brano \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Errore nell'estrarre il brano \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot ha bisogno di fermare l'estrazione della playlist automatica e la "
 "cauzione."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 "MusicBot ha ottenuto un'eccezione non gestita nell'evento finito dal "
 "giocatore."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr "Espandendo playlist automatica con voci estratte da:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "Errore nell'aggiungere il brano dalla playlist automatica: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Eccezione di dati per l'errore sopra:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "Nessun brano riproducibile nella playlist automatica, disabilitato."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "Esecuzione su_player_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 "Saltando automaticamente la voce della scaletta automatica per la voce in "
 "coda."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "Eccezione MusicPlayer per la voce: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "Eccezione di MusicPlayer."
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "Impossibile riprodurre la traccia della scaletta automatica:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "Logout in corso, ignorando l'aggiornamento dello stato."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Aggiorna stato bot:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Serializzazione della coda per %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Deserializzazione della coda per %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Scrittura del brano corrente per %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "Impossibile inviare l'oggetto non-risposta:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Provato a inviare un oggetto di risposta non valido."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "invio incorporato a: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "invio del testo a: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "Impossibile inviare il messaggio a \"%s\", nessun permesso"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "Impossibile inviare il messaggio a \"%s\", canale eliminato o non valido"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "Il messaggio è sopra il limite di dimensione del messaggio (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 "Impossibile inviare un messaggio privato, inviando un canale di ripiego."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr "Vota il messaggio di invio limitato, riprovando in %s secondi."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Riprova messaggio annullato per:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "Valuta il messaggio di invio limitato, ma non riprovare!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "Impossibile inviare il messaggio nel canale di ripiego."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Impossibile inviare a causa di un errore HTTP."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "Impossibile eliminare il messaggio \"%s\", nessun permesso"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "Impossibile eliminare il messaggio \"%s\", messaggio non trovato"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 "Valuta l'eliminazione limitata dei messaggi, riprovando in %s secondi."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "Valuta l'eliminazione del messaggio limitata, ma non riprova!"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Eliminazione del messaggio non riuscita"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Hai HTTPException cercando di eliminare il messaggio: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "Impossibile modificare il messaggio \"%s\", messaggio non trovato"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Invio messaggio invece"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr "Valuta il messaggio di modifica limitato, riprovando in %s secondi."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Modifica messaggio annullata per:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Modifica del messaggio non riuscita"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Hai HTTPException tentato di modificare il messaggio %s a: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Eliminazione annullata per il messaggio (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Ricevuto un segnale dal sistema operativo: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Scollegare e chiudere MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "Eccezione lanciata durante la gestione del segnale di interruzione!"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot sta ora facendo passi di arresto..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1042,44 +1020,44 @@ msgstr ""
 "  Controlla lo stato dell'API sul sito ufficiale: discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "In attesa che le discussioni di download finiscano..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Attenderà il compito:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Cercherà di annullare l'attività:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "In attesa di attività..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Chiusura Connettore HTTP."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Chiusura sessione aiohttp."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "Il logout è stato chiamato."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1089,81 +1067,81 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Eccezione in %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot ha ripreso una sessione con discord."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Termina su_pronto"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Accesso effettuato, ora ottenendo MusicBot pronto..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "ClientUser è in qualche modo nessuno, abbiamo ottenuto la bail..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Proprietario:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Lista Gilda:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "Sinistra %s a causa del proprietario del bot non trovato"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 "Non procedere con i controlli nei server %s a causa di indisponibilità"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "Il proprietario non può essere trovato in nessuna gilda (id: %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Proprietario sconosciuto, bot non è su alcuna gilda."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1177,41 +1155,41 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Non c'è nessuno per il canale collegato con ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "Impossibile collegare al canale non Messaggiabile con ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Legato ai canali di testo:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "Non associato a nessun canale di testo"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "Non c'è nessuno per entrare automaticamente nel canale con ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
@@ -1219,208 +1197,208 @@ msgstr ""
 "%d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 "Impossibile entrare automaticamente nel canale non connettibile con ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Collegamento automatico canali vocali:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "Non si unisce automaticamente a nessun canale vocale"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "L'evento on_ready ha sparato %s volte"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Ottenere informazioni sull'applicazione."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "Assicurare l'esistenza di cartelle dati"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Convalida configurazione"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Convalida configurazione permessi"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Abilitato"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Opzione:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Prefisso dei comandi: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  Volume predefinito: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Salta soglia: %(num)d voti o %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Riproduzione Di @mentions: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Scaletta Automatica: %(status)s (ordine: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "casuale"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "sequenziale"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Auto-Pausa: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Elimina Messaggi: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Elimina Invoking: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Elimina In Riproduzione: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Modalità Debug: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  I brani scaricati saranno %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Elimina se non utilizzato per %d giorni"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Messaggio di stato: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Integrazione Spotify: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Timeout: %s secondi"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Timeout: %d secondi"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Self Deafen: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Prefisso di comando per server: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Coda Round Robin: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "La canzone richiesta `%(subject)s` è bloccata dalla lista dei brani."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 "Tentativo di gestire l'inattività del canale vocale, ma Bot non è in voce..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "Attività canale già in attesa nella gilda: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1429,31 +1407,31 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "Il timer di attività del canale per %s è scaduto. Disconnessione."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Timer attività canale annullato per: %(channel)s in %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Ignorare l'inattività del giocatore nel canale auto-entrato:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "Timer attività giocatore già in attesa nella gilda: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1462,52 +1440,52 @@ msgstr ""
 "canale: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "Il timer di attività del giocatore per %s è scaduto. Disconnessione."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Timer attività giocatore annullato per: %(channel)s in %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Il timer dell'attività del giocatore è in fase di ripristino."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Comando inesistente"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 "È necessario menzionare un utente o fornire il loro numero di identità."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Sottocomando fornito non valido. Usa `help blockuser` per esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot non ha trovato gli utenti specificati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Il proprietario non può essere aggiunto all'elenco dei blocchi."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
@@ -1515,7 +1493,7 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
@@ -1523,81 +1501,81 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Non è possibile aggiungere gli utenti elencati, sono già aggiunti."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Devi fornire un oggetto del brano se nessuna canzone è attualmente in "
 "riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Sottocomando fornito non valido. Usa `help blocksong` per esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "L'oggetto `%(subject)s` è già nella lista dei brani."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "L'oggetto non è nell'elenco dei brani e non può essere rimosso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Sottocomando fornito non valido. Usa `help autoplaylist` per esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Il link del brano fornito non è valido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "La coda è vuota. Aggiungi alcuni brani con un comando di riproduzione!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Questo brano è già nella playlist automatica."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Questa canzone non è ancora nella playlist automatica."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "È necessario fornire un nome file playlist."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Non sei autorizzato a richiedere playlist"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "La playlist ha troppe voci (%(songs)s ma il massimo è %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1609,12 +1587,12 @@ msgstr ""
 "Il limite è %(max)s per il tuo gruppo."
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Ignorare la pausa automatica a causa dell'interruzione della rete."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1623,12 +1601,12 @@ msgstr ""
 "elaborare la pausa automatica."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Elaborazione della pausa automatica, ignorando questo evento."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1638,62 +1616,62 @@ msgstr ""
 "automatica nella gilda:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "Auto-pausa attesa è stata annullata."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 "Un nuovo MusicPlayer è in fase di connessione, ignorando il vecchio evento "
 "di pausa automatica."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 "Riproduzione in un canale vocale vuoto, in pausa automatica per gilda: %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 "Il giocatore precedentemente in pausa automatica è in pausa per la gilda: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Impossibile usare la ricerca se non c'è niente di giocare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Impossibile usare la ricerca sulla traccia corrente, ha una durata "
 "sconosciuta."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "La ricerca non è supportata per gli streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 "Impossibile usare la ricerca senza un tempo per posizionare la riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Impossibile convertire `%(input)s` in un tempo valido in secondi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1703,29 +1681,29 @@ msgstr ""
 "corrente con una lunghezza di `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Sottocomando non valido. Usa il comando `help repeat` per gli esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Il giocatore non si sta caricando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Le posizioni brano devono essere intere!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Hai dato una posizione fuori dalla dimensione della playlist!"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
@@ -1733,38 +1711,38 @@ msgstr ""
 "cui aggiungere reazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "La riproduzione multimediale locale non è abilitata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "L'URL di Spotify non è valido o non è attualmente supportato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Rilevato un URL Spotify, ma Spotify non è abilitato."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Hai raggiunto il limite di canzone in coda (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "La modalità Karaoke è abilitata, riprova quando è disabilitata!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Problema con extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1774,16 +1752,10 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Questo video non può essere riprodotto. Prova a usare il comando streaming."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "La ricerca su YouTube non ha prodotto alcun risultato per:  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1892,18 +1864,18 @@ msgid "Player is not playing."
 msgstr "Il giocatore non sta giocando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Niente nella coda da rimuovere!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Niente trovato nella coda dall'utente `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1912,40 +1884,40 @@ msgstr ""
 "Devi essere colui che l'ha accodata o che ha i permessi di salto istantanei."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numero di voce non valido. Usa il comando coda per trovare le posizioni "
 "della coda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossibile saltare! Il giocatore non sta giocando!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "Non hai il permesso di forzare un brano in loop."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Non hai il permesso di forzare il salto."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Non hai il permesso di saltare una canzone in loop."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` non è un numero valido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1955,7 +1927,7 @@ msgstr ""
 "Il volume può essere impostato solo da 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1964,7 +1936,7 @@ msgstr ""
 " 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1973,29 +1945,29 @@ msgstr ""
 "Utilizzare il comando di configurazione per impostare una velocità di riproduzione predefinita."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocità non può essere applicata ai media in streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Devi fornire una velocità da impostare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocità fornita non è valida. Usa un numero compreso tra 0.5 e 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opzione non valida per il comando: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2005,30 +1977,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Devi fornire un alias e un comando all'alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Devi fornire un nome alias da rimuovere."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` non esiste."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configurazione non può usare le menzioni del canale e dell'utente allo "
 "stesso tempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2038,7 +2010,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2047,18 +2019,18 @@ msgstr ""
 "di fornire una sezione e un nome di opzione validi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'opzione data è ambigua, si prega di fornire un nome di sezione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Devi fornire un nome di sezione e un nome di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2068,26 +2040,26 @@ msgstr ""
 "Le sezioni disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'opzione `%(option)s` non è disponibile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "L'opzione `%(option)s` non è modificabile. Impossibile salvare sul disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossibile salvare l'opzione: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -2095,7 +2067,7 @@ msgstr ""
 "visualizzato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2103,25 +2075,25 @@ msgstr ""
 "l'impostazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Devi fornire una sezione, un'opzione e un valore per questo sottocomando."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Impostazione con %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'opzione `%(option)s` non è stata aggiornata!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2129,49 +2101,49 @@ msgstr ""
 "valore predefinito."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Ripristino %(config)s a predefinito %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'opzione `%(option)s` non è stata ripristinata al predefinito!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "Il comando opzione è deprecato, utilizza invece il comando di "
 "configurazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opzione specificata non valida, usa: info, aggiornamento o cancella"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Non riuscito** per eliminare la cache, controlla i log per ulteriori "
 "informazioni..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "L'argomento pagina coda deve essere un numero intero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Non ci sono brani in coda! Coda qualcosa con un comando di riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2181,24 +2153,24 @@ msgstr ""
 "Ci sono ** pagine%(total)s**."
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "Ha saltato la voce attuale della scaletta."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "Non ci sono abbastanza voci per paginare la coda."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Impossibile postare il messaggio in coda, nessun messaggio a cui aggiungere "
 "reazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2207,17 +2179,17 @@ msgstr ""
 "Se il problema persiste, file una segnalazione di bug."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossibile usare lo spurgo sul canale DM privato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "L'URL fornito non era un URL valido."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2227,12 +2199,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Questa non sembra essere una playlist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2241,19 +2213,19 @@ msgstr ""
 " e riprovare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossibile determinare l'utente discord. Riprova."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Le autorizzazioni non possono usare le menzioni del canale e dell'utente "
 "allo stesso tempo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2263,25 +2235,25 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Devi fornire un nome di gruppo o di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Devi fornire un gruppo, un'opzione e un valore da impostare per questo "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Il sottocomando %(option)s richiede un nome di gruppo e di permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2291,47 +2263,47 @@ msgstr ""
 "I gruppi disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Il permesso `%(option)s` non è disponibile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossibile aggiungere il gruppo `%(group)s` che esiste già."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Impossibile rimuovere il gruppo integrato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Il gruppo proprietario non è modificabile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossibile salvare il gruppo: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Impostazione %(option)s con valore: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Il permesso `%(option)s` non è stato aggiornato!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2340,7 +2312,7 @@ msgstr ""
 "Ricorda che i cambiamenti di nome sono limitati a due volte all'ora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2350,12 +2322,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Impossibile cambiare il soprannome: nessun permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2365,14 +2337,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Le emoji personalizzate devono provenire da questo server per essere "
 "utilizzate come prefisso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2381,30 +2353,30 @@ msgstr ""
 "Usa il comando di configurazione per aggiornare il prefisso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Questo comando può essere usato solo nelle gilde."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sottocomando fornito non valido. Utilizzare il comando help per ulteriori "
 "informazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Impossibile impostare la lingua su `%(locale)s` non è disponibile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "È necessario fornire un URL o allegare un file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2414,64 +2386,64 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 "MusicBot ha trovato un %s senza gilda! Questo potrebbe essere un problema."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Attualmente non connesso al server `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Opzione fornita non valida, usa una di: soft, full, upgrade, uppip, or upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Devi fornire un ID o un nome."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nessuna gilda trovata con l'ID o il nome `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Attivazione ID breakpoint di debug: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossibile importare `objgraph`, è installato?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Codice di debug eseguito con eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Il codice di debug è funzionato con exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "Impossibile eseguire il codice di debug."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2487,57 +2459,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Il sottocomando deve essere uno di: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Impossibile individuare git eseguibile."
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "Impossibile controllare gli aggiornamenti tramite il comando git."
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Pacchetto meta mancante nel rapporto pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 "Impossibile ottenere lo stato di aggiornamento dei pip a causa di qualche "
 "errore."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Ottenuto una strana voce client vocale."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookie già abilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "I cookie devono essere caricati per essere abilitati. (File dei cookie)."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Impossibile abilitare i cookie a causa di errore:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2547,7 +2519,7 @@ msgstr ""
 "I cookie sono temporaneamente disabilitati e saranno riattivati al prossimo riavvio."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2555,50 +2527,50 @@ msgstr ""
 "di un file di cookie."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 "Impossibile rimuovere il vecchio file cookie disabilitato:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Errore nel scaricare il file dei cookie da discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossibile salvare i cookie sul disco:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Hai un messaggio senza canale, in qualche modo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorare il comando da me stesso (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignora il comando da un altro bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignora il comando dal canale di tipo:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2606,101 +2578,101 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Messaggio da %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 "Questo comando non è consentito per il tuo gruppo di permessi:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Questo comando richiede di essere in un canale vocale."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 "Utilizzo del comando non valido, valori mancanti per i parametri: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Errore in %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Eccezione durante la gestione del comando: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Impossibile generare l'aiuto per il comando mancante:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Dati di aiuto mancanti per il comando:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Lasciare il canale vocale %s in %s a causa di inattività."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot si è connesso."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot è stato disconnesso."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Ottenuto un Evento Socket:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "Stato vocale aggiornato prima del termine _pronto"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorare %s in %s in quanto è un canale vocale collegato."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s è stato rilevato come timeout vuoto."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Un utente si è unito %s, annullando il timer."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2708,30 +2680,30 @@ msgstr ""
 "Il bot è stato spostato e il canale vocale %s è vuoto. Timeout gestione."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Il bot è stato spostato e il canale vocale %s non è vuoto."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "Non più seguendo l'utente %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Seguire l'utente `%(user)s` al canale:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState disconnetti before.channel non è nessuno."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2741,7 +2713,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2749,7 +2721,7 @@ msgstr ""
 "  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
@@ -2757,84 +2729,84 @@ msgstr ""
 "Gilda:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Riconnessione alla gilda auto-entrata sul canale:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Impossibile entrare automaticamente nel canale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Il bot è stato aggiunto alla gilda: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Gilda sinistra '%s' a causa del proprietario del bot non trovato."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Creazione cartella dati per la gilda %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Il bot è stato rimosso dalla gilda: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Lista gilda aggiornata:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Gilda \"%s\" è diventato disponibile."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Riprendere il giocatore in \"%s\" a causa della disponibilità."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Gilda \"%s\" non è disponibile."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausa giocatore in \"%s\" a causa di indisponibilità."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Aggiornamento gilda per:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "L'attributo della Gilda %(attr)s è ora: %(new)s  -- Era %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Aggiornamento canale per:  %(channel)s  --  %(changes)s"
@@ -2852,7 +2824,7 @@ msgid "Loading config from:  %s"
 msgstr "Caricamento configurazione da:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2882,7 +2854,7 @@ msgstr ""
 "  Utilizzare le opzioni di esempio come modello o copiarlo dal repository."
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2892,7 +2864,7 @@ msgstr ""
 "limitata."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2901,7 +2873,7 @@ msgstr ""
 "rotazione del file di registro. Usando invece predefinito."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2920,12 +2892,12 @@ msgstr ""
 "  Assicurati che il percorso configurato sia un percorso per una cartella / directory."
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "È stata lanciata un'eccezione durante la convalida di AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2947,13 +2919,13 @@ msgstr ""
 "  Doppio controllo l'impostazione è valida, percorso directory accessibile."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "La cache audio sarà memorizzata in:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2973,7 +2945,7 @@ msgstr ""
 "  Imposta l'opzione di configurazione Token o imposta la variabile di ambiente %(env_var)s con un token App."
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2982,7 +2954,7 @@ msgstr ""
 "128 caratteri."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2992,17 +2964,17 @@ msgstr ""
 "100.0. Il valore di opzione di %.3f sarà limitato."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Validazione delle opzioni con i dati del servizio..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "ID proprietario acquisito tramite API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3023,12 +2995,12 @@ msgstr ""
 "  Imposta manualmente l'opzione di configurazione 'OwnerID' o riprova più tardi."
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot non ha un'istanza utente, non può procedere."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3047,14 +3019,14 @@ msgstr ""
 "  Non utilizzare il Bot o l'App ID nel campo 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "File delle opzioni di configurazione non trovato. Verifica la presenza di "
 "alternative..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3064,20 +3036,20 @@ msgstr ""
 " estensioni dei file."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Copia del file delle opzioni di esempio esistenti:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Qualcosa è andato storto durante il tentativo di trovare un file di opzione "
 "di configurazione."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3099,7 +3071,7 @@ msgstr ""
 "  Verifica che la cartella di configurazione e i file esistano e possono essere letti da MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3123,12 +3095,12 @@ msgstr ""
 "  Copiare il file di esempio dal repo se tutto il resto fallisce."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! L'opzione di configurazione ha getter che non è disponibile."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3137,31 +3109,31 @@ msgstr ""
 "predefinito deve essere lo stesso tipo."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "L'opzione mancava in precedenza."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 "Sezione di configurazione non in configurazione analizzata! Mancante: %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Opzione di configurazione salvata: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Salvataggio della configurazione non riuscito:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3169,13 +3141,13 @@ msgstr ""
 "disabilitato."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Impossibile salvare il file INI predefinito in:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3195,7 +3167,7 @@ msgstr ""
 "  Imposta %(option)s su un ID numerico o impostalo su `auto` o `0` per il binding automatico del proprietario."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3215,7 +3187,7 @@ msgstr ""
 "  Controlla l'impostazione del percorso e assicurati che il file esista ed sia accessibile a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3235,7 +3207,7 @@ msgstr ""
 "  Assicurati che tutti gli ID siano numerici e separati solo da spazi o virgole."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3245,7 +3217,7 @@ msgstr ""
 "%(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3255,7 +3227,7 @@ msgstr ""
 "'%(value)s' usando invece predefinito."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3265,7 +3237,7 @@ msgstr ""
 "(%(value)s) e sarà invece impostato su %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3274,55 +3246,55 @@ msgstr ""
 "%(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Aggiornamento file di configurazione con opzioni rinominate..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Impossibile aggiornare la configurazione. Dovrai aggiornarla manualmente."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "File elenco blocco non trovato:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Impossibile caricare l'elenco dei blocchi dal file:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Impossibile aggiornare il file elenco blocchi:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Lista Blocco utente caricata con voci %s."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Abbiamo trovato un file di blacklist legacy, che verrà rinominato in:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Caricato un elenco di blocchi brani con voci %s."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3330,25 +3302,25 @@ msgstr ""
 "nel codice!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "Nessun file per la gilda %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "Caricamento dei dati della gilda con ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "Un errore OS ha impedito di leggere il file dati della gilda:  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
@@ -3356,7 +3328,7 @@ msgstr ""
 "%(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3364,59 +3336,59 @@ msgstr ""
 " codice!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 "Impossibile salvare i dati specifici della gilda a causa di un errore del "
 "sistema."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 "Impossibile serializzare i dati specifici della gilda a causa di dati non "
 "validi."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Forzare YTDLP per utilizzare l'agente utente:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot utilizzerà i cookie per yt-dlp da:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp userà il tuo server proxy configurato."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD sembra non avere intestazioni..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr "Controllo intestazioni multimediali non riuscito a causa del timeout."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Richiesta HEAD non riuscita per:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "Richiesta di eccezione HEAD: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3426,56 +3398,56 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Informazioni Di Estrazione Ytdl Sanitizzate (non Json):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "L'estrazione di informazioni brano non ha restituito dati."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Chiamato extract_info con: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Impossibile eseguire l'estrazione, il ciclo è chiuso. (Questo è normale in "
 "caso di arresti)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Impossibile continuare l'estrazione, il ciclo dell'evento è chiuso."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL non è valido o non supportato."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Errore di download con URL dello stream"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "Supponendo che il contenuto sia uno stream diretto"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Impossibile trasmettere un URL non valido."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3483,23 +3455,23 @@ msgstr ""
 "spazio."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Chiamato safe_extract_info con:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Impossibile trovare il file multimediale locale."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Manca __input_subject da YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3507,7 +3479,7 @@ msgstr ""
 "evitare questo."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Attenzione, errore di durata per: %(url)s"
@@ -3553,14 +3525,14 @@ msgstr ""
 "Nome voce: %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 "I dati dell'elemento sono mancanti numero di versione, impossibile "
 "deserializzare."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 "I dati dell'elemento hanno il numero di versione sbagliato, non è possibile "
@@ -3595,7 +3567,7 @@ msgstr ""
 "ricerca!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "Impossibile caricare %s"
@@ -3609,7 +3581,7 @@ msgstr ""
 "il tipo: %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Preparazione per l'ingresso:  %r"
@@ -3631,7 +3603,7 @@ msgid "Download already cached at:  %s"
 msgstr "Download già memorizzato in:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3649,7 +3621,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Durata di %(time)s secondi per il file:  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3660,75 +3632,75 @@ msgstr ""
 "funzionare, ma significa che le tue tracce non saranno equalizzate."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Eccezione durante il controllo dei dati di inserimento."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Tentativo di ottenere durata tramite pymediainfo per:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "Impossibile ottenere la durata tramite pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Tentativo di ottenere durata tramite ffprobe per:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "Impossibile individuare ffprobe nel tuo percorso!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe ha restituito qualcosa che non poteva essere utilizzato."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe non può essere eseguito per qualche ragione."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Calcolo del volume medio di:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "Impossibile individuare ffmpeg sul tuo percorso!"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "Impossibile analizzare 'I' nel normalizzare json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "Impossibile analizzare 'LRA' nella normalizzazione json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "Impossibile analizzare 'TP' nel normalizzare json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "Impossibile analizzare 'thresh' nella normalizzazione json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "Impossibile analizzare 'offset' nel normalizzare json."
 
@@ -3772,56 +3744,56 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Download fallito a causa di un errore yt-dlp: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "L'estrazione ha incontrato un'eccezione non gestita."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "Download fallito a causa di un'eccezione non gestita: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Download non riuscito:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Estrazione dei dati per il supporto richiesto non riuscita."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Download completato:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 "StreamPlaylistEntry deserializzato non può trovare il canale con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 "StreamPlaylistEntry deserializzato ha il tipo di canale sbagliato:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "StreamPlaylistEntry deserializzato non può trovare l'autore con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
@@ -3829,7 +3801,7 @@ msgstr ""
 "ricerca!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
@@ -3837,21 +3809,21 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 "Deserializzato LocalFilePlaylistEntry ha il tipo di canale sbagliato:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "Deserialized LocalFilePlaylistEntry non può trovare l'autore con ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3860,7 +3832,7 @@ msgstr ""
 "ricerca!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Durata di %(seconds)s secondi per il file:  %(file)s"
@@ -3970,13 +3942,13 @@ msgstr ""
 "%(file)s  Vecchio: %(old)s  Nuovo: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Errore Argomento Lang:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -3984,7 +3956,7 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4321,67 +4293,67 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Dati decodificati da ffmpeg: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Aggiunta voce stream per URL:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Impossibile estrarre le informazioni"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Questa è una playlist."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 "Le informazioni di immissione sembrano essere un flusso, aggiungendo voce di"
 " flusso..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Tipo di contenuto non valido `%(type)s` per URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 "Ottenuto testo/html per il tipo di contenuto, questo potrebbe essere un "
 "flusso."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Tipo di contenuto discutibile \"%(type)s\" per url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Aggiunta di URLPlaylistEntry per: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Aggiunta di LocalFilePlaylistEntry per: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "Video ignorato dal collegamento composto alla scaletta con ID:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4390,7 +4362,7 @@ msgstr ""
 "URL: %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4399,7 +4371,7 @@ msgstr ""
 "consentito."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4407,40 +4379,40 @@ msgstr ""
 "%s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "Impossibile aggiungere l'elemento"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Articolo: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "Voci saltate %s errate"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Riordina il loop sopra le voci."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Pre-scaricamento traccia successiva:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "nessun dato di durata"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "nessun dato di durata nella voce corrente"
 
@@ -5025,44 +4997,44 @@ msgstr ""
 "(Predefinito: '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Versione:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Apri una nuova istanza di MusicBot. Questo terminale può essere chiuso in "
 "sicurezza!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Caricamento versione MusicBot:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Log aperto:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Modifica della directory di lavoro in:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5073,7 +5045,7 @@ msgstr ""
 " una nuova posizione della directory."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5082,7 +5054,7 @@ msgstr ""
 "Se non hai usato git per clonare il repository, sei fortemente sollecitato."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5091,12 +5063,12 @@ msgstr ""
 "certifi e di uscita."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Ecco l'errore esatto, potrebbe essere un bug."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5105,7 +5077,7 @@ msgstr ""
 "è possibile aprire il sito fallito in Microsoft Edge o IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5114,17 +5086,17 @@ msgstr ""
 "predefinito, tentando invece il certificifi."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Errore di sintassi (modifica rilevata, hai modificato il codice?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Errore di sintassi (questo è un bug, non colpa tua)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5145,14 +5117,14 @@ msgstr ""
 "  o lanciare senza `--no-install-deps` e MusicBot proverà ad installarli per te."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Tentativo di installare automaticamente i pacchetti di dipendenza di "
 "MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5188,12 +5160,12 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, lascia funzionare la speranza di installare dipendenze!"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5202,58 +5174,58 @@ msgstr ""
 "pacchetti. MusicBot deve uscire..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "L'eccezione che ha causato l'errore sopra: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot sta facendo un riavvio morbido..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot sta facendo un riavvio completo..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Errore nell'avvio del bot"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Ciclo dell'evento di chiusura."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Riavvio in %s secondi..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "Tutto fatto."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "OK, stiamo chiudendo!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -5278,12 +5250,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5297,7 +5269,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5365,45 +5337,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -5415,220 +5387,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5647,30 +5619,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5678,18 +5650,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5764,9 +5736,92 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+#~ "La configurazione non ha le credenziali dell'applicazione Spotify, tentando "
+#~ "di utilizzare la modalità ospite."
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "Autenticato con Spotify con successo utilizzando la modalità ospite."
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+#~ "Impossibile avviare il client Spotify usando la modalità ospite. Dettagli: "
+#~ "%s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "La ricerca su YouTube non ha prodotto alcun risultato per:  %(url)s"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/it_IT/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/it_IT/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -816,7 +816,7 @@ msgstr ""
 "riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Le posizioni brano devono essere intere!"
 
@@ -854,28 +854,28 @@ msgid "Local media playback is not enabled."
 msgstr "La riproduzione multimediale locale non è abilitata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "L'URL di Spotify non è valido o non è attualmente supportato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Rilevato un URL Spotify, ma Spotify non è abilitato."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Hai raggiunto il limite di canzone in coda (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "La modalità Karaoke è abilitata, riprova quando è disabilitata!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -885,13 +885,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Questo video non può essere riprodotto. Prova a usare il comando streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -900,7 +900,7 @@ msgstr ""
 " secondi)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -910,13 +910,13 @@ msgstr ""
 "Posizione nella coda: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "La durata del brano supera il limite (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -926,24 +926,24 @@ msgstr ""
 "Posizione in coda: %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "Giocare dopo!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - tempo stimato fino alla riproduzione: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - non può stimare il tempo fino alla riproduzione."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -956,25 +956,25 @@ msgstr ""
 "Nota: FFmpeg può rilasciare il flusso in modo casuale o se si verificano singhiozzi di connessione.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Le playlist in streaming non sono ancora supportate."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "In streaming della traccia `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 "    Cerca con servizio per un certo numero di risultati con la query di "
 "ricerca.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -983,59 +983,59 @@ msgstr ""
 "    Nota: in questo caso sono necessarie le doppie quotazioni.\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Hai raggiunto il limite di elementi della playlist (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 "Specifica una query di ricerca. Usa `help search` per maggiori informazioni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Non puoi cercare più di %(max)s video"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Ricerca video..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "Ricerca fallita a causa di un errore: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "Nessun video trovato."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "Per selezionare un brano, digitare il numero corrispondente."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Risultati della ricerca da %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1044,196 +1044,196 @@ msgstr ""
 "**0**. Annulla"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Scegli un brano"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Aggiunta canzone [%(track)s](%(url)s) alla coda."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Risultato %(number)s di %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "Bene, arrivando a destra!"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Mostra informazioni su ciò che sta attualmente giocando."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "In riproduzione"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Attualmente in streaming:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "In riproduzione:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Aggiunto Da:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Progresso:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Non ci sono brani in coda! Coda qualcosa con un comando di riproduzione."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Dica a MusicBot di unirsi al canale in cui ti trovi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "Non sei connesso alla voce. Prova ad unirti a un canale vocale!"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Connesso a `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr "Rendi MusicBot seguire un utente quando cambiano canali in un server.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "Non più seguendo l'utente `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Ora seguendo l'utente `%(user)s` tra i canali vocali."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot non può seguire un utente che non è un membro del server."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "Seguirà l'utente `%(user)s` tra i canali vocali."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Metti in pausa la riproduzione se una traccia è in riproduzione."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Musica in pausa in `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Il giocatore non sta giocando."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ""
 "Riprende la riproduzione se il giocatore è stato precedentemente in pausa."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Riprendi musica in `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Ripresa coda musicale"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Il giocatore non è in pausa."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Mischia tutte le tracce correnti nella coda."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Mischia tutte le canzoni nella coda."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Rimuove tutti i brani attualmente in coda."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Cancellati tutti i brani dalla coda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Niente nella coda da rimuovere!"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Rimosso `%(track)s` aggiunto da `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Niente trovato nella coda dall'utente `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1242,26 +1242,26 @@ msgstr ""
 "Devi essere colui che l'ha accodata o che ha i permessi di salto istantanei."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numero di voce non valido. Usa il comando coda per trovare le posizioni "
 "della coda."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Voce rimossa `%(track)s` aggiunta da `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Voce rimossa `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1272,23 +1272,23 @@ msgstr ""
 "Se l'opzione LegacySkip è abilitata, il parametro force può essere ignorato.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossibile saltare! Il giocatore non sta giocando!"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "La prossima canzone `%(track)s` è in download, si prega di attendere."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "La prossima canzone verrà riprodotta a breve. Attendere prego."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1297,7 +1297,7 @@ msgstr ""
 "Potresti voler riavviare il bot se non inizia a funzionare."
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1306,28 +1306,28 @@ msgstr ""
 "Potresti voler riavviare il bot se non inizia a funzionare."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "Non hai il permesso di forzare un brano in loop."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Forza saltata `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Non hai il permesso di forzare il salto."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Non hai il permesso di saltare una canzone in loop."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1337,12 +1337,12 @@ msgstr ""
 "Il voto da saltare è stato passato.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " Prossima canzone in arrivo!"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1352,7 +1352,7 @@ msgstr ""
 "Hai bisogno di **%(votes)s** più voto(i) per saltare questa canzone."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1363,25 +1363,25 @@ msgstr ""
 "L'impostazione del volume viene mantenuta fino al riavvio di MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Volume attuale: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` non è un numero valido"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Volume aggiornato da **%(old)d** a **%(new)d"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1391,7 +1391,7 @@ msgstr ""
 "Il volume può essere impostato solo da 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1400,7 +1400,7 @@ msgstr ""
 " 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1411,7 +1411,7 @@ msgstr ""
 "non supporta le regolazioni della velocità.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1420,23 +1420,23 @@ msgstr ""
 "Utilizzare il comando di configurazione per impostare una velocità di riproduzione predefinita."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocità non può essere applicata ai media in streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Devi fornire una velocità da impostare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocità fornita non è valida. Usa un numero compreso tra 0.5 e 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
@@ -1444,12 +1444,12 @@ msgstr ""
 "corrente."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Aggiungi un nuovo alias con argomenti opzionali.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1458,23 +1458,23 @@ msgstr ""
 " il comando aiuto."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opzione non valida per il comando: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Alias ricaricato dal file di configurazione."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Alias salvati nel file di configurazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1484,42 +1484,42 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Devi fornire un alias e un comando all'alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nuovo alias aggiunto. `%(alias)s` è ora un alias di `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Devi fornire un nome alias da rimuovere."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` non esiste."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` è stato rimosso."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Mostra il testo di aiuto su tutte le opzioni di configurazione "
 "mancanti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1528,33 +1528,33 @@ msgstr ""
 "del file di configurazione.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 "    Elenca le opzioni di configurazione disponibili e le loro sezioni.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Ricarica il file options.ini dal disco.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Mostra il testo di aiuto per un'opzione specifica.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Mostra il valore corrente dell'opzione.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Salva il valore corrente nel file delle opzioni.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1563,34 +1563,34 @@ msgstr ""
 "per il file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Reimposta l'opzione al valore predefinito.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Gestisci la configurazione options.ini all'interno di Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configurazione non può usare le menzioni del canale e dell'utente allo "
 "stesso tempo."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*Tutte le opzioni di configurazione sono presenti e contabilizzate!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "Nessuna opzione di configurazione sembra essere cambiata."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1600,7 +1600,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1616,12 +1616,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "Opzioni di configurazione ricaricate dal file con successo!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1631,7 +1631,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1640,18 +1640,18 @@ msgstr ""
 "di fornire una sezione e un nome di opzione validi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'opzione data è ambigua, si prega di fornire un nome di sezione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Devi fornire un nome di sezione e un nome di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1661,27 +1661,27 @@ msgstr ""
 "Le sezioni disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'opzione `%(option)s` non è disponibile."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Questa opzione può essere impostata solo modificando il file di "
 "configurazione."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 "Per impostazione predefinita questa opzione è impostata a: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1695,26 +1695,26 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "L'opzione `%(option)s` non è modificabile. Impossibile salvare sul disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossibile salvare l'opzione: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Opzione salvata con successo: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -1722,7 +1722,7 @@ msgstr ""
 "visualizzato."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1734,7 +1734,7 @@ msgstr ""
 "INI Valore Del File: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1742,19 +1742,19 @@ msgstr ""
 "l'impostazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Devi fornire una sezione, un'opzione e un valore per questo sottocomando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'opzione `%(option)s` non è stata aggiornata!"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1764,7 +1764,7 @@ msgstr ""
 "Per salvare il cambiamento usa `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1772,13 +1772,13 @@ msgstr ""
 "valore predefinito."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'opzione `%(option)s` non è stata ripristinata al predefinito!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1788,19 +1788,19 @@ msgstr ""
 "Per salvare la modifica usa `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Comando obsoleto, usa invece il comando di configurazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "Il comando opzione è deprecato, utilizza invece il comando di "
 "configurazione."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1809,33 +1809,33 @@ msgstr ""
 "Usando l'opzione di aggiornamento scansionerà la cache per modifiche esterne prima di visualizzare i dettagli."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opzione specificata non valida, usa: info, aggiornamento o cancella"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Abilitato"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s giorni"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Illimitato"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1851,24 +1851,24 @@ msgstr ""
 "**Cached Now:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "La cache è stata cancellata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Non riuscito** per eliminare la cache, controlla i log per ulteriori "
 "informazioni..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "Nessuna cache trovata da cancellare."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1877,12 +1877,12 @@ msgstr ""
 "Numero di pagina opzionale mostra le voci successive nella coda.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "L'argomento pagina coda deve essere un numero intero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1892,12 +1892,12 @@ msgstr ""
 "Ci sono ** pagine%(total)s**."
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(durata sconosciuta)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1909,7 +1909,7 @@ msgstr ""
 "Progresso: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1923,12 +1923,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Brani in coda"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1937,7 +1937,7 @@ msgstr ""
 "Se il problema persiste, file una segnalazione di bug."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1948,39 +1948,39 @@ msgstr ""
 "Questo comando può essere lento se vengono forniti intervalli più grandi.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Parametri non validi. Si prega di fornire un numero di messaggi da cercare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossibile usare lo spurgo sul canale DM privato."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Ripuliti %(number)s messaggio."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Il bot non ha i permessi per gestire i messaggi."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Ricarica i singoli URL di una scaletta su un file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "L'URL fornito non era un URL valido."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1990,18 +1990,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Questa non sembra essere una playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Ecco il dump della playlist per:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2010,19 +2010,19 @@ msgstr ""
 "Questo comando è deprecato a favore della Modalità Sviluppatore nei client Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Il tuo ID utente è `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "L'ID utente per `%(username)s` è `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2033,25 +2033,25 @@ msgstr ""
 "Questo comando è deprecato a favore dell'utilizzo della modalità Sviluppatore nei client Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Categorie valide: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Ecco gli ID che hai richiesto:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 "Ottieni un elenco dei tuoi permessi, o i permessi dell'utente menzionato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2060,12 +2060,12 @@ msgstr ""
 " e riprovare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossibile determinare l'utente discord. Riprova."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2079,7 +2079,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2093,65 +2093,65 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Mostra le opzioni dei permessi dei gruppi caricati e dell'elenco.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Ricarica i permessi dal file permissions.ini.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    Aggiungi un nuovo gruppo con valori predefiniti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Rimuovi gruppo esistente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Mostra il testo di aiuto per l'opzione di autorizzazione.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 "    Mostra il valore dei permessi per un determinato gruppo e permesso.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Salva gruppo di autorizzazioni su file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Imposta il valore di autorizzazione per il gruppo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Gestisci la configurazione permissions.ini dall'interno di discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Le autorizzazioni non possono usare le menzioni del canale e dell'utente "
 "allo stesso tempo."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "Permessi ricaricati dal file con successo!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2161,7 +2161,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2175,25 +2175,25 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Devi fornire un nome di gruppo o di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Devi fornire un gruppo, un'opzione e un valore da impostare per questo "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Il sottocomando %(option)s richiede un nome di gruppo e di permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2203,20 +2203,20 @@ msgstr ""
 "I gruppi disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Il permesso `%(option)s` non è disponibile."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Questa autorizzazione può essere impostata solo modificando il file dei "
 "permessi."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
@@ -2224,7 +2224,7 @@ msgstr ""
 "`%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2238,13 +2238,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossibile aggiungere il gruppo `%(group)s` che esiste già."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2256,12 +2256,12 @@ msgstr ""
 "Assicurati di salvare il nuovo gruppo con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Impossibile rimuovere il gruppo integrato."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2271,24 +2271,24 @@ msgstr ""
 "Assicurati di salvare questa modifica con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Il gruppo proprietario non è modificabile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossibile salvare il gruppo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Salvato con successo il gruppo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2300,13 +2300,13 @@ msgstr ""
 "INI Valore Del File: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Il permesso `%(option)s` non è stato aggiornato!"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2316,7 +2316,7 @@ msgstr ""
 "Per salvare il cambiamento usa `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2325,7 +2325,7 @@ msgstr ""
 "Nota: l'API può limitare le modifiche del nome a due volte all'ora."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2334,7 +2334,7 @@ msgstr ""
 "Ricorda che i cambiamenti di nome sono limitati a due volte all'ora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2344,23 +2344,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Imposta il nome utente del bot su `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Cambia il soprannome di MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Impossibile cambiare il soprannome: nessun permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2370,23 +2370,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Imposta il nickname del bot su `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Imposta un prefisso di comando per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Pulisce il prefisso del comando per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2395,25 +2395,25 @@ msgstr ""
 "L'opzione AbilitaPrefixPerGuild deve essere abilitata prima."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Le emoji personalizzate devono provenire da questo server per essere "
 "utilizzate come prefisso."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Il prefisso del comando del server è cancellato."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Il prefisso del comando del server è ora:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2422,39 +2422,39 @@ msgstr ""
 "Usa il comando di configurazione per aggiornare il prefisso."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Mostra i codici di lingua disponibili da usare.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    Imposta la lingua desiderata per questo server.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Reimposta la lingua del server alla lingua predefinita del bot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "Gestisce la lingua utilizzata per i messaggi nel server di chiamata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Questo comando può essere usato solo nelle gilde."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sottocomando fornito non valido. Utilizzare il comando help per ulteriori "
 "informazioni."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2468,25 +2468,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Impossibile impostare la lingua su `%(locale)s` non è disponibile."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Lingua per questo server impostata a: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "La lingua per questo server è stata reimpostata a: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2495,12 +2495,12 @@ msgstr ""
 "Allegare un file e omettere il parametro url funziona.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "È necessario fornire un URL o allegare un file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2510,62 +2510,62 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "Cambiato l'avatar del bot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Forza MusicBot a disconnettersi dal server discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Disconnesso dal server `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Disconnesso un client vocale senza lettore? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Attualmente non connesso al server `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Tentativo di ricaricare senza riavviare il processo. L'opzione "
 "predefinita.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 "    Tentativo di riavviare l'intero processo MusicBot, ricaricando tutto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Riavvio completo, ma tenta di aggiornare i pacchetti pip prima del "
 "riavvio.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Riavvio completo, ma aggiorna il codice sorgente di MusicBot con git "
 "prima.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2574,7 +2574,7 @@ msgstr ""
 "di riavviare completamente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2587,26 +2587,26 @@ msgstr ""
 "Se hai un service manager, ti consigliamo di usarlo invece di questo comando per il riavvio.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Opzione fornita non valida, usa una di: soft, full, upgrade, uppip, or upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Riavvio dell'istanza corrente..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Riavvio del processo robot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2615,30 +2615,30 @@ msgstr ""
 "bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 "%(emoji)s cercherà di aggiornare il codice bot con git e riavviare il bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Cercherà di aggiornare tutto e riavviare il bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Disconnetti da tutti i canali vocali e chiudi il processo MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Lascia il server discord dato dal nome o dal server ID."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2647,12 +2647,12 @@ msgstr ""
 "sono sensibili all'uso di maiuscolo/minuscolo, quindi l'uso di un numero ID è più affidabile.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Devi fornire un ID o un nome."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nessuna gilda trovata con l'ID o il nome `%(input)s`"
@@ -2664,13 +2664,13 @@ msgid "Unknown"
 msgstr "Sconosciuto"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Lasciato la gilda: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2679,38 +2679,38 @@ msgstr ""
 "Può essere usato per individuare manualmente gli eventi nel file di registro di MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Breakpoint loggato con ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Visualizza i tipi più comuni riportati da objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Visualizza output objgraph.show_growth() limitato.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Visualizza i tipi più comuni di oggetti fuoriusciti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Visualizza i tipestat degli oggetti fuoriusciti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Valuta la funzione e gli argomenti dati su objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2721,12 +2721,12 @@ msgstr ""
 "Poiché questo metodo valuta il codice arbitrario, è considerato pericoloso come il comando di debug.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossibile importare `objgraph`, è installato?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2751,7 +2751,7 @@ msgstr ""
 "Il pericolo di questo comando non può essere sottostimato. Non usarlo o dargli accesso se non capisci i rischi!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2767,7 +2767,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2776,23 +2776,23 @@ msgstr ""
 "L'output viene utilizzato per aggiornare le pagine di GitHub ed è quindi inadatto per un uso di riferimento normale."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Il sottocomando deve essere uno di: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Rende i file INI predefiniti."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Salvato il file INI richiesto su disco. Vai a controllarlo"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2801,50 +2801,50 @@ msgstr ""
 "MusicBot o dipendenze.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Impossibile individuare git eseguibile."
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Nessun aggiornamento nel ramo `%(branch)s` remoto."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nuovi commit sono disponibili in `%(branch)s` branch remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "Errore durante il controllo, vedere i registri per i dettagli."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Aggiorna per `%(name)s` alla versione: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "Nessun aggiornamento per le dipendenze trovate."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "Ci sono aggiornamenti per MusicBot disponibili per il download."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot è completamente aggiornato!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2864,18 +2864,18 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "Mostra l' uptime di MusicBot o il tempo dall' ultimo avvio / riavvio."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s è stato online per `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2883,35 +2883,35 @@ msgstr ""
 " vocali connessi."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "Nessun client vocale connesso.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Mostra latenza API e latenza vocale se MusicBot è connesso."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Mostra il numero di versione di MusicBot nella chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2921,18 +2921,18 @@ msgstr ""
 "Versione attuale: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 "    Aggiornare il file cookies.txt utilizzando un allegato cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Abilita o disabilita il file cookies.txt senza eliminarlo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2957,29 +2957,29 @@ msgstr ""
 "  se non si capisce come evitare i rischi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookie già abilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "I cookie devono essere caricati per essere abilitati. (File dei cookie)."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Impossibile abilitare i cookie a causa di errore:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "I cookie sono stati abilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2989,12 +2989,12 @@ msgstr ""
 "I cookie sono temporaneamente disabilitati e saranno riattivati al prossimo riavvio."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "I cookie sono stati disabilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -3002,52 +3002,52 @@ msgstr ""
 "di un file di cookie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Errore nel scaricare il file dei cookie da discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossibile salvare i cookie sul disco:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookie caricati e abilitati."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "Non puoi usare questo bot in messaggi privati."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 "Questo comando non è consentito per il tuo gruppo di permessi:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Questo comando richiede di essere in un canale vocale."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Comando:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Errore Di Eccezione"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3057,17 +3057,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "Nessuna descrizione fornita.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "Nessun utilizzo dato."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3081,13 +3081,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Lasciare il canale vocale %(channel)s a causa di inattività."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3212,7 +3212,7 @@ msgstr ""
 "Usato solo quando BindToChannels manca un ID per un server."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3293,14 +3293,14 @@ msgstr ""
 "È possibile impostare questo da 0 a 1, o 0% a 100%."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 "Permetti a MusicBot di mantenere i media scaricati o eliminarli subito."
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3310,7 +3310,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3319,7 +3319,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3333,7 +3333,7 @@ msgid "Mention the user who added the song when it is played."
 msgstr "Menziona l'utente che ha aggiunto il brano quando viene riprodotto."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3342,7 +3342,7 @@ msgstr ""
 "accessibile all'avvio del bot."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3351,12 +3351,12 @@ msgstr ""
 "automatica quando la coda è vuota."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "Mischia le tracce della scaletta automatica prima di riprodurle."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3365,7 +3365,7 @@ msgstr ""
 "Questo vale solo per il brano in riproduzione corrente se è stato aggiunto dalla scaletta automatica."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3424,7 +3424,7 @@ msgstr ""
 "Attualmente questa opzione non si applica alla playlist automatica o ai brani aggiunti a una coda vuota."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3453,7 +3453,7 @@ msgstr ""
 " {p0_url}      = L'URL della traccia per la traccia in riproduzione."
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 "Se abilitata, i messaggi di stato segnaleranno informazioni sui giocatori in"
@@ -3462,7 +3462,7 @@ msgstr ""
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3501,7 +3501,7 @@ msgstr ""
 "elencare la coda."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3510,7 +3510,7 @@ msgstr ""
 "dalla scaletta automatica."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 "Visualizza le impostazioni di configurazione di MusicBot nei log all'avvio."
@@ -3526,7 +3526,7 @@ msgstr ""
 " salti forza."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3558,14 +3558,14 @@ msgid "Completely remove the footer from embeds."
 msgstr "Rimuovere completamente il piè di pagina dagli incorporati."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 "MusicBot si assorderà automaticamente quando si entra in un canale vocale."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3576,7 +3576,7 @@ msgstr ""
 "Gli ascoltatori sono membri del canale, esclusi i bot, che non sono assordati."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3585,7 +3585,7 @@ msgstr ""
 "È possibile impostare questo a un numero di secondi o frase come: 4 ore"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3594,7 +3594,7 @@ msgstr ""
 "brano è vuota."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3642,7 +3642,7 @@ msgstr ""
 "riproduzione per un brano per membro."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3655,7 +3655,7 @@ msgstr ""
 "Per impostazione predefinita questo è disabilitato."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3667,7 +3667,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3695,7 +3695,7 @@ msgstr ""
 "comandi di riproduzione."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3706,7 +3706,7 @@ msgstr ""
 "Lascia vuoto per disabilitare."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3723,14 +3723,14 @@ msgstr ""
 "Lascia vuoto per usare le stringhe UA predefinite generate dinamicamente."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Attiva/disattiva la funzione lista blocchi utente, senza svuotare la lista "
 "blocchi."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3738,14 +3738,14 @@ msgstr ""
 "uno per riga."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Abilita la funzione della lista dei brani, senza svuotare la lista dei "
 "blocchi."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3754,7 +3754,7 @@ msgstr ""
 "Qualsiasi titolo del brano o URL che contiene qualsiasi riga nella lista sarà bloccato."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3763,7 +3763,7 @@ msgstr ""
 "Ogni file deve contenere un elenco di URL o termini riproducibili, una traccia per riga."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3777,7 +3777,7 @@ msgstr ""
 "Mappe a:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3786,7 +3786,7 @@ msgstr ""
 " lungo e breve termine per la riproduzione."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3798,7 +3798,7 @@ msgstr ""
 "Set to 0 to disable. Maximum allowed number is %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3811,7 +3811,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3841,7 +3841,7 @@ msgstr ""
 "  Utilizzare le opzioni di esempio come modello o copiarlo dal repository."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3860,7 +3860,7 @@ msgstr ""
 "  Assicurati che il percorso configurato sia un percorso per una cartella / directory."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3882,7 +3882,7 @@ msgstr ""
 "  Doppio controllo l'impostazione è valida, percorso directory accessibile."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3902,7 +3902,7 @@ msgstr ""
 "  Imposta l'opzione di configurazione Token o imposta la variabile di ambiente %(env_var)s con un token App."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3923,7 +3923,7 @@ msgstr ""
 "  Imposta manualmente l'opzione di configurazione 'OwnerID' o riprova più tardi."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3942,7 +3942,7 @@ msgstr ""
 "  Non utilizzare il Bot o l'App ID nel campo 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3964,7 +3964,7 @@ msgstr ""
 "  Verifica che la cartella di configurazione e i file esistano e possono essere letti da MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3988,7 +3988,7 @@ msgstr ""
 "  Copiare il file di esempio dal repo se tutto il resto fallisce."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4008,7 +4008,7 @@ msgstr ""
 "  Imposta %(option)s su un ID numerico o impostalo su `auto` o `0` per il binding automatico del proprietario."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4028,7 +4028,7 @@ msgstr ""
 "  Controlla l'impostazione del percorso e assicurati che il file esista ed sia accessibile a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4048,32 +4048,32 @@ msgstr ""
 "  Assicurati che tutti gli ID siano numerici e separati solo da spazi o virgole."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD sembra non avere intestazioni..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "L'estrazione di informazioni brano non ha restituito dati."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Impossibile continuare l'estrazione, il ciclo dell'evento è chiuso."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL non è valido o non supportato."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Impossibile trasmettere un URL non valido."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Impossibile trovare il file multimediale locale."
 
@@ -4429,28 +4429,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4478,7 +4478,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4532,7 +4532,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4540,7 +4540,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4550,7 +4550,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4619,7 +4619,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4633,7 +4633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4642,7 +4642,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4656,7 +4656,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4664,7 +4664,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4673,26 +4673,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4704,28 +4704,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4736,25 +4736,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4763,7 +4763,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/it_IT/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/it_IT/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -41,29 +41,29 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Il membro non è abilitato alla voce e non può usare questo comando."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Non puoi usare questo comando quando non è nel canale vocale."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot non ha il permesso di connettersi nel canale: `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot non ha il permesso di parlare nel canale: `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -72,7 +72,7 @@ msgstr ""
 "Riprova più tardi, o riavvia il bot se continua."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -80,17 +80,17 @@ msgstr ""
 "riavviare?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot non ha il permesso di parlare."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot non può richiedere di parlare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -99,12 +99,12 @@ msgstr ""
 "Usa il comando summon per portare il bot sul tuo canale vocale."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Qualcosa è sbagliato, non abbiamo ottenuto il VoiceClient."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -113,7 +113,7 @@ msgstr ""
 " voce!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
@@ -121,26 +121,26 @@ msgstr ""
 "%(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "Ora giocando in %(channel)s: `%(title)s` aggiunto da %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 "Ora giocando automaticamente ha aggiunto la voce `%(title)s` in %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr "Saltando le canzoni aggiunte da %(user)s come non sono nella voce!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -152,12 +152,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Provato a inviare un oggetto di risposta non valido."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -180,13 +180,13 @@ msgstr ""
 "  Controlla lo stato dell'API sul sito ufficiale: discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "La canzone richiesta `%(subject)s` è bloccata dalla lista dei brani."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -195,12 +195,12 @@ msgstr ""
 "Questo comando verrà rimosso in una versione futura, sostituito dai comandi della playlist automatica."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -208,18 +208,18 @@ msgstr ""
 "disponibili.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Alias per questo comando:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "`%(alias)s` alias di `%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -230,7 +230,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -242,12 +242,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Comando inesistente"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -257,7 +257,7 @@ msgstr ""
 "Per un elenco di tutti i comandi, esegui: %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -279,22 +279,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Blocca un utente menzionato."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Sblocca un utente menzionato."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Mostra lo stato del blocco di un utente menzionato."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -303,45 +303,45 @@ msgstr ""
 "agli utenti bloccati è vietato utilizzare tutti i comandi del bot.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 "È necessario menzionare un utente o fornire il loro numero di identità."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Sottocomando fornito non valido. Usa `help blockuser` per esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot non ha trovato gli utenti specificati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Il proprietario non può essere aggiunto all'elenco dei blocchi."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "La lista dei blocchi utente è attualmente abilitata."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "La lista dei blocchi utente è attualmente disabilitata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Non è possibile aggiungere gli utenti elencati, sono già aggiunti."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -351,24 +351,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "Nessuno di questi utenti è nella blacklist."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "Utente: `%(user)s` non è bloccato.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "Utente: `%(user)s` è bloccato.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -380,7 +380,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -390,7 +390,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -407,27 +407,27 @@ msgstr ""
 "Questo significa che l'aggiunta di 'Pie' corrisponderà a 'Cherry Pie' ma non a 'piecrust' nei controlli.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Devi fornire un oggetto del brano se nessuna canzone è attualmente in "
 "riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Sottocomando fornito non valido. Usa `help blocksong` per esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "L'oggetto `%(subject)s` è già nella lista dei brani."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -437,12 +437,12 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "L'oggetto non è nell'elenco dei brani e non può essere rimosso."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -452,7 +452,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -461,12 +461,12 @@ msgstr ""
 "su/dalla playlist corrente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Aggiunge l'intera coda alla playlist delle gilde.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -475,69 +475,69 @@ msgstr ""
 "playlist automatica della gilda.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Sottocomando fornito non valido. Usa `help autoplaylist` per esempi di "
 "utilizzo."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Il link del brano fornito non è valido"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "La coda è vuota. Aggiungi alcuni brani con un comando di riproduzione!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "Tutte le canzoni nella coda sono già nella playlist automatica."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "Aggiunti brani %(number)d alla playlist automatica."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "Aggiunto `%(url)s` alla playlist automatica."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Questo brano è già nella playlist automatica."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "Rimosso `%(url)s` dalla playlist automatica."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Questa canzone non è ancora nella playlist automatica."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Caricato una nuova copia della playlist: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "È necessario fornire un nome file playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -546,14 +546,14 @@ msgstr ""
 "Questa playlist è nuova, devi aggiungere brani per salvarla sul disco!"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 "La playlist per questo server è stata aggiornata a: `%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
@@ -561,7 +561,7 @@ msgstr ""
 " altro server."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -571,7 +571,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -580,28 +580,28 @@ msgstr ""
 "Gruppi con BypassKaraokeMode controllano quali membri sono membri di Karaoke.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\Nla modalità{OK HAND SIGN} Karaoke è ora abilitata."
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\Nla modalità{OK HAND SIGN} Karaoke è ora disabilitata."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Non sei autorizzato a richiedere playlist"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "La playlist ha troppe voci (%(songs)s ma il massimo è %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -613,13 +613,13 @@ msgstr ""
 "Il limite è %(max)s per il tuo gruppo."
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 "Il bot è stato precedentemente in pausa, riprendendo la riproduzione ora."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -636,7 +636,7 @@ msgstr ""
 "MusicBot supporta anche gli URI e gli URL di Spotify, ma l'audio viene recuperato da YouTube indipendentemente da te.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -645,13 +645,13 @@ msgstr ""
 "aggiungerle alla coda.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "Gli elementi della playlist mischiati nella coda da `%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -660,7 +660,7 @@ msgstr ""
 "Leggi l'aiuto per il comando play per informazioni sugli input supportati.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -669,7 +669,7 @@ msgstr ""
 "Leggi l'aiuto per il comando di riproduzione per informazioni sugli input supportati.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -682,36 +682,36 @@ msgstr ""
 "A causa delle specifiche del codec in ffmpeg, questo potrebbe non essere accurato.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Impossibile usare la ricerca se non c'è niente di giocare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Impossibile usare la ricerca sulla traccia corrente, ha una durata "
 "sconosciuta."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "La ricerca non è supportata per gli streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 "Impossibile usare la ricerca senza un tempo per posizionare la riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Impossibile convertire `%(input)s` in un tempo valido in secondi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -721,7 +721,7 @@ msgstr ""
 "corrente con una lunghezza di `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -730,7 +730,7 @@ msgstr ""
 "corrente."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -741,66 +741,66 @@ msgstr ""
 "Se non viene fornita alcuna opzione e il brano è già ripetuto, la ripetizione sarà disattivata.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 "Nessun brano è attualmente in riproduzione. Riproduci qualcosa con un "
 "comando di riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Sottocomando non valido. Usa il comando `help repeat` per gli esempi di "
 "utilizzo."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "La scaletta ora si ripete."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "La scaletta non si ripete più."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "Il giocatore passerà ora alla canzone corrente."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "Il giocatore non passerà più al brano corrente."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "Il giocatore sta già caricando una canzone!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Il giocatore non si sta caricando."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "La canzone non si ripete più."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "La canzone si sta ripetendo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    Sposta il brano in posizione FROM alla posizione\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -809,24 +809,24 @@ msgstr ""
 "Usa il comando coda per trovare i numeri di posizione della traccia.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 "Non ci sono brani in coda. Riproduci qualcosa con un comando di "
 "riproduzione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Le posizioni brano devono essere intere!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Hai dato una posizione fuori dalla dimensione della playlist!"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -835,7 +835,7 @@ msgstr ""
 "%(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -849,33 +849,33 @@ msgstr ""
 "Vuoi mettere in coda anche la playlist?"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "La riproduzione multimediale locale non è abilitata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "L'URL di Spotify non è valido o non è attualmente supportato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Rilevato un URL Spotify, ma Spotify non è abilitato."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Hai raggiunto il limite di canzone in coda (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "La modalità Karaoke è abilitata, riprova quando è disabilitata!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -885,16 +885,10 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Questo video non può essere riprodotto. Prova a usare il comando streaming."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "La ricerca su YouTube non ha prodotto alcun risultato per:  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1077,7 +1071,7 @@ msgid "Show information on what is currently playing."
 msgstr "Mostra informazioni su ciò che sta attualmente giocando."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1114,7 +1108,7 @@ msgstr "Progresso:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Non ci sono brani in coda! Coda qualcosa con un comando di riproduzione."
@@ -1221,38 +1215,25 @@ msgstr "Rimuove tutti i brani attualmente in coda."
 msgid "Cleared all songs from the queue."
 msgstr "Cancellati tutti i brani dalla coda."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Rimuovi un brano dalla coda, opzionalmente alla posizione della coda data.\n"
-"Se la posizione viene omessa, il brano alla fine della coda viene rimosso.\n"
-"Usa il comando coda per trovare il numero di posizione della tua traccia.\n"
-"Tuttavia, le posizioni di tutte le canzoni sono cambiate quando una nuova canzone inizia a riprodurre.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Niente nella coda da rimuovere!"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Rimosso `%(track)s` aggiunto da `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Niente trovato nella coda dall'utente `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1261,26 +1242,26 @@ msgstr ""
 "Devi essere colui che l'ha accodata o che ha i permessi di salto istantanei."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Numero di voce non valido. Usa il comando coda per trovare le posizioni "
 "della coda."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Voce rimossa `%(track)s` aggiunta da `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Voce rimossa `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1291,23 +1272,23 @@ msgstr ""
 "Se l'opzione LegacySkip è abilitata, il parametro force può essere ignorato.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Impossibile saltare! Il giocatore non sta giocando!"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "La prossima canzone `%(track)s` è in download, si prega di attendere."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "La prossima canzone verrà riprodotta a breve. Attendere prego."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1316,7 +1297,7 @@ msgstr ""
 "Potresti voler riavviare il bot se non inizia a funzionare."
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1325,28 +1306,28 @@ msgstr ""
 "Potresti voler riavviare il bot se non inizia a funzionare."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "Non hai il permesso di forzare un brano in loop."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Forza saltata `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Non hai il permesso di forzare il salto."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Non hai il permesso di saltare una canzone in loop."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1356,12 +1337,12 @@ msgstr ""
 "Il voto da saltare è stato passato.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " Prossima canzone in arrivo!"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1371,7 +1352,7 @@ msgstr ""
 "Hai bisogno di **%(votes)s** più voto(i) per saltare questa canzone."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1382,25 +1363,25 @@ msgstr ""
 "L'impostazione del volume viene mantenuta fino al riavvio di MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Volume attuale: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` non è un numero valido"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Volume aggiornato da **%(old)d** a **%(new)d"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1410,7 +1391,7 @@ msgstr ""
 "Il volume può essere impostato solo da 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1419,7 +1400,7 @@ msgstr ""
 " 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1430,7 +1411,7 @@ msgstr ""
 "non supporta le regolazioni della velocità.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1439,23 +1420,23 @@ msgstr ""
 "Utilizzare il comando di configurazione per impostare una velocità di riproduzione predefinita."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "La velocità non può essere applicata ai media in streaming."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Devi fornire una velocità da impostare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "La velocità fornita non è valida. Usa un numero compreso tra 0.5 e 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
@@ -1463,12 +1444,12 @@ msgstr ""
 "corrente."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Aggiungi un nuovo alias con argomenti opzionali.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1477,23 +1458,23 @@ msgstr ""
 " il comando aiuto."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Opzione non valida per il comando: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Alias ricaricato dal file di configurazione."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Alias salvati nel file di configurazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1503,42 +1484,42 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Devi fornire un alias e un comando all'alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nuovo alias aggiunto. `%(alias)s` è ora un alias di `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Devi fornire un nome alias da rimuovere."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "L'alias `%(alias)s` non esiste."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` è stato rimosso."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Mostra il testo di aiuto su tutte le opzioni di configurazione "
 "mancanti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1547,33 +1528,33 @@ msgstr ""
 "del file di configurazione.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 "    Elenca le opzioni di configurazione disponibili e le loro sezioni.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Ricarica il file options.ini dal disco.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Mostra il testo di aiuto per un'opzione specifica.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Mostra il valore corrente dell'opzione.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Salva il valore corrente nel file delle opzioni.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1582,34 +1563,34 @@ msgstr ""
 "per il file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Reimposta l'opzione al valore predefinito.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Gestisci la configurazione options.ini all'interno di Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "La configurazione non può usare le menzioni del canale e dell'utente allo "
 "stesso tempo."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*Tutte le opzioni di configurazione sono presenti e contabilizzate!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "Nessuna opzione di configurazione sembra essere cambiata."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1619,7 +1600,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1635,12 +1616,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "Opzioni di configurazione ricaricate dal file con successo!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1650,7 +1631,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1659,18 +1640,18 @@ msgstr ""
 "di fornire una sezione e un nome di opzione validi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "L'opzione data è ambigua, si prega di fornire un nome di sezione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Devi fornire un nome di sezione e un nome di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1680,27 +1661,27 @@ msgstr ""
 "Le sezioni disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "L'opzione `%(option)s` non è disponibile."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Questa opzione può essere impostata solo modificando il file di "
 "configurazione."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 "Per impostazione predefinita questa opzione è impostata a: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1714,26 +1695,26 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "L'opzione `%(option)s` non è modificabile. Impossibile salvare sul disco."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Impossibile salvare l'opzione: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Opzione salvata con successo: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -1741,7 +1722,7 @@ msgstr ""
 "visualizzato."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1753,7 +1734,7 @@ msgstr ""
 "INI Valore Del File: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1761,19 +1742,19 @@ msgstr ""
 "l'impostazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Devi fornire una sezione, un'opzione e un valore per questo sottocomando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "L'opzione `%(option)s` non è stata aggiornata!"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1783,7 +1764,7 @@ msgstr ""
 "Per salvare il cambiamento usa `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1791,13 +1772,13 @@ msgstr ""
 "valore predefinito."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "L'opzione `%(option)s` non è stata ripristinata al predefinito!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1807,19 +1788,19 @@ msgstr ""
 "Per salvare la modifica usa `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Comando obsoleto, usa invece il comando di configurazione."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 "Il comando opzione è deprecato, utilizza invece il comando di "
 "configurazione."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1828,33 +1809,33 @@ msgstr ""
 "Usando l'opzione di aggiornamento scansionerà la cache per modifiche esterne prima di visualizzare i dettagli."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Opzione specificata non valida, usa: info, aggiornamento o cancella"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Abilitato"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s giorni"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Illimitato"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1870,24 +1851,24 @@ msgstr ""
 "**Cached Now:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "La cache è stata cancellata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Non riuscito** per eliminare la cache, controlla i log per ulteriori "
 "informazioni..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "Nessuna cache trovata da cancellare."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1896,12 +1877,12 @@ msgstr ""
 "Numero di pagina opzionale mostra le voci successive nella coda.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "L'argomento pagina coda deve essere un numero intero."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1911,12 +1892,12 @@ msgstr ""
 "Ci sono ** pagine%(total)s**."
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(durata sconosciuta)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1928,7 +1909,7 @@ msgstr ""
 "Progresso: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1942,12 +1923,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Brani in coda"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1956,7 +1937,7 @@ msgstr ""
 "Se il problema persiste, file una segnalazione di bug."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1967,39 +1948,39 @@ msgstr ""
 "Questo comando può essere lento se vengono forniti intervalli più grandi.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Parametri non validi. Si prega di fornire un numero di messaggi da cercare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Impossibile usare lo spurgo sul canale DM privato."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Ripuliti %(number)s messaggio."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Il bot non ha i permessi per gestire i messaggi."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Ricarica i singoli URL di una scaletta su un file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "L'URL fornito non era un URL valido."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2009,18 +1990,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Questa non sembra essere una playlist."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Ecco il dump della playlist per:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2029,19 +2010,19 @@ msgstr ""
 "Questo comando è deprecato a favore della Modalità Sviluppatore nei client Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Il tuo ID utente è `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "L'ID utente per `%(username)s` è `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2052,25 +2033,25 @@ msgstr ""
 "Questo comando è deprecato a favore dell'utilizzo della modalità Sviluppatore nei client Discord.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Categorie valide: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Ecco gli ID che hai richiesto:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 "Ottieni un elenco dei tuoi permessi, o i permessi dell'utente menzionato."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2079,12 +2060,12 @@ msgstr ""
 " e riprovare."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Impossibile determinare l'utente discord. Riprova."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2098,7 +2079,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2112,65 +2093,65 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Mostra le opzioni dei permessi dei gruppi caricati e dell'elenco.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Ricarica i permessi dal file permissions.ini.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    Aggiungi un nuovo gruppo con valori predefiniti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Rimuovi gruppo esistente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Mostra il testo di aiuto per l'opzione di autorizzazione.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 "    Mostra il valore dei permessi per un determinato gruppo e permesso.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Salva gruppo di autorizzazioni su file.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Imposta il valore di autorizzazione per il gruppo.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Gestisci la configurazione permissions.ini dall'interno di discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Le autorizzazioni non possono usare le menzioni del canale e dell'utente "
 "allo stesso tempo."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "Permessi ricaricati dal file con successo!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2180,7 +2161,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2194,25 +2175,25 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Devi fornire un nome di gruppo o di opzione per questo comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 "Devi fornire un gruppo, un'opzione e un valore da impostare per questo "
 "comando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Il sottocomando %(option)s richiede un nome di gruppo e di permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2222,20 +2203,20 @@ msgstr ""
 "I gruppi disponibili sono:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Il permesso `%(option)s` non è disponibile."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Questa autorizzazione può essere impostata solo modificando il file dei "
 "permessi."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
@@ -2243,7 +2224,7 @@ msgstr ""
 "`%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2257,13 +2238,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Impossibile aggiungere il gruppo `%(group)s` che esiste già."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2275,12 +2256,12 @@ msgstr ""
 "Assicurati di salvare il nuovo gruppo con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Impossibile rimuovere il gruppo integrato."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2290,24 +2271,24 @@ msgstr ""
 "Assicurati di salvare questa modifica con: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Il gruppo proprietario non è modificabile."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Impossibile salvare il gruppo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Salvato con successo il gruppo: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2319,13 +2300,13 @@ msgstr ""
 "INI Valore Del File: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Il permesso `%(option)s` non è stato aggiornato!"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2335,7 +2316,7 @@ msgstr ""
 "Per salvare il cambiamento usa `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2344,7 +2325,7 @@ msgstr ""
 "Nota: l'API può limitare le modifiche del nome a due volte all'ora."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2353,7 +2334,7 @@ msgstr ""
 "Ricorda che i cambiamenti di nome sono limitati a due volte all'ora.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2363,23 +2344,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Imposta il nome utente del bot su `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Cambia il soprannome di MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Impossibile cambiare il soprannome: nessun permesso."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2389,23 +2370,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Imposta il nickname del bot su `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Imposta un prefisso di comando per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Pulisce il prefisso del comando per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2414,25 +2395,25 @@ msgstr ""
 "L'opzione AbilitaPrefixPerGuild deve essere abilitata prima."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Le emoji personalizzate devono provenire da questo server per essere "
 "utilizzate come prefisso."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Il prefisso del comando del server è cancellato."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Il prefisso del comando del server è ora:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2441,39 +2422,39 @@ msgstr ""
 "Usa il comando di configurazione per aggiornare il prefisso."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Mostra i codici di lingua disponibili da usare.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    Imposta la lingua desiderata per questo server.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Reimposta la lingua del server alla lingua predefinita del bot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "Gestisce la lingua utilizzata per i messaggi nel server di chiamata."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Questo comando può essere usato solo nelle gilde."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Sottocomando fornito non valido. Utilizzare il comando help per ulteriori "
 "informazioni."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2487,25 +2468,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Impossibile impostare la lingua su `%(locale)s` non è disponibile."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Lingua per questo server impostata a: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "La lingua per questo server è stata reimpostata a: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2514,12 +2495,12 @@ msgstr ""
 "Allegare un file e omettere il parametro url funziona.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "È necessario fornire un URL o allegare un file."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2529,62 +2510,62 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "Cambiato l'avatar del bot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Forza MusicBot a disconnettersi dal server discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Disconnesso dal server `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Disconnesso un client vocale senza lettore? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Attualmente non connesso al server `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Tentativo di ricaricare senza riavviare il processo. L'opzione "
 "predefinita.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 "    Tentativo di riavviare l'intero processo MusicBot, ricaricando tutto.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Riavvio completo, ma tenta di aggiornare i pacchetti pip prima del "
 "riavvio.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Riavvio completo, ma aggiorna il codice sorgente di MusicBot con git "
 "prima.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2593,7 +2574,7 @@ msgstr ""
 "di riavviare completamente.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2606,26 +2587,26 @@ msgstr ""
 "Se hai un service manager, ti consigliamo di usarlo invece di questo comando per il riavvio.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "Opzione fornita non valida, usa una di: soft, full, upgrade, uppip, or upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Riavvio dell'istanza corrente..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Riavvio del processo robot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2634,30 +2615,30 @@ msgstr ""
 "bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 "%(emoji)s cercherà di aggiornare il codice bot con git e riavviare il bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Cercherà di aggiornare tutto e riavviare il bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Disconnetti da tutti i canali vocali e chiudi il processo MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Lascia il server discord dato dal nome o dal server ID."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2666,30 +2647,30 @@ msgstr ""
 "sono sensibili all'uso di maiuscolo/minuscolo, quindi l'uso di un numero ID è più affidabile.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Devi fornire un ID o un nome."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nessuna gilda trovata con l'ID o il nome `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Sconosciuto"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Lasciato la gilda: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2698,38 +2679,38 @@ msgstr ""
 "Può essere usato per individuare manualmente gli eventi nel file di registro di MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Breakpoint loggato con ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Visualizza i tipi più comuni riportati da objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Visualizza output objgraph.show_growth() limitato.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Visualizza i tipi più comuni di oggetti fuoriusciti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Visualizza i tipestat degli oggetti fuoriusciti.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Valuta la funzione e gli argomenti dati su objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2740,12 +2721,12 @@ msgstr ""
 "Poiché questo metodo valuta il codice arbitrario, è considerato pericoloso come il comando di debug.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Impossibile importare `objgraph`, è installato?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2770,7 +2751,7 @@ msgstr ""
 "Il pericolo di questo comando non può essere sottostimato. Non usarlo o dargli accesso se non capisci i rischi!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2786,7 +2767,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2795,23 +2776,23 @@ msgstr ""
 "L'output viene utilizzato per aggiornare le pagine di GitHub ed è quindi inadatto per un uso di riferimento normale."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Il sottocomando deve essere uno di: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Rende i file INI predefiniti."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Salvato il file INI richiesto su disco. Vai a controllarlo"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2820,50 +2801,50 @@ msgstr ""
 "MusicBot o dipendenze.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Impossibile individuare git eseguibile."
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Nessun aggiornamento nel ramo `%(branch)s` remoto."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nuovi commit sono disponibili in `%(branch)s` branch remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "Errore durante il controllo, vedere i registri per i dettagli."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Aggiorna per `%(name)s` alla versione: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "Nessun aggiornamento per le dipendenze trovate."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "Ci sono aggiornamenti per MusicBot disponibili per il download."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot è completamente aggiornato!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2883,18 +2864,18 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "Mostra l' uptime di MusicBot o il tempo dall' ultimo avvio / riavvio."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s è stato online per `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2902,35 +2883,35 @@ msgstr ""
 " vocali connessi."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "Nessun client vocale connesso.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Mostra latenza API e latenza vocale se MusicBot è connesso."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Mostra il numero di versione di MusicBot nella chat."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2940,18 +2921,18 @@ msgstr ""
 "Versione attuale: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 "    Aggiornare il file cookies.txt utilizzando un allegato cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Abilita o disabilita il file cookies.txt senza eliminarlo."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2976,29 +2957,29 @@ msgstr ""
 "  se non si capisce come evitare i rischi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookie già abilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "I cookie devono essere caricati per essere abilitati. (File dei cookie)."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Impossibile abilitare i cookie a causa di errore:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "I cookie sono stati abilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -3008,12 +2989,12 @@ msgstr ""
 "I cookie sono temporaneamente disabilitati e saranno riattivati al prossimo riavvio."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "I cookie sono stati disabilitati."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -3021,52 +3002,52 @@ msgstr ""
 "di un file di cookie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Errore nel scaricare il file dei cookie da discord:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Impossibile salvare i cookie sul disco:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookie caricati e abilitati."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "Non puoi usare questo bot in messaggi privati."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 "Questo comando non è consentito per il tuo gruppo di permessi:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Questo comando richiede di essere in un canale vocale."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Comando:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Errore Di Eccezione"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3076,17 +3057,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "Nessuna descrizione fornita.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "Nessun utilizzo dato."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3100,13 +3081,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Lasciare il canale vocale %(channel)s a causa di inattività."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3742,14 +3723,14 @@ msgstr ""
 "Lascia vuoto per usare le stringhe UA predefinite generate dinamicamente."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Attiva/disattiva la funzione lista blocchi utente, senza svuotare la lista "
 "blocchi."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3757,14 +3738,14 @@ msgstr ""
 "uno per riga."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Abilita la funzione della lista dei brani, senza svuotare la lista dei "
 "blocchi."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3773,7 +3754,7 @@ msgstr ""
 "Qualsiasi titolo del brano o URL che contiene qualsiasi riga nella lista sarà bloccato."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3782,7 +3763,7 @@ msgstr ""
 "Ogni file deve contenere un elenco di URL o termini riproducibili, una traccia per riga."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3796,7 +3777,7 @@ msgstr ""
 "Mappe a:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3805,7 +3786,7 @@ msgstr ""
 " lungo e breve termine per la riproduzione."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3817,7 +3798,7 @@ msgstr ""
 "Set to 0 to disable. Maximum allowed number is %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3830,7 +3811,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3860,7 +3841,7 @@ msgstr ""
 "  Utilizzare le opzioni di esempio come modello o copiarlo dal repository."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3879,7 +3860,7 @@ msgstr ""
 "  Assicurati che il percorso configurato sia un percorso per una cartella / directory."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3901,7 +3882,7 @@ msgstr ""
 "  Doppio controllo l'impostazione è valida, percorso directory accessibile."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3921,7 +3902,7 @@ msgstr ""
 "  Imposta l'opzione di configurazione Token o imposta la variabile di ambiente %(env_var)s con un token App."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3942,7 +3923,7 @@ msgstr ""
 "  Imposta manualmente l'opzione di configurazione 'OwnerID' o riprova più tardi."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3961,7 +3942,7 @@ msgstr ""
 "  Non utilizzare il Bot o l'App ID nel campo 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3983,7 +3964,7 @@ msgstr ""
 "  Verifica che la cartella di configurazione e i file esistano e possono essere letti da MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -4007,7 +3988,7 @@ msgstr ""
 "  Copiare il file di esempio dal repo se tutto il resto fallisce."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4027,7 +4008,7 @@ msgstr ""
 "  Imposta %(option)s su un ID numerico o impostalo su `auto` o `0` per il binding automatico del proprietario."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4047,7 +4028,7 @@ msgstr ""
 "  Controlla l'impostazione del percorso e assicurati che il file esista ed sia accessibile a MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4067,32 +4048,32 @@ msgstr ""
 "  Assicurati che tutti gli ID siano numerici e separati solo da spazi o virgole."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD sembra non avere intestazioni..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "L'estrazione di informazioni brano non ha restituito dati."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Impossibile continuare l'estrazione, il ciclo dell'evento è chiuso."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL non è valido o non supportato."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Impossibile trasmettere un URL non valido."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Impossibile trovare il file multimediale locale."
 
@@ -4118,13 +4099,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Download fallito a causa di un errore yt-dlp: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "Download fallito a causa di un'eccezione non gestita: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Estrazione dei dati per il supporto richiesto non riuscita."
 
@@ -4310,28 +4291,28 @@ msgstr ""
 "L'estrattore yt-dlp `%(extractor)s` non è permesso nel tuo gruppo."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Impossibile estrarre le informazioni"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Questa è una playlist."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Tipo di contenuto non valido `%(type)s` per URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "nessun dato di durata"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "nessun dato di durata nella voce corrente"
 
@@ -4414,21 +4395,21 @@ msgid "Only dev users can use this command."
 msgstr "Solo gli utenti dev possono usare questo comando."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4436,13 +4417,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -4454,22 +4435,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4497,61 +4478,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4559,7 +4540,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4569,7 +4550,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4593,40 +4574,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4634,13 +4608,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4659,7 +4633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4668,7 +4642,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4699,28 +4673,123 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "La ricerca su YouTube non ha prodotto alcun risultato per:  %(url)s"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+#~ "Rimuovi un brano dalla coda, opzionalmente alla posizione della coda data.\n"
+#~ "Se la posizione viene omessa, il brano alla fine della coda viene rimosso.\n"
+#~ "Usa il comando coda per trovare il numero di posizione della tua traccia.\n"
+#~ "Tuttavia, le posizioni di tutte le canzoni sono cambiate quando una nuova canzone inizia a riprodurre.\n"
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/ja_JP/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/ja_JP/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -145,7 +145,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "タスクの未処理例外:  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotifyはトークンを提供していません。無効にしています。"
 
@@ -162,61 +162,43 @@ msgid ""
 "Details: %s. Continuing anyway in 5 seconds..."
 msgstr "Spotifyクライアントを起動できませんでした。クライアントIDと秘密情報は正しいですか？詳細： %s。とにかく5秒後に続行します..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr "設定にはSpotifyアプリの資格情報がありませんでした。ゲストモードを使用しようとしています。"
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "ゲストモードで Spotify で正常に認証されました。"
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr "ゲストモードでSpotifyクライアントを起動できませんでした。詳細: %s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "初期化されました。今すぐDiscordに接続しています。"
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "ネットワーク接続テストは設定で無効になっています。"
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "ネットワーク接続テストは終了しています。"
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "ターゲットを解決できませんでした。"
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "ネットワーク接続テストがキャンセルされました。"
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "HTTP経由のネットワークテストには、借りるセッションがありません。"
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "環境で `ping` 実行ファイルが見つかりませんでした。"
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -226,7 +208,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -236,7 +218,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -246,35 +228,35 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "MusicBot が検出されたネットワークは再び利用可能です。"
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "VoiceClientが接続されていません。MusicPlayerの再開を待機しています..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "プレーヤーの再生再開: (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBotはネットワーク停止を検出しました。"
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr "ネットワークの空き状況によりMusicPlayerを一時停止: (%(guild_id)s) %(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -282,143 +264,143 @@ msgid ""
 msgstr "ギルドで所有者を探しています: %(guild)s (必須音声: %(required)s) と得点:  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "自動参加または再開するチャンネルを確認しています..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr "ギルドが利用できません。自動参加できません:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "再開可能なボイスチャンネルが見つかりました：ギルド内の  %(channel)s  ：  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr "自動接続チャンネルの代わりに音声セッションを再開してみます:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "音声チャンネルの所有者が見つかりました:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr "再開可能なチャネルを無視して、チャンネル内の所有者へのAutoSummon :  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr "自動参加チャンネルを無視しました。チャンネルの所有者に自動召喚:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "既にチャンネルに接続されています: ギルド内の  %(channel)s  :  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "チャンネルへの参加を試みています: ギルドの  %(channel)s  :  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "MusicPlayerを破棄し、新しいMusicPlayerを作成しています..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBotが新しいMusicPlayerを作成します..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr "%(guild)s/%(channel)sに参加していません。サポートされているボイスチャンネルではありません。"
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "設定されたチャンネルへの参加が終了しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "メンバーは音声対応ではないため、このコマンドは使用できません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "ボイスチャンネルでない場合、このコマンドは使用できません。"
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Botアプリケーション情報を取得しています。"
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot にチャンネルへの接続権限がありません:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBotにチャンネルで接続する権限がありません: `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot にチャンネル内で話す権限がありません:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBotにチャンネルで話す権限がありません: `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "ギルドからボットVoiceClientを再利用:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "ギルド内の古いVoiceClientの切断を強制:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "切断に失敗したか、キャンセルされましたか？"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "MusicBotは現在チャンネルに接続できません:  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -427,12 +409,12 @@ msgstr ""
 "後でもう一度試すか、続行するとボットを再起動してください。"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBotには現在VoiceClientがあります..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -440,71 +422,71 @@ msgid ""
 msgstr "接続中にタイムアウトエラー (%(attempt)s) の後に接続を再試行しています:  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr "MusicBot VoiceClient 接続がキャンセルされました。再試行しません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr "ボイスチャットへのMusicBot接続がキャンセルされました。これは奇妙です。再起動しますか？"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot がチャンネルでのスピーキングをリクエストしています: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot には話す権限がありません。"
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot は話すことができませんでした。"
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "ギルドでMusicPlayerを切断:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "MusicPlayerを停止する前にVoiceClientを切断します。"
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "切断に失敗またはキャンセルされました。"
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr "MusicBotにはVoiceClientではないVoiceProtocolがあります。とにかく接続を解除してください。"
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "ギルド内の不正なVoiceClientの接続を切断:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "ギルド以外のVoiceClientの接続を切断..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -514,43 +496,43 @@ msgstr ""
 "オブジェクトは実際は型です。  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr "ギルド内にMusicPlayerのrefがあります (%(guild_id)s):  %(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Guild (%(guild)s) はプレイヤー、任意の  %(player)r を要求しています"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
 msgstr "[BUG] MusicPlayerにVoiceClientがありません。おそらく再起動してください。"
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer に接続されていない VoiceClient があります。"
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "MusicPlayer obj:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -560,7 +542,7 @@ msgstr ""
 "デシリアライズ:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -568,7 +550,7 @@ msgid ""
 msgstr "ギルド %(guild_id)s の %(number)s エントリーでデシリアライゼーションを経由してプレイヤーを作成"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -577,374 +559,374 @@ msgstr ""
 "召喚コマンドを使ってボットをボイスチャンネルに連れてきてください。"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "問題が発生しました。VoiceClientを取得できませんでした。"
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "実行中のplayer_play"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "URL履歴を設定する ギルド %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "URLのエントリに設定されたサムネイルはありません: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "メッセージを再生するチャンネルがありません"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "既に投稿されていたメッセージは無視されました。"
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "実行中のplayer_resume"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "player_pause実行中"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "実行中のplayer_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "実行中の on_player_finished_playing"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "イベントループは閉じられています。ここで行うことは何もありません。"
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "このイベントを無視して進行中にログアウトします。"
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr "VoiceClient は、接続されていない、ここでできることは何もありません。"
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "プレーヤーが終了し、キューが空です。ボイスチャンネルを残しています..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr "不足している曲を削除するためにキューをループさせています..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr "Author `%(user)s` 欠席、スキップされた(削除された)エントリ:  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr "ギルドの自動プレイリストに再生可能な曲がありません。"
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "現在の自動再生リストにはコンテンツがありません。新しい音楽で塗りつぶします..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "プレーヤーの自動再生リストの上にループしています..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "曲「%(url)s」の処理中にエラーが発生しました：  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "曲 \"%(url)s\" の抽出中にエラーが発生しました： %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBotは自動プレイリストの抽出と保釈を停止する必要があります。"
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr "MusicBotはプレイヤーの終了イベントで処理されていない例外を受け取りました。"
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr "%s から抽出されたエントリで自動プレイリストを展開します"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "自動再生リストから曲を追加中にエラーが発生しました: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "上記のエラーの例外データ:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "自動プレイリストに再生可能な曲がありません。無効にします。"
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "実行中 on_player_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr "キューに入れられたエントリの自動プレイリストのエントリを自動的にスキップします。"
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "エントリの MusicPlayer 例外: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "MusicPlayer例外です。"
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "自動プレイリストトラックを再生できませんでした:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "状態更新イベントを無視して進行中のログアウトします。"
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "ボットのステータスを更新:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "キューを %sにシリアライズ中"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "%sのキューをデシリアライズしています"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "%s のために現在の曲を書き込み中"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "応答しないオブジェクトを送信できません:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "無効なレスポンスオブジェクトを送信しようとしました。"
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "%s に埋め込みを送信中"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "%s にテキストを送信しています"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "\"%s\"にメッセージを送信できません。権限がありません"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "\"%s\"にメッセージを送信できません。無効または削除されたチャンネル"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "メッセージのサイズ制限を超えています（%s）"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr "代わりにフォールバックチャンネルを送信してプライベートメッセージを送信できませんでした。"
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr "レート制限されたメッセージを送信し、 %s 秒後に再試行します。"
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "キャンセルされたメッセージの再試行:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "制限されたメッセージの送信を評価するが、再試行することはできません！"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "フォールバックチャンネルでメッセージを送信できませんでした。"
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "HTTPエラーのため送信に失敗しました。"
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "メッセージ「%s」を削除できません。権限がありません"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "メッセージ \"%s\" を削除できません。メッセージが見つかりません。"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr "Rate limited message delete, retrying in %s seconds."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "制限されたメッセージの削除を評価しますが、再試行できません！"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "メッセージの削除に失敗しました"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "HTTPExceptionがメッセージを削除しようとしています: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "メッセージ \"%s\" を編集できません。メッセージが見つかりません。"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "代わりにメッセージを送信中"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr "制限された編集メッセージを評価し、 %s 秒後に再試行します。"
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "%s へのメッセージ編集をキャンセルしました"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "メッセージの編集に失敗しました"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "HTTPExceptionがメッセージ %s を編集しようとしています: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "メッセージの削除をキャンセルしました (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "OSからの信号をキャッチしました： %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "MusicBotの接続を切断して閉じます..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "割込み信号の処理中に例外がスローされました！"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot がシャットダウンステップを行っています..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -958,44 +940,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "ダウンロードスレッドが終了するのを待っています..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Will wait for task:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "タスクをキャンセルしようとします:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "保留中のタスクを待機しています..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "HTTP コネクタを閉じています。"
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "aiohttp セッションを閉じています。"
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "ログアウトを呼び出しました。"
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1005,80 +987,80 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "%s の例外"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBotはdiscordとのセッションを再開しました。"
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "完了(_L)"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "ログイン中、MusicBot の準備中..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "クライアントユーザーは何らかの形ではありません。保釈する必要があります..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "所有者:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "ギルド一覧:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "ボット所有者が見つからないため、 %s を退出しました"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr "%s サーバーでのチェックが利用できません。"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "所有者は不明です。botはギルドにいません。"
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1088,405 +1070,405 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Got None for bound channel with ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "IDを持つメッセージ可能でないチャンネルにバインドできません:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Bound to text channels:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "テキストチャンネルにバインドされていません"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "IDを持つ自動参加チャンネルにNoneを取得しました:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr "IDを持つプライベート/非ギルドチャンネルに自動的に参加できません:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr "IDを持つ非接続可能なチャンネルに自動的に参加できません:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "ボイスチャンネルの自動結合:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "音声チャンネルに自動的に参加しません"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "イベントon_ready が %s 回発射しました"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "アプリケーション情報を取得しています。"
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "データフォルダが存在することを確認"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "設定を検証中"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "権限設定を検証中"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "無効"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "有効"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "オプション:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  コマンドプレフィックス: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  デフォルトボリューム: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Skip threshold: %(num)d vote or %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  現在@メンションを再生中: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  自動プレイリスト: %(status)s (注文: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "random"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "シーケンシャル"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  自動停止: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  メッセージの削除: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    呼び出しを削除: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    今すぐプレイを削除: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  デバッグモード: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  ダウンロードした曲は %sになります"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    %d 日間未使用の場合は削除"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  ステータスメッセージ： %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Spotify統合: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    タイムアウト: %s 秒"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    タイムアウト: %d 秒"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  セルフスピーカー: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  サーバー毎のコマンドプレフィックス: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  ラウンドロビン隊列： %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "The requested song `%(subject)s` is blocked by the song block list."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr "Voice Channel を操作しようとしていますが、Botは音声に入っていません..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "ギルドで既に待機しているチャンネルアクティビティ： %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr "チャンネルのアクティビティが %(time)d 秒でチャンネルを退出するまで待機しています: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "%s のチャネルアクティビティタイマーの有効期限が切れました。切断してください。"
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "チャネルアクティビティのタイマーをキャンセルしました: %(channel)s の %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "自動参加チャンネルのプレイヤーの非アクティブを無視:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "ギルド内で既に待機しているプレイヤーアクティビティタイマー： %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr "%(time)d 秒でチャンネルを退出するのを待っているプレイヤーアクティビティタイマー: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "%s のプレイヤーアクティビティタイマーの有効期限が切れています。切断してください。"
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "プレイヤーアクティビティのタイマーを %(channel)s でキャンセルしました: %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "プレイヤーアクティビティのタイマーがリセットされています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "そのようなコマンドはありません"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "ユーザーに言及するか、ID番号を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "無効なサブコマンドが与えられました。使用例には `help blockuser` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBotは指定したユーザーを見つけることができませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "オーナーをブロックリストに追加できません。"
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr "ユーザーをブロックリストに追加していません。既にブロックされています:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr "リストにないブロックリストからユーザーを削除していません:  %(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "あなたがリストしたユーザーを追加することはできません、すでに追加されています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "現在再生中の曲がない場合は、曲の件名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "無効なサブコマンドが与えられました。使用例には `help blocksong` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Subject `%(subject)s` はすでにソングブロックリストにあります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "件名はソングブロックリストにないため、削除できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr "無効なサブコマンドが与えられました。使用例には `help autoplaylist` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "指定された曲のリンクは無効です"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "キューが空です。再生コマンドで曲を追加してください！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "この曲はすでに自動プレイリストにあります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "この曲はまだ自動プレイリストに入っていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "プレイリストファイル名を指定する必要があります。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "プレイリストをリクエストする権限がありません"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "プレイリストのエントリが多すぎます(%(songs)s ですが、最大は %(max)s です)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1495,24 +1477,24 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "ネットワーク停止による自動停止を無視します。"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
 msgstr "MusicPlayerにVoiceClientがないか、チャンネルデータがないか、自動停止処理できません。"
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "このイベントを無視して、すでに自動一時停止を処理しています。"
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1520,55 +1502,55 @@ msgid ""
 msgstr "%sVoiceClient が接続されていないため、ギルド内の自動停止を処理する %s 秒待機しています:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "自動一時停止はキャンセルされました。"
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr "古い自動一時停止イベントを無視して、新しいMusicPlayerが接続されています。"
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr "空のボイスチャンネルで再生します。ギルドの自動一時停止： %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "以前の自動一時停止中のプレイヤーはギルドの一時停止が解除されています: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "何もプレイしていない場合はシークを使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "現在のトラックでシークを使用することはできません、それは不明な期間を持っています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Seeking is not supported for streams."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "再生を配置する時間がなければシークは使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "`%(input)s`を秒単位で有効な時間に変換できませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1577,64 +1559,64 @@ msgstr ""
 "`%(input)s/%(seconds)s`の長さのトラックの`%(progress)s `（` %(total)s`秒）をシークできません"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr "無効なサブコマンドです。使用例には「ヘルプの繰り返し」コマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "プレーヤーは現在ループしていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "曲の位置は整数でなければなりません！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "プレイリストのサイズ以外の位置を指定しました！"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr "プレイリストの再生を促すことができませんでした。リアクションを追加するメッセージがありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "ローカルメディアの再生が有効になっていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "SpotifyのURLが無効または現在サポートされていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Spotify の URL が検出されましたが、Spotify は有効ではありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "キューに登録された曲の上限に達しました (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "カラオケモードが有効になっています。無効になったらもう一度お試しください！"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "extract_info() の問題: "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1644,15 +1626,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "動画を再生できません。streamコマンドを使用してみてください。"
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "YouTubeの検索結果が  %(url)sにはありませんでした"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1755,18 +1731,18 @@ msgid "Player is not playing."
 msgstr "プレイヤーがプレイしていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "削除するキューがありません！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s`からのキューには何も見つかりませんでした。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1775,38 +1751,38 @@ msgstr ""
 "キューに登録した方、または即座にスキップ権限を持っている必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "無効なエントリ番号です。キューの位置を見つけるには、キューコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "スキップできません！プレイヤーがプレイしていません！"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "ループされた曲をスキップする権限がありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "スキップを強制する権限がありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "ループ曲をスキップする権限がありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "'%(new_volume)s' は有効な数字ではありません"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1816,14 +1792,14 @@ msgstr ""
 "ボリュームは1から100まで設定できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "不合理なボリュームが提供されました: %(volume)s. 1から100までの値を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1832,28 +1808,28 @@ msgstr ""
 "デフォルトの再生速度を設定するにはconfigコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "ストリームメディアには速度を適用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "設定する速度を提供する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "指定した速度が無効です。0.5 から 100までの数字を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "コマンドの無効なオプション: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1863,28 +1839,28 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "エイリアスにエイリアスとコマンドを提供する必要があります"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "削除するにはエイリアス名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "設定では、チャンネルとユーザーのメンションを同時に使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1894,24 +1870,24 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "オプション名からセクション名を解決できませんでした。有効なセクション名とオプション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "与えられたオプションは曖昧です。セクション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "このコマンドのセクション名とオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1921,97 +1897,97 @@ msgstr ""
 "The available section:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "オプション `%(option)s` は使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "オプション `%(option)s` は編集できません。ディスクに保存できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "オプションの保存に失敗しました: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` は編集できません。値を表示できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "オプション `%(option)s` は編集できません。設定を更新できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "このサブコマンドのセクション、オプション、値を指定する必要があります。"
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "%(config)s == %(value)s で設定する"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` は更新されませんでした！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "オプション `%(option)s` は編集できません。デフォルトにリセットできません。"
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "%(config)s を既定の %(value)s にリセット"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` はデフォルトにリセットされませんでした！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "option コマンドは推奨されません。config コマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "無効なオプションが指定されました。情報、更新、またはクリアを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**キャッシュの削除に失敗しました。ログの詳細を確認してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "キューページ引数は整数でなければなりません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "曲がキューに追加されていません! playコマンドで何かをキューに追加します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2021,22 +1997,22 @@ msgstr ""
 "**%(total)s** ページがあります。"
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "現在のプレイリストのエントリをスキップしました。"
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "キューをページネーションするのに十分なエントリがありません。"
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr "キューメッセージを投稿できませんでした。リアクションを追加するメッセージがありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2045,17 +2021,17 @@ msgstr ""
 "問題が解決しない場合は、バグレポートを送信してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "プライベート DM チャンネルでパージを使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "指定されたURLは有効なURLではありませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2063,29 +2039,29 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "これはプレイリストではないようです。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "無効なユーザーIDまたはサーバーニックネームです。IDを再確認してもう一度やり直してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "discordユーザーを特定できませんでした。もう一度お試しください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "権限は同時にチャンネルとユーザーメンションを使用することはできません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2095,23 +2071,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "このコマンドのグループまたはオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "このコマンドに設定するには、グループ、オプション、値を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s サブコマンドにはグループ名と権限名が必要です。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2121,47 +2097,47 @@ msgstr ""
 "The available groups is :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "パーミッション`%(option)s`は利用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "グループを追加できません`%(group)s` が既に存在します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "組み込みグループを削除できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "オーナーグループは編集できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "グループの保存に失敗しました: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "%(option)s に値： %(value)s を設定する"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "パーミッション`%(option)s`は更新されませんでした！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2170,7 +2146,7 @@ msgstr ""
 "名前の変更は1時間に2回に制限されています。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2180,12 +2156,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "ニックネームを変更できません: 権限がありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2195,12 +2171,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "プレフィックスとして使用するには、このサーバーからカスタム絵文字を使用する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2209,28 +2185,28 @@ msgstr ""
 "configコマンドを使用して、代わりにプレフィックスを更新してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "このコマンドはギルドでのみ使用できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "指定された無効なサブコマンドです。詳細についてはヘルプコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "言語を`%(locale)s`に設定できません。利用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "URLを入力するか、ファイルを添付する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2240,62 +2216,62 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBotはギルドのない %s を見つけました！問題が発生する可能性があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "現在サーバーに接続されていません `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "無効なオプションが与えられました。ソフト、フル、アップグレード、uppip、またはupgitのいずれかを使用してください"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "IDまたは名前を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "IDまたは名前のギルドが見つかりませんでした。`%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "デバッグブレークポイントIDをアクティベート中: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "`objgraph` をインポートできませんでした。インストールされていますか？"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "eval() で実行されたデバッグコード。"
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "exec()でデバッグコードを実行しました。"
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "デバッグコードの実行に失敗しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2311,54 +2287,54 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "サブコマンドは次のいずれかでなければなりません： %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "git 実行可能ファイルが見つかりませんでした。"
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "git コマンドで更新の確認に失敗しました。"
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "pipレポートにメタが見つからないパッケージ。"
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr "エラーが発生したため、Pip の更新ステータスを取得できませんでした。"
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "変なボイスクライアントのエントリがあります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "クッキーは既に有効になっています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "クッキーを有効にするには、アップロードする必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "エラーのためクッキーを有効にできませんでした:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2368,183 +2344,183 @@ msgstr ""
 "クッキーは一時的に無効化され、次回の再起動時に再度有効になります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "添付されたアップロードが見つかりませんでした。Cookie ファイルのアップロード中に再試行してください。"
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "古い無効化されたCookieファイルを削除できませんでした:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "discordからCookieファイルをダウンロード中にエラーが発生しました:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "ディスクにクッキーを保存できませんでした:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "チャンネルがないメッセージがあります。  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "自分からのコマンドを無視しました (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "他のボットからコマンドを無視しました (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "%s のチャンネルからコマンドを無視しました"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr "ブロックリストのユーザー: %(id)s/%(name)s  tried command: %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "%(id)s/%(name)sからのメッセージ : %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "このコマンドは権限グループには許可されていません：  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "このコマンドを使用するには、ボイスチャンネルに参加する必要があります。"
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "無効なコマンド使用法、パラメータの値がありません: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "%(command)sのエラー : %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "コマンド処理中の例外: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "不足しているコマンドのヘルプを生成できません:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "コマンドのヘルプデータがありません:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "%s に音声チャンネル %s を退出しています。"
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot が接続されました。"
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBotの接続が切断されました。"
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "ソケットイベントがあります:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState は、on_readyが終了する前に更新されました"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "%s の %s を無視しました。音声チャンネルです。"
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s は空として検出されました。処理のタイムアウト。"
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "ユーザーが %sに参加し、タイマーをキャンセルしました。"
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "ボットが移動され、音声チャンネル %s が空です。タイムアウトを処理します。"
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "ボットが移動され、音声チャンネル %s が空ではありません。"
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "ユーザー %sをフォローしていません"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "次のユーザー`%(user)s`チャンネル:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState disconnection.channel is None."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2553,96 +2529,96 @@ msgstr ""
 "Discordによる音声から切断されました: %(guild)s/%(channel)s (コード: %(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr "タイプの自動参加チャンネルは使用できません: ギルドの %(type)s  :  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "自動参加チャンネルが見つかりません。削除されましたか? ギルド:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "チャンネルのギルド自動参加に再接続中:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "チャンネルに自動参加できません:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Botがギルドに追加されました： %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "ボット所有者が見つからないため、ギルド「%s」を退出しました。"
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "ギルド %sのデータフォルダを作成しています"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Botがギルドから削除されました: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "更新されたギルドリスト:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "ギルド「%s」が利用可能になりました。"
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "空き状況により \"%s\" のプレイヤーを再開しています。"
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "ギルド「%s」は利用できなくなりました。"
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "「%s」でプレイヤーを一時停止しています。"
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "ギルド更新:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Guild 属性 %(attr)s が現在: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "チャンネル更新:  %(channel)s  --  %(changes)s"
@@ -2660,7 +2636,7 @@ msgid "Loading config from:  %s"
 msgstr "%s から設定を読み込んでいます"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2678,7 +2654,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2686,14 +2662,14 @@ msgid ""
 msgstr "%s ログファイル以上を保存できません。オプションの LogsMaxKept は代わりに制限されます。"
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr "ConfigオプションLogsDateFormatは空で、ログファイルのローテーションが壊れます。代わりにデフォルトを使用します。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2705,12 +2681,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "AudioCachePath の検証中に例外がスローされました。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2732,13 +2708,13 @@ msgstr ""
 "  設定が有効であることを再確認してください。 アクセス可能なディレクトリパス"
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "オーディオキャッシュは  %sに保存されます"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2751,14 +2727,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr "StatusMessage 設定オプションが長すぎます。128 文字に制限されます。"
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2766,17 +2742,17 @@ msgid ""
 msgstr "デフォルトの再生速度は0.5から100.0の間でなければなりません。 %.3f のオプション値は制限されます。"
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "サービスデータを使用してオプションを検証しています..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "API経由で取得した所有者ID"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2789,12 +2765,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBotにユーザーインスタンスがありません。続行できません。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2806,12 +2782,12 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "設定オプションファイルが見つかりません。選択肢を確認しています..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2819,18 +2795,18 @@ msgid ""
 msgstr "%(ini_file)s を %(option_file)sにリネームするには、おそらくファイル拡張子を ON にする必要があります。"
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "既存のオプションファイルのコピー:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr "設定オプションファイルの検索中に問題が発生しました。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2852,7 +2828,7 @@ msgstr ""
 "  設定フォルダとファイルが存在することを確認し、MusicBotによって読み込まれます。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2867,54 +2843,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! 設定オプションは利用できないゲッターがあります。"
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr "Dev Bug! Config オプションは無効な型、getter とデフォルトは同じ型でなければなりません。"
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "オプションは以前に存在しませんでした。"
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "パースされた設定セクションに設定セクションがありません! ミス: %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "保存された設定オプション: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "設定を保存できませんでした:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr "オプション名はINIセクション間で一意ではありません! リゾルバーは無効です。"
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "デフォルトのINIファイルを  %sに保存できませんでした"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2927,7 +2903,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2940,7 +2916,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2953,7 +2929,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2961,7 +2937,7 @@ msgid ""
 msgstr "レベルに戻ります:%(value)s\"が無効です: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2971,7 +2947,7 @@ msgstr ""
 " default instead."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2981,144 +2957,144 @@ msgstr ""
 "%(fallback)s に設定されます。"
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr "INIファイルエントリの名前を変更 [%(old_s)s] > %(old_o)s  to [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "名前を変更したオプション付き設定ファイルをアップグレード中..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "設定のアップグレードに失敗しました。手動でアップグレードする必要があります。"
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "ブロックリストファイルが見つかりません:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "ファイルからブロックリストを読み込めませんでした:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "ブロックリストファイルを更新できませんでした:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "%s エントリでユーザーブロックリストを読み込みました。"
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "レガシーブラックリストファイルを見つけました。名前は  %sに変更されます。"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "%s エントリでソングブロックリストをロードしました。"
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr "ID0のギルドのデータをロードできません。コード内のバグでしょう！"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "ギルド %(id)s/%(name)s のファイルがありません"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "IDを持つギルドのギルドデータをロードしています:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "ギルドデータファイル  %s の読み込みに失敗しました。"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr "Guild %(id)s/%(name)s にカスタムコマンドプレフィックスがあります: %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr "ID 0のギルドのデータを保存できません。コード内のバグです！"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr "OS エラーのため、ギルド固有のデータを保存できませんでした。"
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr "無効なデータのため、ギルド固有のデータをシリアライズできませんでした。"
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "ユーザーエージェントの使用を強制する YTDLP :  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBotはyt-dlpにクッキーを使用します:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlpは設定したプロキシサーバーを使用します。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "ヘッダがないみたいだな。"
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr "タイムアウトのためメディアヘッダーの確認に失敗しました。"
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "%sへのヘッド要求に失敗しました"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "HEAD リクエストの例外: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3128,82 +3104,82 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "サニタイズYTDL抽出情報 (JSONではありません):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "曲情報の抽出はデータを返しませんでした。"
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "extract_infoと呼ばれる: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr "抽出を実行できません。ループは閉じられています。（シャットダウン時は正常です）"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "抽出を続行できません。イベントループは閉じられています。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "SpotifyのURLが無効かサポートされていません。"
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "ストリームURLのダウンロードエラー"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "コンテンツがダイレクトストリームであると仮定する"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "無効なURLをストリーミングできません。"
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr "NoSupportingHandlersをキャッチし、コロンをスペースに置き換えた後に再試行します。"
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "safe_extract_infoと呼ばれています:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "ローカルメディアファイルが見つかりません。"
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "YtdlpResponseDictから__input_subjectがありません"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr "エントリは YtdlpResponseDict のリストではありません。 process=True に設定してこれを回避します。"
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "警告、期間エラー： %(url)s"
@@ -3249,12 +3225,12 @@ msgstr ""
 "エントリ名:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr "Entry data is missing version number, cannot deerialize."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr "Entry data has the wrong version number, cannot deerialize."
 
@@ -3284,7 +3260,7 @@ msgstr ""
 "Deserialized URLPlaylistEntry has an author ID but no channel for lookup!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "%s を読み込めませんでした"
@@ -3296,7 +3272,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr "Spotifyのリンクをダウンロードできません。 %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "エントリの準備をしています:  %r"
@@ -3318,7 +3294,7 @@ msgid "Download already cached at:  %s"
 msgstr "既にキャッシュされているダウンロード:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3336,7 +3312,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "ファイルの %(time)s 秒間の持続時間：  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3346,75 +3322,75 @@ msgstr ""
 "これはBotの機能に影響を与えていませんが、トラックがイコライズされないことを意味します。"
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "エントリデータを確認中の例外"
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "pymediainfo経由で継続時間を取得しようとしています:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "pymediainfo経由で継続時間を取得できませんでした。"
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "ffprobe 経由で継続時間を取得しようとしています:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "パス内の ffprobe が見つかりませんでした！"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "FFプローブは使えないものを返しました"
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "何らかの理由でFFプローブを実行できなかった"
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "%s の平均音量を計算しています"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "パス上にffmpegが見つかりませんでした！"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "jsonの正規化で「I」を解析できませんでした。"
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "jsonの正規化で「LRA」を解析できませんでした。"
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "jsonの正規化で「TP」を解析できませんでした。"
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "json正規化で「しきい値」を解析できませんでした。"
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "jsonの正規化で「オフセット」を解析できませんでした。"
 
@@ -3456,77 +3432,77 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "yt-dlpエラーのためダウンロードに失敗しました: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "抽出で処理されていない例外が発生しました。"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "未処理の例外のためダウンロードに失敗しました: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "ダウンロードに失敗しました:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "要求されたメディアのデータの抽出に失敗しました。"
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "ダウンロードが完了しました:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr "Deserialized StreamPlaylistEntry には作者IDがありますが、検索のためのチャンネルはありません!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3534,7 +3510,7 @@ msgstr ""
 "Deserialized LocalFilePlaylistEntry にはauthor IDがありますが、検索のためのチャンネルはありません!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "ファイルの %(seconds)s 秒間の持続時間：  %(file)s"
@@ -3638,19 +3614,19 @@ msgid ""
 msgstr "キー: %(file)s  古い: %(old)s  新着: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "ラング引数エラー:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr "[%s]  のいずれかのログ翻訳の読み込みに失敗しました:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -3972,116 +3948,116 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "ffmpegからデータをデコードしました: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "URLのストリームエントリを追加しています:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "情報を抽出できませんでした"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "これはプレイリストです。"
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr "Entry info appears to be a stream, adding stream entry..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "無効なコンテンツタイプ`%(type)s`の URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "content-typeについては text/html を取得しました。これはストリームかもしれません。"
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "疑問のあるコンテンツタイプ \"%(type)s\" for url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "%(subject)s の URLPlaylistEntry を追加中"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "LocalFilePlaylistEntry の追加: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "ID：  %s との複合プレイリストリンクから無視されたビデオ"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr "曲のブロックリストにあるエントリが許可されていません:  %(title)s  URL: %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr "「%s」のエントリ内の曲を無視しています。許可されている最大より長くなっています。"
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr "プライベートまたは削除のマークがあるため、YouTube 動画を追加しません:  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "アイテムを追加できませんでした"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "アイテム: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "%s 不良項目をスキップしました"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "エントリのループを順序変更します。"
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "次のトラックを事前ダウンロード:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "持続時間データがありません"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "現在のエントリに期間データがありません"
 
@@ -4636,42 +4612,42 @@ msgstr ""
 "と互換性のある値を含む必要があります。(デフォルト: '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "バージョン：  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "新しいMusicBotインスタンスを開きました。この端末は安全に閉じることができます！"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "MusicBot のバージョンを読み込み中:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "ログを開きました:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "作業ディレクトリの変更:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4681,7 +4657,7 @@ msgstr ""
 "新しいディレクトリの場所を確認するためのフォルダです。"
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4690,7 +4666,7 @@ msgstr ""
 "リポジトリのクローンにgit を使用していない場合は、強くお勧めします。"
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4699,36 +4675,36 @@ msgstr ""
 "exiting."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "ここに正確なエラーがあり、バグがある可能性があります。"
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr "デフォルトのトラストストアから発行者証明書を取得できませんでした。代わりに証明書を試してみてください。"
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "構文エラー（変更が検出されました。コードを編集しましたか？）"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "構文エラー（これはバグであり、障害ではありません）"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4741,12 +4717,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "MusicBot依存パッケージを自動的にインストールしようとしています...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4767,12 +4743,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK、依存関係のインストールがうまくいったことを願っています！"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -4780,58 +4756,58 @@ msgstr ""
 "MusicBot がパッケージをインストールしようとしてImportError を受け取りました。MusicBot は終了する必要があります..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "上記のエラーを引き起こした例外: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot がソフトな再起動を行っています..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot が完全な再起動処理を行っています..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "ボット起動時のエラー"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "イベントループを閉じています。"
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "%s 秒後に再起動中..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "すべて完了です。"
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "OK、閉店中です！"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -4856,12 +4832,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4875,7 +4851,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4943,45 +4919,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -4993,220 +4969,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5225,30 +5201,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5256,18 +5232,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5342,9 +5318,88 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr "設定にはSpotifyアプリの資格情報がありませんでした。ゲストモードを使用しようとしています。"
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "ゲストモードで Spotify で正常に認証されました。"
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr "ゲストモードでSpotifyクライアントを起動できませんでした。詳細: %s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "YouTubeの検索結果が  %(url)sにはありませんでした"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/ja_JP/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/ja_JP/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -433,20 +433,20 @@ msgid ""
 msgstr "ボイスチャットへのMusicBot接続がキャンセルされました。これは奇妙です。再起動しますか？"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot がチャンネルでのスピーキングをリクエストしています: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot には話す権限がありません。"
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot は話すことができませんでした。"
 
@@ -575,7 +575,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "URL履歴を設定する ギルド %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "URLのエントリに設定されたサムネイルはありません: %s"
@@ -658,19 +658,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "プレーヤーの自動再生リストの上にループしています..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "曲「%(url)s」の処理中にエラーが発生しました：  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "曲 \"%(url)s\" の抽出中にエラーが発生しました： %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBotは自動プレイリストの抽出と保釈を停止する必要があります。"
 
@@ -1031,7 +1031,7 @@ msgstr "ギルド一覧:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1569,7 +1569,7 @@ msgid "The player is not currently looping."
 msgstr "プレーヤーは現在ループしていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "曲の位置は整数でなければなりません！"
 
@@ -1590,33 +1590,33 @@ msgid "Local media playback is not enabled."
 msgstr "ローカルメディアの再生が有効になっていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "SpotifyのURLが無効または現在サポートされていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Spotify の URL が検出されましたが、Spotify は有効ではありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "キューに登録された曲の上限に達しました (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "カラオケモードが有効になっています。無効になったらもう一度お試しください！"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "extract_info() の問題: "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1626,12 +1626,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "動画を再生できません。streamコマンドを使用してみてください。"
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1639,110 +1639,110 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr "曲が追加されていません。すべての曲が最大時間（%(max)s 秒）を超えています。"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "抽出キーとして 'youtube:playlist' でエントリを抽出しました"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "曲の再生時間が制限を超えています(%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "%s位置に曲を追加しました"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "位置の再生までの時間を見積もることはできません: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "ストリームリクエストからの情報の取得に失敗しました: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "ストリーミングプレイリストはまだサポートされていません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "プレイリストアイテムの上限に達しました (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr "検索クエリを指定してください。詳細は `ヘルプ検索` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "%(max)s 以上の動画を検索することはできません"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "召喚ロックを待っています： %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "ロックを召喚: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "音声に接続されていません。音声チャンネルに参加してみてください！"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "%(guild)s/%(channel)s に参加中"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot はサーバーのメンバーではないユーザーをフォローできません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "プレイヤーがプレイしていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "削除するキューがありません！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s`からのキューには何も見つかりませんでした。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1751,38 +1751,38 @@ msgstr ""
 "キューに登録した方、または即座にスキップ権限を持っている必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "無効なエントリ番号です。キューの位置を見つけるには、キューコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "スキップできません！プレイヤーがプレイしていません！"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "ループされた曲をスキップする権限がありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "スキップを強制する権限がありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "ループ曲をスキップする権限がありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "'%(new_volume)s' は有効な数字ではありません"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1792,14 +1792,14 @@ msgstr ""
 "ボリュームは1から100まで設定できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "不合理なボリュームが提供されました: %(volume)s. 1から100までの値を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1808,28 +1808,28 @@ msgstr ""
 "デフォルトの再生速度を設定するにはconfigコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "ストリームメディアには速度を適用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "設定する速度を提供する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "指定した速度が無効です。0.5 から 100までの数字を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "コマンドの無効なオプション: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1839,28 +1839,28 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "エイリアスにエイリアスとコマンドを提供する必要があります"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "削除するにはエイリアス名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "設定では、チャンネルとユーザーのメンションを同時に使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1870,24 +1870,24 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "オプション名からセクション名を解決できませんでした。有効なセクション名とオプション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "与えられたオプションは曖昧です。セクション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "このコマンドのセクション名とオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1897,97 +1897,97 @@ msgstr ""
 "The available section:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "オプション `%(option)s` は使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "オプション `%(option)s` は編集できません。ディスクに保存できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "オプションの保存に失敗しました: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` は編集できません。値を表示できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "オプション `%(option)s` は編集できません。設定を更新できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "このサブコマンドのセクション、オプション、値を指定する必要があります。"
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "%(config)s == %(value)s で設定する"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` は更新されませんでした！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "オプション `%(option)s` は編集できません。デフォルトにリセットできません。"
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "%(config)s を既定の %(value)s にリセット"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` はデフォルトにリセットされませんでした！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "option コマンドは推奨されません。config コマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "無効なオプションが指定されました。情報、更新、またはクリアを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**キャッシュの削除に失敗しました。ログの詳細を確認してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "キューページ引数は整数でなければなりません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "曲がキューに追加されていません! playコマンドで何かをキューに追加します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1997,22 +1997,22 @@ msgstr ""
 "**%(total)s** ページがあります。"
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "現在のプレイリストのエントリをスキップしました。"
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "キューをページネーションするのに十分なエントリがありません。"
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr "キューメッセージを投稿できませんでした。リアクションを追加するメッセージがありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2021,17 +2021,17 @@ msgstr ""
 "問題が解決しない場合は、バグレポートを送信してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "プライベート DM チャンネルでパージを使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "指定されたURLは有効なURLではありませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2039,29 +2039,29 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "これはプレイリストではないようです。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "無効なユーザーIDまたはサーバーニックネームです。IDを再確認してもう一度やり直してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "discordユーザーを特定できませんでした。もう一度お試しください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "権限は同時にチャンネルとユーザーメンションを使用することはできません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2071,23 +2071,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "このコマンドのグループまたはオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "このコマンドに設定するには、グループ、オプション、値を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s サブコマンドにはグループ名と権限名が必要です。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2097,47 +2097,47 @@ msgstr ""
 "The available groups is :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "パーミッション`%(option)s`は利用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "グループを追加できません`%(group)s` が既に存在します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "組み込みグループを削除できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "オーナーグループは編集できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "グループの保存に失敗しました: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "%(option)s に値： %(value)s を設定する"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "パーミッション`%(option)s`は更新されませんでした！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2146,7 +2146,7 @@ msgstr ""
 "名前の変更は1時間に2回に制限されています。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2156,12 +2156,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "ニックネームを変更できません: 権限がありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2171,12 +2171,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "プレフィックスとして使用するには、このサーバーからカスタム絵文字を使用する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2185,28 +2185,28 @@ msgstr ""
 "configコマンドを使用して、代わりにプレフィックスを更新してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "このコマンドはギルドでのみ使用できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "指定された無効なサブコマンドです。詳細についてはヘルプコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "言語を`%(locale)s`に設定できません。利用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "URLを入力するか、ファイルを添付する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2216,62 +2216,62 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBotはギルドのない %s を見つけました！問題が発生する可能性があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "現在サーバーに接続されていません `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "無効なオプションが与えられました。ソフト、フル、アップグレード、uppip、またはupgitのいずれかを使用してください"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "IDまたは名前を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "IDまたは名前のギルドが見つかりませんでした。`%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "デバッグブレークポイントIDをアクティベート中: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "`objgraph` をインポートできませんでした。インストールされていますか？"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "eval() で実行されたデバッグコード。"
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "exec()でデバッグコードを実行しました。"
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "デバッグコードの実行に失敗しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2287,54 +2287,54 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "サブコマンドは次のいずれかでなければなりません： %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "git 実行可能ファイルが見つかりませんでした。"
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "git コマンドで更新の確認に失敗しました。"
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "pipレポートにメタが見つからないパッケージ。"
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr "エラーが発生したため、Pip の更新ステータスを取得できませんでした。"
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "変なボイスクライアントのエントリがあります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "クッキーは既に有効になっています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "クッキーを有効にするには、アップロードする必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "エラーのためクッキーを有効にできませんでした:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2344,183 +2344,183 @@ msgstr ""
 "クッキーは一時的に無効化され、次回の再起動時に再度有効になります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "添付されたアップロードが見つかりませんでした。Cookie ファイルのアップロード中に再試行してください。"
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "古い無効化されたCookieファイルを削除できませんでした:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "discordからCookieファイルをダウンロード中にエラーが発生しました:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "ディスクにクッキーを保存できませんでした:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "チャンネルがないメッセージがあります。  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "自分からのコマンドを無視しました (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "他のボットからコマンドを無視しました (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "%s のチャンネルからコマンドを無視しました"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr "ブロックリストのユーザー: %(id)s/%(name)s  tried command: %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "%(id)s/%(name)sからのメッセージ : %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "このコマンドは権限グループには許可されていません：  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "このコマンドを使用するには、ボイスチャンネルに参加する必要があります。"
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "無効なコマンド使用法、パラメータの値がありません: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "%(command)sのエラー : %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "コマンド処理中の例外: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "不足しているコマンドのヘルプを生成できません:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "コマンドのヘルプデータがありません:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "%s に音声チャンネル %s を退出しています。"
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot が接続されました。"
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBotの接続が切断されました。"
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "ソケットイベントがあります:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState は、on_readyが終了する前に更新されました"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "%s の %s を無視しました。音声チャンネルです。"
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s は空として検出されました。処理のタイムアウト。"
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "ユーザーが %sに参加し、タイマーをキャンセルしました。"
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "ボットが移動され、音声チャンネル %s が空です。タイムアウトを処理します。"
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "ボットが移動され、音声チャンネル %s が空ではありません。"
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "ユーザー %sをフォローしていません"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "次のユーザー`%(user)s`チャンネル:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState disconnection.channel is None."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2529,96 +2529,96 @@ msgstr ""
 "Discordによる音声から切断されました: %(guild)s/%(channel)s (コード: %(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr "タイプの自動参加チャンネルは使用できません: ギルドの %(type)s  :  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "自動参加チャンネルが見つかりません。削除されましたか? ギルド:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "チャンネルのギルド自動参加に再接続中:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "チャンネルに自動参加できません:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Botがギルドに追加されました： %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "ボット所有者が見つからないため、ギルド「%s」を退出しました。"
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "ギルド %sのデータフォルダを作成しています"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Botがギルドから削除されました: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "更新されたギルドリスト:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "ギルド「%s」が利用可能になりました。"
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "空き状況により \"%s\" のプレイヤーを再開しています。"
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "ギルド「%s」は利用できなくなりました。"
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "「%s」でプレイヤーを一時停止しています。"
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "ギルド更新:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Guild 属性 %(attr)s が現在: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "チャンネル更新:  %(channel)s  --  %(changes)s"
@@ -2636,7 +2636,7 @@ msgid "Loading config from:  %s"
 msgstr "%s から設定を読み込んでいます"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2654,7 +2654,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2662,14 +2662,14 @@ msgid ""
 msgstr "%s ログファイル以上を保存できません。オプションの LogsMaxKept は代わりに制限されます。"
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr "ConfigオプションLogsDateFormatは空で、ログファイルのローテーションが壊れます。代わりにデフォルトを使用します。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2681,12 +2681,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "AudioCachePath の検証中に例外がスローされました。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2708,13 +2708,13 @@ msgstr ""
 "  設定が有効であることを再確認してください。 アクセス可能なディレクトリパス"
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "オーディオキャッシュは  %sに保存されます"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2727,14 +2727,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr "StatusMessage 設定オプションが長すぎます。128 文字に制限されます。"
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2742,17 +2742,17 @@ msgid ""
 msgstr "デフォルトの再生速度は0.5から100.0の間でなければなりません。 %.3f のオプション値は制限されます。"
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "サービスデータを使用してオプションを検証しています..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "API経由で取得した所有者ID"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2765,12 +2765,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBotにユーザーインスタンスがありません。続行できません。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2782,12 +2782,12 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "設定オプションファイルが見つかりません。選択肢を確認しています..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2795,18 +2795,18 @@ msgid ""
 msgstr "%(ini_file)s を %(option_file)sにリネームするには、おそらくファイル拡張子を ON にする必要があります。"
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "既存のオプションファイルのコピー:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr "設定オプションファイルの検索中に問題が発生しました。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2828,7 +2828,7 @@ msgstr ""
 "  設定フォルダとファイルが存在することを確認し、MusicBotによって読み込まれます。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2843,54 +2843,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! 設定オプションは利用できないゲッターがあります。"
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr "Dev Bug! Config オプションは無効な型、getter とデフォルトは同じ型でなければなりません。"
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "オプションは以前に存在しませんでした。"
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "パースされた設定セクションに設定セクションがありません! ミス: %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "保存された設定オプション: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "設定を保存できませんでした:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr "オプション名はINIセクション間で一意ではありません! リゾルバーは無効です。"
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "デフォルトのINIファイルを  %sに保存できませんでした"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2903,7 +2903,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2916,7 +2916,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2929,7 +2929,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2937,7 +2937,7 @@ msgid ""
 msgstr "レベルに戻ります:%(value)s\"が無効です: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2947,7 +2947,7 @@ msgstr ""
 " default instead."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2957,54 +2957,54 @@ msgstr ""
 "%(fallback)s に設定されます。"
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr "INIファイルエントリの名前を変更 [%(old_s)s] > %(old_o)s  to [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "名前を変更したオプション付き設定ファイルをアップグレード中..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "設定のアップグレードに失敗しました。手動でアップグレードする必要があります。"
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "ブロックリストファイルが見つかりません:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "ファイルからブロックリストを読み込めませんでした:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "ブロックリストファイルを更新できませんでした:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "%s エントリでユーザーブロックリストを読み込みました。"
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "レガシーブラックリストファイルを見つけました。名前は  %sに変更されます。"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "%s エントリでソングブロックリストをロードしました。"
@@ -3062,39 +3062,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "ユーザーエージェントの使用を強制する YTDLP :  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBotはyt-dlpにクッキーを使用します:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlpは設定したプロキシサーバーを使用します。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "ヘッダがないみたいだな。"
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr "タイムアウトのためメディアヘッダーの確認に失敗しました。"
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "%sへのヘッド要求に失敗しました"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "HEAD リクエストの例外: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3104,82 +3104,82 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "サニタイズYTDL抽出情報 (JSONではありません):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "曲情報の抽出はデータを返しませんでした。"
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "extract_infoと呼ばれる: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr "抽出を実行できません。ループは閉じられています。（シャットダウン時は正常です）"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "抽出を続行できません。イベントループは閉じられています。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "SpotifyのURLが無効かサポートされていません。"
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "ストリームURLのダウンロードエラー"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "コンテンツがダイレクトストリームであると仮定する"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "無効なURLをストリーミングできません。"
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr "NoSupportingHandlersをキャッチし、コロンをスペースに置き換えた後に再試行します。"
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "safe_extract_infoと呼ばれています:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "ローカルメディアファイルが見つかりません。"
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "YtdlpResponseDictから__input_subjectがありません"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr "エントリは YtdlpResponseDict のリストではありません。 process=True に設定してこれを回避します。"
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "警告、期間エラー： %(url)s"
@@ -4426,13 +4426,13 @@ msgstr ""
 "システムパッケージマネージャでffmpegを確認するか、ソースからビルドします。"
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "%sMB 未満の空き容量がこのデバイスに残っています"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4441,42 +4441,42 @@ msgstr ""
 "MusicBotのアップデートや依存関係の確認..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "`git`コマンドで利用可能なMusicBotのアップデートはありません。"
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
 msgstr "`git` コマンドを使用してアップデートを確認できませんでした。手動で確認する必要があります。"
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "以下のパッケージを更新できます:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  からバージョン:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "`pip`コマンドで利用可能な依存関係の更新はありません。"
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
 msgstr "`pip`コマンドを使用してアップデートを確認できませんでした。手動で確認する必要があります。"
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4486,73 +4486,73 @@ msgstr ""
 "    %s ./update.py コマンドを使用してガイド付き更新を実行できます。"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "値は最大限を超えています。"
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "値は負であってはなりません。"
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "保持される最大ログの値は0から %sまでの数値でなければなりません"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "ログレベル「%s」は利用できません。"
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "ログレベルは次のいずれかでなければなりません：  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
 msgstr "discord.py、youtubeDL、ffmpegを使用して構築されたDiscordボットを再生している音楽を起動します。"
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Github で利用可能:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr "このボットでより多くの助けとサポートが得られるように、私たちのdiscordに参加してください。"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "このソフトウェアはMITライセンスの下で提供されています。"
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "詳細については、 `LICENSE` テキストファイルを参照してください。"
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr "MusicBotのすべてのテキストのデフォルト/システム検出言語を上書きします。"
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr "MusicBotからのすべてのサーバーサイドログメッセージにこの言語を使用します。"
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4561,34 +4561,34 @@ msgstr ""
 "ギルド毎の言語の選択を防ぐことはできません。"
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "MusicBot のバージョン情報を印刷して終了します。"
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr "アップデートチェックを含む、オプションの起動チェックをすべてスキップします。"
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "起動時にディスク容量の確認だけをスキップします。"
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "起動時にアップデートの確認だけをスキップします。"
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
 msgstr "MusicBot が依存関係をインポートできない場合のインストールを無効にします。"
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4596,13 +4596,13 @@ msgid ""
 msgstr "保存するログ ファイルの数を指定します。0 から %s までです。(デフォルト: %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr "設定で設定されたログレベルの設定を上書きします。以下のいずれかにする必要があります： %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4612,42 +4612,42 @@ msgstr ""
 "と互換性のある値を含む必要があります。(デフォルト: '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "バージョン：  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "新しいMusicBotインスタンスを開きました。この端末は安全に閉じることができます！"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "MusicBot のバージョンを読み込み中:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "ログを開きました:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "作業ディレクトリの変更:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4657,7 +4657,7 @@ msgstr ""
 "新しいディレクトリの場所を確認するためのフォルダです。"
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4666,7 +4666,7 @@ msgstr ""
 "リポジトリのクローンにgit を使用していない場合は、強くお勧めします。"
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4675,36 +4675,36 @@ msgstr ""
 "exiting."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "ここに正確なエラーがあり、バグがある可能性があります。"
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr "デフォルトのトラストストアから発行者証明書を取得できませんでした。代わりに証明書を試してみてください。"
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "構文エラー（変更が検出されました。コードを編集しましたか？）"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "構文エラー（これはバグであり、障害ではありません）"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4717,12 +4717,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "MusicBot依存パッケージを自動的にインストールしようとしています...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4743,56 +4743,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK、依存関係のインストールがうまくいったことを願っています！"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot がパッケージをインストールしようとしてImportError を受け取りました。MusicBot は終了する必要があります..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "上記のエラーを引き起こした例外: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot がソフトな再起動を行っています..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot が完全な再起動処理を行っています..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "ボット起動時のエラー"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "イベントループを閉じています。"
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "%s 秒後に再起動中..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "すべて完了です。"
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "OK、閉店中です！"
 
@@ -4813,31 +4800,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4851,7 +4838,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4911,7 +4898,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5142,24 +5129,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5206,25 +5193,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5232,66 +5219,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5318,7 +5259,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5330,25 +5271,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5361,29 +5302,144 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot がパッケージをインストールしようとしてImportError を受け取りました。MusicBot は終了する必要があります..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "上記のエラーを引き起こした例外: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/ja_JP/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/ja_JP/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -33,29 +33,29 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "メンバーは音声対応ではないため、このコマンドは使用できません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "ボイスチャンネルでない場合、このコマンドは使用できません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBotにチャンネルで接続する権限がありません: `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBotにチャンネルで話す権限がありません: `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -64,23 +64,23 @@ msgstr ""
 "後でもう一度試すか、続行するとボットを再起動してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr "ボイスチャットへのMusicBot接続がキャンセルされました。これは奇妙です。再起動しますか？"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot には話す権限がありません。"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot は話すことができませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -89,43 +89,43 @@ msgstr ""
 "召喚コマンドを使ってボットをボイスチャンネルに連れてきてください。"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "問題が発生しました。VoiceClientを取得できませんでした。"
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr "次の曲をスキップする `%(title)s`リクエスターとしての`%(user)s`は声になっていません！"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr "%(mention)s - あなたの曲「%(title)s」が %(channel)sで再生されました！"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "%(channel)sで遊んでいます: `%(title)s`が %(author)s によって追加されました!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr "%(user)s によって追加された曲を声に出していないのでスキップしています！"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -137,12 +137,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "無効なレスポンスオブジェクトを送信しようとしました。"
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -156,13 +156,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "The requested song `%(subject)s` is blocked by the song block list."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -171,29 +171,29 @@ msgstr ""
 "このコマンドは、将来のバージョンでは削除され、自動プレイリストコマンドに置き換えられます。"
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr "コマンドの使用状況と説明を表示するか、利用可能なすべてのコマンドを一覧表示します。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**このコマンドのエイリアス:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -204,7 +204,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -216,12 +216,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "そのようなコマンドはありません"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -229,7 +229,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -251,22 +251,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    メンションされたユーザーをブロックします。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    メンションしたユーザーのブロックを解除します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    メンションされたユーザーのブロックステータスを表示します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -275,42 +275,42 @@ msgstr ""
 "ブロックされたユーザーはすべてのボットコマンドを使用できません。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "ユーザーに言及するか、ID番号を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "無効なサブコマンドが与えられました。使用例には `help blockuser` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBotは指定したユーザーを見つけることができませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "オーナーをブロックリストに追加できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "ユーザーブロックリストは現在有効です。"
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "ユーザーのブロックリストは現在無効です。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "あなたがリストしたユーザーを追加することはできません、すでに追加されています。"
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -320,24 +320,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "それらのユーザーのいずれもブラックリストにありません。"
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "ユーザー: `%(user)s` はブロックされていません。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "ユーザー: `%(user)s` がブロックされました。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -349,7 +349,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -359,7 +359,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -370,23 +370,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "現在再生中の曲がない場合は、曲の件名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "無効なサブコマンドが与えられました。使用例には `help blocksong` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Subject `%(subject)s` はすでにソングブロックリストにあります。"
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -396,12 +396,12 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "件名はソングブロックリストにないため、削除できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -411,85 +411,85 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr "    指定した曲を追加または削除するか、現在プレイリストに曲を再生中です。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    ギルドプレイリストにキュー全体を追加します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr "    このギルドのデフォルトとしてプレイリストを設定し、ギルドの自動プレイリストを再ロードします。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr "無効なサブコマンドが与えられました。使用例には `help autoplaylist` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "指定された曲のリンクは無効です"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "キューが空です。再生コマンドで曲を追加してください！"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "キュー内のすべての曲はすでに自動プレイリストにあります。"
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "自動プレイリストに %(number)d 曲を追加しました。"
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "自動プレイリストに「%(url)s」を追加しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "この曲はすでに自動プレイリストにあります。"
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "自動プレイリストから`%(url)s`を削除しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "この曲はまだ自動プレイリストに入っていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "プレイリストの新しいコピーを読み込みました: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "プレイリストファイル名を指定する必要があります。"
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -498,19 +498,19 @@ msgstr ""
 "このプレイリストは新規です。ディスクに保存するには曲を追加してください！"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr "このサーバーのプレイリストが更新されました: `%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr "このボットを他のサーバーに追加するために使用できる招待リンクを生成します。"
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -520,7 +520,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -529,28 +529,28 @@ msgstr ""
 "カラオケメンバーであるBypassKaraokeMode権限制御を持つグループ。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\N{OK HAND SIGN} カラオケモードが有効になりました。"
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\N{OK HAND SIGN} カラオケモードが無効になりました。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "プレイリストをリクエストする権限がありません"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "プレイリストのエントリが多すぎます(%(songs)s ですが、最大は %(max)s です)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -559,12 +559,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "Botは以前に一時停止されていました。再生を再開しています。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -575,20 +575,20 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
 msgstr "キューに追加する前にプレイリストエントリをシャッフルするコマンドを再生します。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "`%(request)s`からのキューにプレイリストアイテムをシャッフルしました"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -597,7 +597,7 @@ msgstr ""
 "サポートされている入力に関する情報については、playコマンドのヘルプを参照してください。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -606,7 +606,7 @@ msgstr ""
 "サポートされている入力に関する情報については、playコマンドのヘルプを参照してください。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -615,33 +615,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "何もプレイしていない場合はシークを使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "現在のトラックでシークを使用することはできません、それは不明な期間を持っています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Seeking is not supported for streams."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "再生を配置する時間がなければシークは使用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "`%(input)s`を秒単位で有効な時間に変換できませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -650,14 +650,14 @@ msgstr ""
 "`%(input)s/%(seconds)s`の長さのトラックの`%(progress)s `（` %(total)s`秒）をシークできません"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr "現在の曲には、%(input)s`（`%(seconds).2f`秒）を求めています。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -665,62 +665,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr "再生中の曲はありません。再生コマンドで何か再生できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr "無効なサブコマンドです。使用例には「ヘルプの繰り返し」コマンドを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "プレイリストが繰り返されています。"
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "プレイリストはもう繰り返しません。"
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "プレーヤーは現在の曲をループさせます。"
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "プレーヤーは現在の曲をループしなくなります。"
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "プレイヤーは既に曲をループしています！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "プレーヤーは現在ループしていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "歌はもう繰り返されません。"
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "歌が繰り返されています。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    位置から位置へ曲を移動します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -729,29 +729,29 @@ msgstr ""
 "トラック位置番号を検索するにはキューコマンドを使用します。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr "曲がキューに追加されていません。再生コマンドで何かを再生します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "曲の位置は整数でなければなりません！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "プレイリストのサイズ以外の位置を指定しました！"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr "曲をキューの %(from)s から %(to)sに移動しました！"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -765,33 +765,33 @@ msgstr ""
 "プレイリストもキューに入れますか？"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "ローカルメディアの再生が有効になっていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "SpotifyのURLが無効または現在サポートされていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Spotify の URL が検出されましたが、Spotify は有効ではありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "キューに登録された曲の上限に達しました (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "カラオケモードが有効になっています。無効になったらもう一度お試しください！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -801,15 +801,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "動画を再生できません。streamコマンドを使用してみてください。"
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "YouTubeの検索結果が  %(url)sにはありませんでした"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -981,7 +975,7 @@ msgid "Show information on what is currently playing."
 msgstr "現在プレイ中の情報を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1018,7 +1012,7 @@ msgstr "進行状況:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "曲がキューに追加されていません! playコマンドで何かをキューに追加します。"
 
@@ -1123,34 +1117,25 @@ msgstr "現在キュー内のすべての曲を削除します。"
 msgid "Cleared all songs from the queue."
 msgstr "キューからすべての曲を消去しました。"
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "削除するキューがありません！"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "削除された`%(track)s` によって追加された`%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s`からのキューには何も見つかりませんでした。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1159,24 +1144,24 @@ msgstr ""
 "キューに登録した方、または即座にスキップ権限を持っている必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "無効なエントリ番号です。キューの位置を見つけるには、キューコマンドを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "削除された項目 `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1184,23 +1169,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "スキップできません！プレイヤーがプレイしていません！"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "次の曲「%(track)s」がダウンロードされています。お待ちください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "次の曲はまもなく再生されます。しばらくお待ちください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1209,7 +1194,7 @@ msgstr ""
 "動作し始めない場合は再起動してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1218,28 +1203,28 @@ msgstr ""
 "動き始めない場合は再起動してください。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "ループされた曲をスキップする権限がありません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "`%(track)s`を強制スキップしました。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "スキップを強制する権限がありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "ループ曲をスキップする権限がありません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1249,12 +1234,12 @@ msgstr ""
 "スキップへの投票が完了しました。%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " 次の曲が登場！"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1264,7 +1249,7 @@ msgstr ""
 "この曲をスキップするには**%(votes)s**以上の投票が必要です。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1272,25 +1257,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "現在のボリューム: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "'%(new_volume)s' は有効な数字ではありません"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "**%(old)d**から**%(new)d **までの音量を更新しました **"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1300,14 +1285,14 @@ msgstr ""
 "ボリュームは1から100まで設定できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "不合理なボリュームが提供されました: %(volume)s. 1から100までの値を入力してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1315,7 +1300,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1324,56 +1309,56 @@ msgstr ""
 "デフォルトの再生速度を設定するにはconfigコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "ストリームメディアには速度を適用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "設定する速度を提供する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "指定した速度が無効です。0.5 から 100までの数字を使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr "現在のトラックの再生速度を「%(speed).3f」に設定しました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    オプション引数を持つ新しいエイリアスを追加します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr "ディスコードからエイリアスを管理できます。エイリアスを表示するにはヘルプコマンドを使用します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "コマンドの無効なオプション: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "エイリアスが設定ファイルからリロードされました。"
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "エイリアスを設定ファイルに保存しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1383,104 +1368,104 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "エイリアスにエイリアスとコマンドを提供する必要があります"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "新しいエイリアスが追加されました。`%(alias)s`は`%(command)s`のエイリアスになりました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "削除するにはエイリアス名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "エイリアス`%(alias)s`は削除されました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    不足している設定オプションについてヘルプテキストを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr "    設定ファイルの読み込み時に変更されたオプションの名前を一覧表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr "    利用可能な設定オプションとそのセクションを一覧表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    特定のオプションのヘルプテキストを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    オプションの現在の値を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    現在の値をオプションファイルに保存します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr "    オプションを検証し、セッションの設定をファイルではなく設定します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    オプションをデフォルト値にリセットします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Discord内で options.ini の設定を管理します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "設定では、チャンネルとユーザーのメンションを同時に使用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*すべての設定オプションが存在し、考慮されています！*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "設定オプションは変更されていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1490,7 +1475,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1506,12 +1491,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "設定オプションが正常にファイルから再読み込みされました！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1521,24 +1506,24 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "オプション名からセクション名を解決できませんでした。有効なセクション名とオプション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "与えられたオプションは曖昧です。セクション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "このコマンドのセクション名とオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1548,24 +1533,24 @@ msgstr ""
 "The available section:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "オプション `%(option)s` は使用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr "このオプションは設定ファイルを編集することでのみ設定できます。"
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "デフォルトでは、このオプションは %(default)s に設定されています"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1579,31 +1564,31 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "オプション `%(option)s` は編集できません。ディスクに保存できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "オプションの保存に失敗しました: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "正常にオプションを保存しました: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` は編集できません。値を表示できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1612,24 +1597,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "オプション `%(option)s` は編集できません。設定を更新できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "このサブコマンドのセクション、オプション、値を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` は更新されませんでした！"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1639,19 +1624,19 @@ msgstr ""
 "To save the change use `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "オプション `%(option)s` は編集できません。デフォルトにリセットできません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` はデフォルトにリセットされませんでした！"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1661,17 +1646,17 @@ msgstr ""
 "変更を保存するには、 `config save %(section)s %(option)s ` を使用してください"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "非推奨のコマンドは、configコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "option コマンドは推奨されません。config コマンドを使用してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1680,33 +1665,33 @@ msgstr ""
 "updateオプションを使用すると、詳細を表示する前に外部の変更のキャッシュをスキャンします。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "無効なオプションが指定されました。情報、更新、またはクリアを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "無効"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "有効"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s 日"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "無制限です"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1722,22 +1707,22 @@ msgstr ""
 "**キャッシュされた:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "キャッシュがクリアされました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**キャッシュの削除に失敗しました。ログの詳細を確認してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "クリアするキャッシュが見つかりません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1746,12 +1731,12 @@ msgstr ""
 "オプションのページ番号は、キューの後のエントリを表示します。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "キューページ引数は整数でなければなりません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1761,12 +1746,12 @@ msgstr ""
 "**%(total)s** ページがあります。"
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(不明な期間)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1778,7 +1763,7 @@ msgstr ""
 "進捗: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1792,12 +1777,12 @@ msgstr ""
 "%(tracks)s から始まります。"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "キュー内の曲"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1806,7 +1791,7 @@ msgstr ""
 "問題が解決しない場合は、バグレポートを送信してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1814,38 +1799,38 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "無効なパラメータです。検索するために、多数のメッセージを入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "プライベート DM チャンネルでパージを使用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "%(number)s メッセージをクリーンアップしました。"
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Botにメッセージを管理する権限がありません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "プレイリストの個々の URL をファイルにダンプします。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "指定されたURLは有効なURLではありませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1853,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "これはプレイリストではないようです。"
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "次のプレイリストダンプがあります:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1873,19 +1858,19 @@ msgstr ""
 "このコマンドはDiscordクライアントの開発者モードを支持して非推奨です。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "あなたのユーザーIDは `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "`%(username)s`のユーザーIDは`%(id)s`です"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1893,36 +1878,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "有効なカテゴリ: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "要求されたIDは次のとおりです："
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "アクセス権の一覧、またはメンションされたユーザーの権限を取得します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "無効なユーザーIDまたはサーバーニックネームです。IDを再確認してもう一度やり直してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "discordユーザーを特定できませんでした。もう一度お試しください。"
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1936,7 +1921,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1950,62 +1935,62 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    ロードされたグループと権限オプションを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    パーミッション.ini ファイルからパーミッションを再読み込みします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    新しいグループをデフォルトで追加します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    既存のグループを削除します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    権限オプションのヘルプテキストを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    指定されたグループと権限の権限値を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    権限グループをファイルに保存します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    グループの権限値を設定します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "discord内からpermissions.iniの設定を管理します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "権限は同時にチャンネルとユーザーメンションを使用することはできません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "権限がファイルから正常に再読み込みされました！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2015,7 +2000,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2029,23 +2014,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "このコマンドのグループまたはオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "このコマンドに設定するには、グループ、オプション、値を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s サブコマンドにはグループ名と権限名が必要です。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2055,24 +2040,24 @@ msgstr ""
 "The available groups is :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "パーミッション`%(option)s`は利用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr "この権限は権限ファイルを編集することでのみ設定できます。"
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "デフォルトでは、この権限は次に設定されています: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2086,13 +2071,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "グループを追加できません`%(group)s` が既に存在します。"
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2101,12 +2086,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "組み込みグループを削除できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2114,24 +2099,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "オーナーグループは編集できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "グループの保存に失敗しました: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "グループを正常に保存しました: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2140,13 +2125,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "パーミッション`%(option)s`は更新されませんでした！"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2156,7 +2141,7 @@ msgstr ""
 "変更を保存するには、 `setperms save %(section)s %(option)s ` を使います。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2165,7 +2150,7 @@ msgstr ""
 "注意: APIは名前の変更を1時間に2回まで制限する場合があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2174,7 +2159,7 @@ msgstr ""
 "名前の変更は1時間に2回に制限されています。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2184,23 +2169,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "ボットのユーザー名を `%(name)s` に設定します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "MusicBotのニックネームを変更します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "ニックネームを変更できません: 権限がありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2210,23 +2195,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "ボットのニックネームを `%(nick)s` に設定しました"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    サーバー毎のコマンドプレフィックスを設定します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    サーバー毎のコマンドプレフィックスをクリアします。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2235,23 +2220,23 @@ msgstr ""
 "オプションEnablePrefixPerGuildが最初に有効になっている必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "プレフィックスとして使用するには、このサーバーからカスタム絵文字を使用する必要があります。"
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "サーバーのコマンドプレフィックスがクリアされました。"
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "サーバーのコマンドプレフィックスは現在:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2260,37 +2245,37 @@ msgstr ""
 "configコマンドを使用して、代わりにプレフィックスを更新してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    使用可能な言語コードを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    このサーバーの言語を設定してください。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    サーバーの言語をボットのデフォルト言語にリセットします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "通話サーバーのメッセージに使用される言語を管理します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "このコマンドはギルドでのみ使用できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "指定された無効なサブコマンドです。詳細についてはヘルプコマンドを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2304,25 +2289,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "言語を`%(locale)s`に設定できません。利用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "このサーバーの言語は次のように設定されました: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "このサーバーの言語がリセットされました: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2331,12 +2316,12 @@ msgstr ""
 "ファイルを添付してURLパラメータを省略することもできます。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "URLを入力するか、ファイルを添付する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2346,62 +2331,62 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "ボットのアバターを変更しました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "MusicBotを強制的にDiscordサーバーから切断します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "サーバーから切断されました`%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "現在サーバーに接続されていません `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr "    プロセスを再起動せずに再読み込みしようとします。デフォルトのオプションです。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr "    完全な再起動ですが、再起動前に pip パッケージを更新しようとします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    完全に再起動しますが、最初にGitでMusicBotのソースコードをアップデートしてください。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr "    完全に再起動する前に、すべての依存関係とソースコードを更新しようとしています。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2410,54 +2395,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "無効なオプションが与えられました。ソフト、フル、アップグレード、uppip、またはupgitのいずれかを使用してください"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s 現在のインスタンスを再起動中..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s ボットを再起動中..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr "%(emoji)s 必要な pip パッケージのアップグレードを試み、ボットを再起動します..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "%(emoji)s git でボットコードを更新しようとし、ボットを再起動します..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s はすべてをアップグレードしてボットを再起動します..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "すべてのボイスチャンネルから切断し、MusicBotプロセスを閉じます。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Discordサーバー名またはサーバーIDを指定したままにしてください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2466,30 +2451,30 @@ msgstr ""
 "名前は大文字と小文字を区別しますので、ID番号を使用する方が信頼性が高くなります。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "IDまたは名前を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "IDまたは名前のギルドが見つかりませんでした。`%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "不明"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "ギルドを退出: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2498,38 +2483,38 @@ msgstr ""
 "MusicBotログファイルのイベントを手動で特定するために使用できます。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "IDでログインしたブレークポイント:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Objgraphによって報告された最も一般的なタイプを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    制限付きobjgraph.show_growth() 出力を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    漏洩オブジェクトの最も一般的なタイプを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    漏れたオブジェクトの型番を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    objgraphで与えられた関数と引数を評価します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2537,12 +2522,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "`objgraph` をインポートできませんでした。インストールされていますか？"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2557,7 +2542,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2573,7 +2558,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2582,73 +2567,73 @@ msgstr ""
 "出力は GitHub Pages の更新に使用されるため、通常の参照使用には適していません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "サブコマンドは次のいずれかでなければなりません： %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "デフォルトのINIファイルを作成します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "要求されたINIファイルをディスクに保存しました。確認してください"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr "現在のボットバージョンを表示し、MusicBotまたは依存関係の更新を確認します。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "git 実行可能ファイルが見つかりませんでした。"
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "ブランチにアップデートはありません。`%(branch)s`リモコン。"
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "新しいコミットは、`%(branch)s`ブランチリモコンで利用できます。"
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "チェック中にエラーが発生しました。詳細はログを参照してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Update for `%(name)s` to version: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "依存関係の更新は見つかりません。"
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "MusicBotのアップデートがダウンロードできます。"
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBotは完全に最新です！"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2668,52 +2653,52 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "MusicBotの起動時間、または前回の起動/再起動からの時間を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s は `%(time)s` のオンラインになりました"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr "Discord APIと接続しているすべてのボイスクライアントのレイテンシー情報を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "音声クライアントが接続されていません。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "MusicBotが接続されている場合は、APIレイテンシーと音声レイテンシーを表示します。"
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "自動"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "チャットで MusicBot のバージョン番号を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2723,17 +2708,17 @@ msgstr ""
 "現在のバージョン: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    cookies.txt 添付ファイルを使用して、cookies.txt ファイルを更新します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    cookies.txt ファイルを削除せずに有効または無効にします。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2748,28 +2733,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "クッキーは既に有効になっています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "クッキーを有効にするには、アップロードする必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "エラーのためクッキーを有効にできませんでした:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "クッキーが有効になりました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2779,62 +2764,62 @@ msgstr ""
 "クッキーは一時的に無効化され、次回の再起動時に再度有効になります。"
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Cookieは無効になっています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "添付されたアップロードが見つかりませんでした。Cookie ファイルのアップロード中に再試行してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "discordからCookieファイルをダウンロード中にエラーが発生しました:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "ディスクにクッキーを保存できませんでした:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookieがアップロードされ有効になりました。"
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "このボットはプライベートメッセージでは使用できません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "このコマンドは権限グループには許可されていません：  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "このコマンドを使用するには、ボイスチャンネルに参加する必要があります。"
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**コマンド:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "例外エラー"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2844,17 +2829,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "説明がありません。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "使用されていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2868,13 +2853,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "音声チャンネル %(channel)s を離れています。"
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Botの所有者が見つからなかったため、%(guild)sを残しました。"
@@ -3411,23 +3396,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "ブロックリストを空にせずに、ユーザーのブロックリスト機能を切り替えます。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr "DiscordユーザーIDを一行に1つリストするテキストファイルへのオプションのファイルパスです。"
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "ブロックリストを空にせずに、ソングブロックリスト機能を有効にします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3436,7 +3421,7 @@ msgstr ""
 "リスト内の任意の行を含む曲名やURLはブロックされます。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3445,7 +3430,7 @@ msgstr ""
 "各ファイルには、プレイ可能な URL または用語のリストが含まれている必要があります。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3455,14 +3440,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr "MusicBotが長く短いキャッシュを保存するオプションのディレクトリパスです。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3471,7 +3456,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3480,7 +3465,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3498,7 +3483,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3510,7 +3495,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3532,7 +3517,7 @@ msgstr ""
 "  設定が有効であることを再確認してください。 アクセス可能なディレクトリパス"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3545,7 +3530,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3558,7 +3543,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3570,7 +3555,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3592,7 +3577,7 @@ msgstr ""
 "  設定フォルダとファイルが存在することを確認し、MusicBotによって読み込まれます。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3607,7 +3592,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3620,7 +3605,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3633,7 +3618,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3646,32 +3631,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "ヘッダがないみたいだな。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "曲情報の抽出はデータを返しませんでした。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "抽出を続行できません。イベントループは閉じられています。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "SpotifyのURLが無効かサポートされていません。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "無効なURLをストリーミングできません。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "ローカルメディアファイルが見つかりません。"
 
@@ -3694,13 +3679,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "yt-dlpエラーのためダウンロードに失敗しました: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "未処理の例外のためダウンロードに失敗しました: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "要求されたメディアのデータの抽出に失敗しました。"
 
@@ -3864,28 +3849,28 @@ msgstr ""
 "yt-dlp extractor `%(extractor)s` はあなたのグループでは許可されていません。"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "情報を抽出できませんでした"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "これはプレイリストです。"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "無効なコンテンツタイプ`%(type)s`の URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "持続時間データがありません"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "現在のエントリに期間データがありません"
 
@@ -3964,21 +3949,21 @@ msgid "Only dev users can use this command."
 msgstr "このコマンドは開発者のみが使用できます。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -3986,13 +3971,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -4004,22 +3989,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4047,61 +4032,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4109,7 +4094,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4119,7 +4104,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4143,40 +4128,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4184,13 +4162,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4209,7 +4187,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4218,7 +4196,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4249,28 +4227,119 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "YouTubeの検索結果が  %(url)sにはありませんでした"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr "自動プレイリストファイルとギルドごとの設定を管理します。"

--- a/i18n/ja_JP/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/ja_JP/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -734,7 +734,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr "曲がキューに追加されていません。再生コマンドで何かを再生します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "曲の位置は整数でなければなりません！"
 
@@ -770,28 +770,28 @@ msgid "Local media playback is not enabled."
 msgstr "ローカルメディアの再生が有効になっていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "SpotifyのURLが無効または現在サポートされていません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Spotify の URL が検出されましたが、Spotify は有効ではありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "キューに登録された曲の上限に達しました (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "カラオケモードが有効になっています。無効になったらもう一度お試しください！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -801,19 +801,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "動画を再生できません。streamコマンドを使用してみてください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr "曲が追加されていません。すべての曲が最大時間（%(max)s 秒）を超えています。"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -823,13 +823,13 @@ msgstr ""
 "キュー内の位置: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "曲の再生時間が制限を超えています(%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -837,24 +837,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "次にプレイ！"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - 再生までの推定時間: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - プレイするまでの時間を見積もることはできません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -863,23 +863,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "ストリーミングプレイリストはまだサポートされていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "トラックをストリーミング中 `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr "    検索クエリで多数の結果をサービスで検索します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -888,58 +888,58 @@ msgstr ""
 "    注意: この場合はダブルクォートが必要です。\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "プレイリストアイテムの上限に達しました (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr "検索クエリを指定してください。詳細は `ヘルプ検索` を使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "%(max)s 以上の動画を検索することはできません"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "動画を検索しています..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "エラーのため検索に失敗しました: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "動画が見つかりません。"
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "曲を選択するには、対応する番号を入力します。"
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "%(service)s からの検索結果 :"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** | %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -948,194 +948,194 @@ msgstr ""
 "**0** . キャンセル"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "曲を選択"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "曲[%(track)s](%(url)s) をキューに追加しました。"
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "結果 %(number)s of %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "よし、すぐに来るぞ！"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "現在プレイ中の情報を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "再生中"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "現在ストリーミング中:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "現在プレイ中:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "追加者:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "進行状況:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "曲がキューに追加されていません! playコマンドで何かをキューに追加します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "あなたのチャンネルに参加するようMusicBotに伝えてください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "音声に接続されていません。音声チャンネルに参加してみてください！"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "`%(channel)s に接続しました`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr "MusicBotがサーバー内のチャンネルを変更したときにユーザーに従うようにします。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "もうユーザーをフォローしていません `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "ボイスチャンネル間のユーザー`%(user)s`をフォローしました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot はサーバーのメンバーではないユーザーをフォローできません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "ボイスチャンネル間のユーザー`%(user)s`に従います。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "トラックが再生中の場合、再生を一時停止します。"
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "音楽を一時停止しました`%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "プレイヤーがプレイしていません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "プレーヤーが以前に一時停止していた場合、再生を再開します。"
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "音楽を%(channel)s で再開しました"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "再開された音楽キュー"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "プレイヤーは一時停止されていません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "キュー内の現在のトラックをすべてシャッフルします。"
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "キュー内のすべての曲をシャッフルしました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "現在キュー内のすべての曲を削除します。"
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "キューからすべての曲を消去しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "削除するキューがありません！"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "削除された`%(track)s` によって追加された`%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s`からのキューには何も見つかりませんでした。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1144,24 +1144,24 @@ msgstr ""
 "キューに登録した方、または即座にスキップ権限を持っている必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "無効なエントリ番号です。キューの位置を見つけるには、キューコマンドを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "削除された項目 `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1169,23 +1169,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "スキップできません！プレイヤーがプレイしていません！"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "次の曲「%(track)s」がダウンロードされています。お待ちください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "次の曲はまもなく再生されます。しばらくお待ちください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1194,7 +1194,7 @@ msgstr ""
 "動作し始めない場合は再起動してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1203,28 +1203,28 @@ msgstr ""
 "動き始めない場合は再起動してください。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "ループされた曲をスキップする権限がありません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "`%(track)s`を強制スキップしました。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "スキップを強制する権限がありません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "ループ曲をスキップする権限がありません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1234,12 +1234,12 @@ msgstr ""
 "スキップへの投票が完了しました。%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " 次の曲が登場！"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1249,7 +1249,7 @@ msgstr ""
 "この曲をスキップするには**%(votes)s**以上の投票が必要です。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1257,25 +1257,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "現在のボリューム: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "'%(new_volume)s' は有効な数字ではありません"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "**%(old)d**から**%(new)d **までの音量を更新しました **"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1285,14 +1285,14 @@ msgstr ""
 "ボリュームは1から100まで設定できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "不合理なボリュームが提供されました: %(volume)s. 1から100までの値を入力してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1300,7 +1300,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1309,56 +1309,56 @@ msgstr ""
 "デフォルトの再生速度を設定するにはconfigコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "ストリームメディアには速度を適用できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "設定する速度を提供する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "指定した速度が無効です。0.5 から 100までの数字を使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr "現在のトラックの再生速度を「%(speed).3f」に設定しました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    オプション引数を持つ新しいエイリアスを追加します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr "ディスコードからエイリアスを管理できます。エイリアスを表示するにはヘルプコマンドを使用します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "コマンドの無効なオプション: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "エイリアスが設定ファイルからリロードされました。"
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "エイリアスを設定ファイルに保存しました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1368,104 +1368,104 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "エイリアスにエイリアスとコマンドを提供する必要があります"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "新しいエイリアスが追加されました。`%(alias)s`は`%(command)s`のエイリアスになりました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "削除するにはエイリアス名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "The alias `%(alias)s` does not exist."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "エイリアス`%(alias)s`は削除されました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    不足している設定オプションについてヘルプテキストを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr "    設定ファイルの読み込み時に変更されたオプションの名前を一覧表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr "    利用可能な設定オプションとそのセクションを一覧表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    特定のオプションのヘルプテキストを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    オプションの現在の値を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    現在の値をオプションファイルに保存します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr "    オプションを検証し、セッションの設定をファイルではなく設定します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    オプションをデフォルト値にリセットします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Discord内で options.ini の設定を管理します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "設定では、チャンネルとユーザーのメンションを同時に使用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*すべての設定オプションが存在し、考慮されています！*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "設定オプションは変更されていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1475,7 +1475,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1491,12 +1491,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "設定オプションが正常にファイルから再読み込みされました！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1506,24 +1506,24 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "オプション名からセクション名を解決できませんでした。有効なセクション名とオプション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "与えられたオプションは曖昧です。セクション名を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "このコマンドのセクション名とオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1533,24 +1533,24 @@ msgstr ""
 "The available section:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "オプション `%(option)s` は使用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr "このオプションは設定ファイルを編集することでのみ設定できます。"
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "デフォルトでは、このオプションは %(default)s に設定されています"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1564,31 +1564,31 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "オプション `%(option)s` は編集できません。ディスクに保存できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "オプションの保存に失敗しました: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "正常にオプションを保存しました: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Option `%(option)s` は編集できません。値を表示できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1597,24 +1597,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "オプション `%(option)s` は編集できません。設定を更新できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "このサブコマンドのセクション、オプション、値を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Option `%(option)s` は更新されませんでした！"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1624,19 +1624,19 @@ msgstr ""
 "To save the change use `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr "オプション `%(option)s` は編集できません。デフォルトにリセットできません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Option `%(option)s` はデフォルトにリセットされませんでした！"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1646,17 +1646,17 @@ msgstr ""
 "変更を保存するには、 `config save %(section)s %(option)s ` を使用してください"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "非推奨のコマンドは、configコマンドを使用してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "option コマンドは推奨されません。config コマンドを使用してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1665,33 +1665,33 @@ msgstr ""
 "updateオプションを使用すると、詳細を表示する前に外部の変更のキャッシュをスキャンします。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "無効なオプションが指定されました。情報、更新、またはクリアを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "無効"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "有効"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s 日"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "無制限です"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1707,22 +1707,22 @@ msgstr ""
 "**キャッシュされた:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "キャッシュがクリアされました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**キャッシュの削除に失敗しました。ログの詳細を確認してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "クリアするキャッシュが見つかりません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1731,12 +1731,12 @@ msgstr ""
 "オプションのページ番号は、キューの後のエントリを表示します。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "キューページ引数は整数でなければなりません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1746,12 +1746,12 @@ msgstr ""
 "**%(total)s** ページがあります。"
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(不明な期間)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1763,7 +1763,7 @@ msgstr ""
 "進捗: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1777,12 +1777,12 @@ msgstr ""
 "%(tracks)s から始まります。"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "キュー内の曲"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1791,7 +1791,7 @@ msgstr ""
 "問題が解決しない場合は、バグレポートを送信してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1799,38 +1799,38 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "無効なパラメータです。検索するために、多数のメッセージを入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "プライベート DM チャンネルでパージを使用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "%(number)s メッセージをクリーンアップしました。"
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Botにメッセージを管理する権限がありません。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "プレイリストの個々の URL をファイルにダンプします。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "指定されたURLは有効なURLではありませんでした。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1838,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "これはプレイリストではないようです。"
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "次のプレイリストダンプがあります:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1858,19 +1858,19 @@ msgstr ""
 "このコマンドはDiscordクライアントの開発者モードを支持して非推奨です。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "あなたのユーザーIDは `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "`%(username)s`のユーザーIDは`%(id)s`です"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1878,36 +1878,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "有効なカテゴリ: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "要求されたIDは次のとおりです："
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "アクセス権の一覧、またはメンションされたユーザーの権限を取得します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "無効なユーザーIDまたはサーバーニックネームです。IDを再確認してもう一度やり直してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "discordユーザーを特定できませんでした。もう一度お試しください。"
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1921,7 +1921,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1935,62 +1935,62 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    ロードされたグループと権限オプションを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    パーミッション.ini ファイルからパーミッションを再読み込みします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    新しいグループをデフォルトで追加します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    既存のグループを削除します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    権限オプションのヘルプテキストを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    指定されたグループと権限の権限値を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    権限グループをファイルに保存します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    グループの権限値を設定します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "discord内からpermissions.iniの設定を管理します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "権限は同時にチャンネルとユーザーメンションを使用することはできません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "権限がファイルから正常に再読み込みされました！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2000,7 +2000,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2014,23 +2014,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "このコマンドのグループまたはオプション名を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "このコマンドに設定するには、グループ、オプション、値を指定する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s サブコマンドにはグループ名と権限名が必要です。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2040,24 +2040,24 @@ msgstr ""
 "The available groups is :  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "パーミッション`%(option)s`は利用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr "この権限は権限ファイルを編集することでのみ設定できます。"
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "デフォルトでは、この権限は次に設定されています: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2071,13 +2071,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "グループを追加できません`%(group)s` が既に存在します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2086,12 +2086,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "組み込みグループを削除できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2099,24 +2099,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "オーナーグループは編集できません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "グループの保存に失敗しました: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "グループを正常に保存しました: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2125,13 +2125,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "パーミッション`%(option)s`は更新されませんでした！"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2141,7 +2141,7 @@ msgstr ""
 "変更を保存するには、 `setperms save %(section)s %(option)s ` を使います。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2150,7 +2150,7 @@ msgstr ""
 "注意: APIは名前の変更を1時間に2回まで制限する場合があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2159,7 +2159,7 @@ msgstr ""
 "名前の変更は1時間に2回に制限されています。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2169,23 +2169,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "ボットのユーザー名を `%(name)s` に設定します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "MusicBotのニックネームを変更します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "ニックネームを変更できません: 権限がありません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2195,23 +2195,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "ボットのニックネームを `%(nick)s` に設定しました"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    サーバー毎のコマンドプレフィックスを設定します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    サーバー毎のコマンドプレフィックスをクリアします。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2220,23 +2220,23 @@ msgstr ""
 "オプションEnablePrefixPerGuildが最初に有効になっている必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "プレフィックスとして使用するには、このサーバーからカスタム絵文字を使用する必要があります。"
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "サーバーのコマンドプレフィックスがクリアされました。"
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "サーバーのコマンドプレフィックスは現在:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2245,37 +2245,37 @@ msgstr ""
 "configコマンドを使用して、代わりにプレフィックスを更新してください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    使用可能な言語コードを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    このサーバーの言語を設定してください。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    サーバーの言語をボットのデフォルト言語にリセットします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "通話サーバーのメッセージに使用される言語を管理します。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "このコマンドはギルドでのみ使用できます。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "指定された無効なサブコマンドです。詳細についてはヘルプコマンドを使用してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2289,25 +2289,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "言語を`%(locale)s`に設定できません。利用できません。"
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "このサーバーの言語は次のように設定されました: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "このサーバーの言語がリセットされました: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2316,12 +2316,12 @@ msgstr ""
 "ファイルを添付してURLパラメータを省略することもできます。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "URLを入力するか、ファイルを添付する必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2331,62 +2331,62 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "ボットのアバターを変更しました。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "MusicBotを強制的にDiscordサーバーから切断します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "サーバーから切断されました`%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "現在サーバーに接続されていません `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr "    プロセスを再起動せずに再読み込みしようとします。デフォルトのオプションです。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr "    完全な再起動ですが、再起動前に pip パッケージを更新しようとします。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    完全に再起動しますが、最初にGitでMusicBotのソースコードをアップデートしてください。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr "    完全に再起動する前に、すべての依存関係とソースコードを更新しようとしています。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2395,54 +2395,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "無効なオプションが与えられました。ソフト、フル、アップグレード、uppip、またはupgitのいずれかを使用してください"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s 現在のインスタンスを再起動中..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s ボットを再起動中..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr "%(emoji)s 必要な pip パッケージのアップグレードを試み、ボットを再起動します..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "%(emoji)s git でボットコードを更新しようとし、ボットを再起動します..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s はすべてをアップグレードしてボットを再起動します..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "すべてのボイスチャンネルから切断し、MusicBotプロセスを閉じます。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Discordサーバー名またはサーバーIDを指定したままにしてください。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2451,12 +2451,12 @@ msgstr ""
 "名前は大文字と小文字を区別しますので、ID番号を使用する方が信頼性が高くなります。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "IDまたは名前を入力してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "IDまたは名前のギルドが見つかりませんでした。`%(input)s`"
@@ -2468,13 +2468,13 @@ msgid "Unknown"
 msgstr "不明"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "ギルドを退出: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2483,38 +2483,38 @@ msgstr ""
 "MusicBotログファイルのイベントを手動で特定するために使用できます。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "IDでログインしたブレークポイント:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Objgraphによって報告された最も一般的なタイプを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    制限付きobjgraph.show_growth() 出力を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    漏洩オブジェクトの最も一般的なタイプを表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    漏れたオブジェクトの型番を表示します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    objgraphで与えられた関数と引数を評価します。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2522,12 +2522,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "`objgraph` をインポートできませんでした。インストールされていますか？"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2542,7 +2542,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2558,7 +2558,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2567,73 +2567,73 @@ msgstr ""
 "出力は GitHub Pages の更新に使用されるため、通常の参照使用には適していません。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "サブコマンドは次のいずれかでなければなりません： %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "デフォルトのINIファイルを作成します。"
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "要求されたINIファイルをディスクに保存しました。確認してください"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr "現在のボットバージョンを表示し、MusicBotまたは依存関係の更新を確認します。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "git 実行可能ファイルが見つかりませんでした。"
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "ブランチにアップデートはありません。`%(branch)s`リモコン。"
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "新しいコミットは、`%(branch)s`ブランチリモコンで利用できます。"
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "チェック中にエラーが発生しました。詳細はログを参照してください。"
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Update for `%(name)s` to version: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "依存関係の更新は見つかりません。"
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "MusicBotのアップデートがダウンロードできます。"
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBotは完全に最新です！"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2653,52 +2653,52 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "MusicBotの起動時間、または前回の起動/再起動からの時間を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s は `%(time)s` のオンラインになりました"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr "Discord APIと接続しているすべてのボイスクライアントのレイテンシー情報を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "音声クライアントが接続されていません。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "MusicBotが接続されている場合は、APIレイテンシーと音声レイテンシーを表示します。"
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "自動"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "チャットで MusicBot のバージョン番号を表示します。"
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2708,17 +2708,17 @@ msgstr ""
 "現在のバージョン: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    cookies.txt 添付ファイルを使用して、cookies.txt ファイルを更新します。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    cookies.txt ファイルを削除せずに有効または無効にします。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2733,28 +2733,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "クッキーは既に有効になっています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "クッキーを有効にするには、アップロードする必要があります。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "エラーのためクッキーを有効にできませんでした:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "クッキーが有効になりました。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2764,62 +2764,62 @@ msgstr ""
 "クッキーは一時的に無効化され、次回の再起動時に再度有効になります。"
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Cookieは無効になっています。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "添付されたアップロードが見つかりませんでした。Cookie ファイルのアップロード中に再試行してください。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "discordからCookieファイルをダウンロード中にエラーが発生しました:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "ディスクにクッキーを保存できませんでした:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookieがアップロードされ有効になりました。"
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "このボットはプライベートメッセージでは使用できません。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "このコマンドは権限グループには許可されていません：  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "このコマンドを使用するには、ボイスチャンネルに参加する必要があります。"
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**コマンド:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "例外エラー"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2829,17 +2829,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "説明がありません。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "使用されていません。"
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2853,13 +2853,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "音声チャンネル %(channel)s を離れています。"
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Botの所有者が見つからなかったため、%(guild)sを残しました。"
@@ -2966,7 +2966,7 @@ msgstr ""
 "BindToChannels にサーバーの ID がない場合にのみ使用されます。"
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3041,13 +3041,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr "MusicBot がダウンロードしたメディアを保存したり、すぐに削除したりできます。"
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3055,14 +3055,14 @@ msgstr "SaveVideoが有効になっている場合は、使用するストレー
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr "SaveVideoが有効になっている場合、ファイルの保持時間の制限を設定します。"
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3074,26 +3074,26 @@ msgid "Mention the user who added the song when it is played."
 msgstr "再生時に曲を追加したユーザーに言及します。"
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
 msgstr "ボットの起動時にアクセス可能な音声チャンネルにいる場合は、所有者に自動的に参加します。"
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
 msgstr "キューが空の場合、自動プレイリストから音楽を自動再生するには、MusicBotを有効にします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "再生する前に自動プレイリストトラックをシャッフルします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3102,7 +3102,7 @@ msgstr ""
 "自動プレイリストで追加された場合にのみ、現在再生中の曲に適用されます。"
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3157,7 +3157,7 @@ msgstr ""
 "現在、このオプションは、空のキューに追加された自動プレイリストや曲には適用されません。"
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3174,14 +3174,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr "有効にすると、ステータスメッセージは一時停止中のプレイヤーに情報を報告します。"
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3214,14 +3214,14 @@ msgid ""
 msgstr "キューを一覧表示するために q コマンドを使用するときに、ページごとに表示するエントリ数です。"
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
 msgstr "自動再生リストから再生できないエントリを自動的に削除するには、MusicBotを有効にします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr "起動時にログに MusicBot の設定を表示します。"
 
@@ -3234,7 +3234,7 @@ msgid ""
 msgstr "InstaSkip権限を持つユーザーを有効にして、スキップ投票とスキップをバイパスします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3262,13 +3262,13 @@ msgid "Completely remove the footer from embeds."
 msgstr "埋め込みからフッターを完全に削除します。"
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr "MusicBot は音声チャンネルに入ると自動的に聴覚障害を発生します。"
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3276,7 +3276,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3285,14 +3285,14 @@ msgstr ""
 "次のような秒数またはフレーズに設定できます: 4時間"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
 msgstr "有効にすると、MusicBotは曲のキューが空の場合、すぐにチャンネルから退出します。"
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3332,7 +3332,7 @@ msgid ""
 msgstr "有効にして複数のメンバーが曲を追加している場合、MusicBotはメンバーごとに1曲の再生を整理します。"
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3341,7 +3341,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3353,7 +3353,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3374,7 +3374,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr "再生コマンドを使用すると、MusicBotが自動的に一時停止を解除できるようになります。"
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3385,7 +3385,7 @@ msgstr ""
 "無効にするには空白のままにします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3396,23 +3396,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "ブロックリストを空にせずに、ユーザーのブロックリスト機能を切り替えます。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr "DiscordユーザーIDを一行に1つリストするテキストファイルへのオプションのファイルパスです。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "ブロックリストを空にせずに、ソングブロックリスト機能を有効にします。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3421,7 +3421,7 @@ msgstr ""
 "リスト内の任意の行を含む曲名やURLはブロックされます。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3430,7 +3430,7 @@ msgstr ""
 "各ファイルには、プレイ可能な URL または用語のリストが含まれている必要があります。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3440,14 +3440,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr "MusicBotが長く短いキャッシュを保存するオプションのディレクトリパスです。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3456,7 +3456,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3465,7 +3465,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3483,7 +3483,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3495,7 +3495,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3517,7 +3517,7 @@ msgstr ""
 "  設定が有効であることを再確認してください。 アクセス可能なディレクトリパス"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3530,7 +3530,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3543,7 +3543,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3555,7 +3555,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3577,7 +3577,7 @@ msgstr ""
 "  設定フォルダとファイルが存在することを確認し、MusicBotによって読み込まれます。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3592,7 +3592,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3605,7 +3605,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3618,7 +3618,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3631,32 +3631,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "ヘッダがないみたいだな。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "曲情報の抽出はデータを返しませんでした。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "抽出を続行できません。イベントループは閉じられています。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "SpotifyのURLが無効かサポートされていません。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "無効なURLをストリーミングできません。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "ローカルメディアファイルが見つかりません。"
 
@@ -3983,28 +3983,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4032,7 +4032,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4086,7 +4086,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4094,7 +4094,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4104,7 +4104,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4173,7 +4173,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4187,7 +4187,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4196,7 +4196,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4210,7 +4210,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4218,7 +4218,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4227,26 +4227,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4258,28 +4258,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4290,25 +4290,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4317,7 +4317,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/ko_KR/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/ko_KR/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -129,7 +129,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr ""
 
@@ -146,61 +146,43 @@ msgid ""
 "Details: %s. Continuing anyway in 5 seconds..."
 msgstr ""
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr ""
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -210,7 +192,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -220,7 +202,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -230,35 +212,35 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -266,155 +248,155 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -422,65 +404,65 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -488,36 +470,36 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -525,7 +507,7 @@ msgid ""
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -533,364 +515,364 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -904,44 +886,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -949,80 +931,80 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1032,348 +1014,348 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1382,24 +1364,24 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1407,55 +1389,55 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1463,59 +1445,59 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1523,7 +1505,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -1623,56 +1605,56 @@ msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1680,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1718,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1747,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1772,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1870,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1910,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1949,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2004,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2017,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2042,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2108,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2163,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2347,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2448,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2456,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2475,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2494,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2513,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2528,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2551,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2576,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2591,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2651,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2664,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2677,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2685,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2693,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2701,120 +2683,120 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2822,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -2934,12 +2916,12 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 
@@ -2956,13 +2938,13 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr ""
@@ -2984,7 +2966,7 @@ msgid "Download already cached at:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -2999,50 +2981,50 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr ""
 
@@ -3084,60 +3066,60 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr ""
@@ -3206,7 +3188,7 @@ msgid "Cache level requires cleanup. %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -3482,104 +3464,104 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -4088,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4131,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4187,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4213,55 +4195,55 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr ""
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4279,117 +4261,111 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: noise
@@ -4417,19 +4393,19 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4437,34 +4413,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4478,7 +4454,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4496,12 +4472,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4514,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4526,7 +4502,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4535,31 +4511,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4583,7 +4559,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -4591,50 +4567,50 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
@@ -4680,13 +4656,13 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4764,13 +4740,13 @@ msgid "Deserialize returned an object that is not a MusicPlayer:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4826,45 +4802,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -4876,220 +4852,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5108,30 +5084,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5139,18 +5115,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5225,9 +5201,88 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/ko_KR/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/ko_KR/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -416,13 +416,13 @@ msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr ""
 
@@ -615,13 +615,13 @@ msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr ""
@@ -1455,7 +1455,7 @@ msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -1476,28 +1476,28 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1505,12 +1505,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1518,143 +1518,143 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1662,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1700,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1729,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1754,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1852,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1892,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1931,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1986,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1999,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2024,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2090,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2145,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2329,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2438,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2457,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2476,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2495,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2510,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2533,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2558,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2573,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2633,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2646,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2659,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2667,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2675,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2683,30 +2683,30 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
@@ -2764,39 +2764,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2804,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -3892,55 +3892,55 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr ""
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
 msgstr ""
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr ""
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr ""
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -3948,107 +3948,107 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr ""
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr ""
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
 msgstr ""
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr ""
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr ""
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
 msgstr ""
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
 msgstr ""
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4056,13 +4056,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4070,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4113,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4169,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4195,55 +4195,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr ""
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4261,7 +4249,7 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
@@ -4274,13 +4262,13 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
@@ -4364,48 +4352,48 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4413,34 +4401,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4454,7 +4442,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4472,12 +4460,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4490,7 +4478,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4502,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4511,31 +4499,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4794,7 +4782,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5025,24 +5013,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5089,25 +5077,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5115,66 +5103,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5201,7 +5143,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5213,25 +5155,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5244,29 +5186,143 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr ""
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/ko_KR/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/ko_KR/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -19,95 +19,95 @@ msgstr ""
 "X-Crowdin-Project-ID: 734017\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -116,12 +116,12 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -135,36 +135,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -173,7 +173,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -182,12 +182,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -195,7 +195,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -209,64 +209,64 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -274,24 +274,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -300,7 +300,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -319,18 +319,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -338,12 +338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -351,104 +351,104 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -456,35 +456,35 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -493,39 +493,39 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -534,33 +534,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -568,14 +568,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -583,84 +583,84 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -670,28 +670,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -860,7 +860,7 @@ msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
@@ -1002,58 +1002,49 @@ msgstr ""
 msgid "Cleared all songs from the queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1061,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1120,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1133,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1141,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1167,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1182,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1241,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1336,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1347,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1360,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1385,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1412,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1445,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1470,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1490,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1544,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1579,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1593,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1603,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1623,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1657,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1695,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1721,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1731,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1796,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1820,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1847,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1866,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1892,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1906,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1921,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1945,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2011,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2075,110 +2066,110 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2186,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2206,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2217,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2296,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2349,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2374,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2403,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2466,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2486,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2941,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2981,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2997,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3006,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3018,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3032,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3045,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3059,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3074,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3087,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3100,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3113,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3155,13 +3146,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
@@ -3287,22 +3278,22 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -3385,32 +3376,32 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -3418,19 +3409,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -3441,21 +3432,15 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
@@ -3472,50 +3457,50 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3523,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3532,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3579,42 +3564,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -3657,7 +3642,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3671,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3689,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3702,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3749,7 +3734,7 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
@@ -3762,61 +3747,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3824,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3834,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -3858,40 +3843,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -3899,13 +3877,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -3924,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3933,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3964,28 +3942,119 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/ko_KR/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/ko_KR/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -650,7 +650,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -675,23 +675,23 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,19 +699,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -719,13 +719,13 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -733,24 +733,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -759,292 +759,292 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1052,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1111,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1124,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1132,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1158,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1173,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1232,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1327,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1338,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1351,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1376,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1403,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1436,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1461,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1481,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1535,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1570,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1584,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1594,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1614,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1648,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1686,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1712,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1722,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1787,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1811,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1838,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1857,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1883,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1897,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1912,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1936,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2002,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2066,66 +2066,66 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
@@ -2137,39 +2137,39 @@ msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2177,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2197,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2208,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2287,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2340,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2365,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2394,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2457,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2477,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2575,7 +2575,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -2637,13 +2637,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -2651,14 +2651,14 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -2670,26 +2670,26 @@ msgid "Mention the user who added the song when it is played."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -2736,14 +2736,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -2769,7 +2769,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 
@@ -2782,7 +2782,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -2808,13 +2808,13 @@ msgid "Completely remove the footer from embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -2822,21 +2822,21 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -2873,7 +2873,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -2882,7 +2882,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -2892,7 +2892,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -2913,7 +2913,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -2921,7 +2921,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -2932,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2972,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2988,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -2997,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3009,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3023,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3036,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3050,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3065,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3078,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3091,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3104,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3439,68 +3439,68 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3508,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3517,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3564,56 +3564,56 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3635,14 +3635,14 @@ msgid "Allow MusicBot to format its messages as embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3656,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3674,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3687,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3747,7 +3747,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -3801,7 +3801,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3809,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3819,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -3888,7 +3888,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -3902,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3911,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3925,7 +3925,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -3933,7 +3933,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -3942,26 +3942,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -3973,28 +3973,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4005,25 +4005,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4032,7 +4032,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/musicbot_logs.pot
+++ b/i18n/musicbot_logs.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Just-Some-Bots/MusicBot release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: Just-Some-Bots/MusicBot 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-13 10:11-0700\n"
+"POT-Creation-Date: 2025-11-06 00:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,7 +141,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr ""
 
@@ -157,58 +157,47 @@ msgid "Could not start Spotify client. Is your client ID and secret correct? Det
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:336
-msgid "The config did not have Spotify app credentials, attempting to use guest mode."
+#: musicbot/bot.py:335
+msgid "Your config does not have Spotify app credentials. Spotify support will not be available."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr ""
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -218,7 +207,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -228,7 +217,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -238,261 +227,261 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid "Looking for owner in guild: %(guild)s (required voice: %(required)s) and got:  %(owner)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid "Retrying connection after a timeout error (%(attempt)s) while trying to connect to:  %(channel)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting anyway..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -500,436 +489,436 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably restart the bot."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  Create: %(create)s  Deserialize:  %(serial)s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid "Created player via deserialization for guild %(guild_id)s with %(number)s entries"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -943,44 +932,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -988,80 +977,80 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1071,90 +1060,90 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -1173,529 +1162,529 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1703,18 +1692,18 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1723,140 +1712,140 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-pause."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with a length of `%(progress)s / %(total)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4437
+#: musicbot/bot.py:4436
 #, python-format
-msgid "YouTube search returned no results for:  %(url)s"
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: info
@@ -1973,56 +1962,66 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid "You do not have the permission to remove all the songs in the given range from the queue.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -2030,41 +2029,41 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2072,28 +2071,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2101,22 +2100,22 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid "Could not resolve section name from option name. Please provide a valid section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2124,97 +2123,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2222,39 +2221,45 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr ""
 
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid "You may have QueueLength set too high! The setting is %(option)d but we could only list %(count)d tracks."
+msgstr ""
+
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2262,27 +2267,27 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid "Invalid user ID or server nickname, please double-check the ID and try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2290,23 +2295,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2314,54 +2319,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2369,12 +2374,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2382,40 +2387,40 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2423,61 +2428,61 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2488,54 +2493,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2543,297 +2548,297 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid "MusicBot has bound channel config and caller channel is not in bound channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: %(code)s) [S:%(state)s]"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2851,12 +2856,12 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -2870,7 +2875,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2888,18 +2893,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid "Cannot store more than %s log files. Option LogsMaxKept will be limited instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid "Config option LogsDateFormat is empty and this will break log file rotation. Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2911,12 +2916,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2930,13 +2935,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2949,28 +2954,28 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid "StatusMessage config option is too long, it will be limited to 128 characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid "The default playback speed must be between 0.5 and 100.0. The option value of %.3f will be limited instead."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2983,12 +2988,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3000,24 +3005,24 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid "Renaming %(ini_file)s to %(option_file)s, you should probably turn file extensions on."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -3026,12 +3031,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3045,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3060,51 +3065,51 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid "Dev Bug! Config option has invalid type, getter and default must be the same type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3117,7 +3122,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3130,7 +3135,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3143,159 +3148,164 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid "Invalid DebugLevel option \"%(value)s\" given, falling back to level: %(fallback)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using default instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid "Option [%(section)s] > %(option)s has a value greater than 100 %% (%(value)s) and will be set to %(fallback)s instead."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3303,120 +3313,120 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
-msgstr ""
-
-#. Used by: ExtractionError
-#: musicbot/downloader.py:511
-#, python-format
-msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
-msgstr ""
-
-#. Used by: exception
-#: musicbot/downloader.py:515
-msgid "Download Error with stream URL"
-msgstr ""
-
-#. Used by: debug
-#: musicbot/downloader.py:520
-msgid "Assuming content is a direct stream"
-msgstr ""
-
-#. Used by: ExtractionError
-#: musicbot/downloader.py:528
-msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: ExtractionError
 #: musicbot/downloader.py:532
 #, python-format
+msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
+msgstr ""
+
+#. Used by: exception
+#: musicbot/downloader.py:536
+msgid "Download Error with stream URL"
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:541
+msgid "Assuming content is a direct stream"
+msgstr ""
+
+#. Used by: ExtractionError
+#: musicbot/downloader.py:549
+msgid "Cannot stream an invalid URL."
+msgstr ""
+
+#. Used by: ExtractionError
+#: musicbot/downloader.py:553
+#, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid "Extractor %(extractor)s returned single-entry result, replacing base info with entry info."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -3460,17 +3470,17 @@ msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 
@@ -3498,7 +3508,7 @@ msgid "Deserialized URLPlaylistEntry has an author ID but no channel for lookup!
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr ""
@@ -3510,7 +3520,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr ""
@@ -3532,7 +3542,7 @@ msgid "Download already cached at:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3547,80 +3557,80 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid "There as a problem with working out EQ, likely caused by a strange installation of FFmpeg. This has not impacted the ability for the bot to work, but will mean your tracks will not be equalized."
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr ""
 
@@ -3661,81 +3671,81 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid "Deserialized LocalFilePlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr ""
@@ -3839,19 +3849,19 @@ msgid "Auto playlist cache map conflict on Key: %(file)s  Old: %(old)s  New: %(n
 msgstr ""
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
 msgstr ""
@@ -4202,114 +4212,114 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -4464,18 +4474,18 @@ msgid "Failed to get Guest Token due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
@@ -4932,91 +4942,116 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:990
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid "Cannot start the bot!  You started `run.py` in the wrong directory and we could not locate `musicbot` and `.git` folders to verify a new directory location."
 msgstr ""
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
 
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid "Certificate error is not a verification error, not trying certifi and exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid "Could not get Issuer Certificate from default trust store, trying certifi instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5029,12 +5064,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5055,53 +5090,53 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid "MusicBot got an ImportError after trying to install packages. MusicBot must exit..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr ""
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr ""
 

--- a/i18n/musicbot_logs.pot
+++ b/i18n/musicbot_logs.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Just-Some-Bots/MusicBot 235ee4c\n"
+"Project-Id-Version: Just-Some-Bots/MusicBot 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-06 00:13+0000\n"
+"POT-Creation-Date: 2026-02-04 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -430,20 +430,20 @@ msgid "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr ""
 
@@ -558,7 +558,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
@@ -640,19 +640,19 @@ msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr ""
@@ -1679,12 +1679,12 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1797,7 +1797,7 @@ msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -1817,211 +1817,211 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid "Processed %(number)d of %(total)d songs in %(time).3f seconds at %(time_per).2f s/song"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid "You do not have the permission to remove all the songs in the given range from the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -2029,41 +2029,41 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2071,28 +2071,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2100,22 +2100,22 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid "Could not resolve section name from option name. Please provide a valid section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2123,97 +2123,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2221,45 +2221,45 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid "You may have QueueLength set too high! The setting is %(option)d but we could only list %(count)d tracks."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2267,27 +2267,27 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid "Invalid user ID or server nickname, please double-check the ID and try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2295,23 +2295,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2319,54 +2319,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2374,12 +2374,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2387,40 +2387,40 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2428,61 +2428,61 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2493,54 +2493,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2548,297 +2548,297 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid "MusicBot has bound channel config and caller channel is not in bound channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: %(code)s) [S:%(state)s]"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2856,12 +2856,12 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -2875,7 +2875,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2893,18 +2893,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid "Cannot store more than %s log files. Option LogsMaxKept will be limited instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid "Config option LogsDateFormat is empty and this will break log file rotation. Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2916,12 +2916,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2935,13 +2935,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2954,28 +2954,28 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid "StatusMessage config option is too long, it will be limited to 128 characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid "The default playback speed must be between 0.5 and 100.0. The option value of %.3f will be limited instead."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2988,12 +2988,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3005,24 +3005,24 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid "Renaming %(ini_file)s to %(option_file)s, you should probably turn file extensions on."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -3031,12 +3031,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3050,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3065,51 +3065,51 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid "Dev Bug! Config option has invalid type, getter and default must be the same type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3122,7 +3122,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3135,7 +3135,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3148,71 +3148,71 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid "Invalid DebugLevel option \"%(value)s\" given, falling back to level: %(fallback)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using default instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid "Option [%(section)s] > %(option)s has a value greater than 100 %% (%(value)s) and will be set to %(fallback)s instead."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
@@ -3273,39 +3273,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3313,120 +3313,120 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid "Extractor %(extractor)s returned single-entry result, replacing base info with entry info."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -4625,18 +4625,18 @@ msgstr ""
 
 #. Used by: info
 #: run.py:388
-msgid "Checking for Python 3.9+"
+msgid "Checking for Python 3.10+"
 msgstr ""
 
 #. Used by: warning
 #: run.py:392
 #, python-format
-msgid "Python 3.9+ is required. This version is %s"
+msgid "Python 3.10+ is required. This version is %s"
 msgstr ""
 
 #. Used by: warning
 #: run.py:394
-msgid "Attempting to locate Python 3.9..."
+msgid "Attempting to locate Python 3.10..."
 msgstr ""
 
 #. Used by: warning
@@ -4646,7 +4646,7 @@ msgstr ""
 
 #. Used by: warning
 #: run.py:413
-msgid "Could not execute `py.exe -3.9` "
+msgid "Could not execute `py.exe -3.10` "
 msgstr ""
 
 #. Used by: info
@@ -4656,12 +4656,12 @@ msgstr ""
 
 #. Used by: info
 #: run.py:422
-msgid "Trying \"python3.9\""
+msgid "Trying \"python3.10\""
 msgstr ""
 
 #. Used by: warning
 #: run.py:425
-msgid "Could not locate python3.9 on path."
+msgid "Could not locate python3.10 on path."
 msgstr ""
 
 #. Used by: info
@@ -4669,12 +4669,12 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
 msgstr ""
 
 #. Used by: critical
 #: run.py:444
-msgid "Could not find Python 3.9 or higher.  Please run the bot using Python version 3.9 to 3.13"
+msgid "Could not find Python 3.10 or higher.  Please run the bot using Python version 3.10 to 3.13"
 msgstr ""
 
 #. Used by: info
@@ -4769,51 +4769,75 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr ""
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
 msgstr ""
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid "Could not check for updates using `git` commands.  You should check manually."
 msgstr ""
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr ""
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr ""
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid "Could not check for updates using `pip` commands.  You should check manually."
 msgstr ""
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4821,120 +4845,120 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr ""
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr ""
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid "Launch a music playing discord bot built using discord.py, youtubeDL, and ffmpeg."
 msgstr ""
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr ""
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr ""
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
 msgstr ""
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid "Disable MusicBot from trying to install dependencies when it cannot import them."
 msgstr ""
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid "Specify how many log files to keep, between 0 and %s inclusive. (Default: %s)"
 msgstr ""
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid "Override the default date format used when rotating log files. This should contain values compatible with strftime().  (Default:  '%s')"
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -4942,116 +4966,122 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid "Cannot start the bot!  You started `run.py` in the wrong directory and we could not locate `musicbot` and `.git` folders to verify a new directory location."
 msgstr ""
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid "Certificate error is not a verification error, not trying certifi and exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid "Could not get Issuer Certificate from default trust store, trying certifi instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5064,12 +5094,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5090,53 +5120,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
-#. Used by: error
-#: run.py:1267
-msgid "MusicBot got an ImportError after trying to install packages. MusicBot must exit..."
-msgstr ""
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr ""
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr ""
 

--- a/i18n/musicbot_messages.pot
+++ b/i18n/musicbot_messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Just-Some-Bots/MusicBot 235ee4c\n"
+"Project-Id-Version: Just-Some-Bots/MusicBot 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-11-06 00:13+0000\n"
+"POT-Creation-Date: 2026-02-04 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgstr ""
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -768,7 +768,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -799,45 +799,45 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -845,13 +845,13 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -859,24 +859,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -885,30 +885,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -922,254 +922,254 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -1180,64 +1180,64 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid "You do not have the permission to remove all the songs in the given range from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1245,58 +1245,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1304,12 +1304,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1317,7 +1317,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1325,25 +1325,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1351,13 +1351,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1365,71 +1365,71 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid "Allows management of aliases from discord. To see aliases use the help command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1437,95 +1437,95 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid "    Lists the names of options which have been changed since loading config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid "    Validates the option and sets the config for the session, but not to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -1534,12 +1534,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1547,7 +1547,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1558,12 +1558,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1571,22 +1571,22 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid "Could not resolve section name from option name. Please provide a valid section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1594,24 +1594,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1621,31 +1621,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1654,24 +1654,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1679,19 +1679,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1699,50 +1699,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1753,34 +1753,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1788,12 +1788,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1802,7 +1802,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -1811,7 +1811,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1821,19 +1821,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1841,38 +1841,38 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1880,37 +1880,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1918,33 +1918,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid "Invalid user ID or server nickname, please double-check the ID and try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1954,7 +1954,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1964,62 +1964,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2027,7 +2027,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2037,23 +2037,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2061,24 +2061,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2088,13 +2088,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2103,12 +2103,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2116,24 +2116,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2142,13 +2142,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2156,21 +2156,21 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2178,23 +2178,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2202,83 +2202,83 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2288,37 +2288,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2326,59 +2326,59 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid "    Attempt to update all dependency and source code before fully restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2387,124 +2387,124 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2512,12 +2512,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2532,7 +2532,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2543,78 +2543,78 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid "Display the current bot version and check for updates to MusicBot or dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2627,34 +2627,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using %(bitrate)s kbps.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -2664,18 +2664,18 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -2683,18 +2683,18 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2702,17 +2702,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2727,28 +2727,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2756,61 +2756,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2818,17 +2818,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2838,13 +2838,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3132,7 +3132,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -3140,29 +3140,29 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid "Enable MusicBot to automatically play music from the auto playlist when the queue is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid "Remove songs from the auto playlist if they are found in the song block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3171,53 +3171,53 @@ msgstr ""
 
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid "Enable saving songs played per-server to a playlist file:  %(basename)s[Server ID]%(ext)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid "Enable MusicBot to automatically remove unplayable entries from the auto playlist."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid "If SaveVideos is enabled, set a limit on how much storage space should be used."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid "If SaveVideos is enabled, never purge auto playlist songs from the cache regardless of limits."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid "Automatically join the owner if they are in an accessible voice channel when bot starts."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3234,33 +3234,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid "If enabled, MusicBot will save the track title to:  data/[Server ID]/current.txt"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid "If enabled, MusicBot will leave servers if the owner is not in their member list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3268,19 +3268,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid "If enabled, MusicBot will leave the channel immediately when the song queue is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3288,7 +3288,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3297,7 +3297,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3305,7 +3305,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3316,7 +3316,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -3325,7 +3325,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -3334,7 +3334,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"
@@ -3343,36 +3343,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3382,12 +3382,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid "An optional directory path where MusicBot will store long and short-term cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3396,7 +3396,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3405,7 +3405,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3419,7 +3419,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3437,7 +3437,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3449,7 +3449,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3463,7 +3463,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3476,7 +3476,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3489,7 +3489,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3501,7 +3501,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3515,7 +3515,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3530,7 +3530,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3543,7 +3543,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3556,7 +3556,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3618,49 +3618,49 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 

--- a/i18n/musicbot_messages.pot
+++ b/i18n/musicbot_messages.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Just-Some-Bots/MusicBot release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: Just-Some-Bots/MusicBot 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-13 10:11-0700\n"
+"POT-Creation-Date: 2025-11-06 00:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,81 +33,81 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
@@ -115,18 +115,18 @@ msgstr ""
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -135,12 +135,12 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -154,41 +154,41 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -197,7 +197,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -206,12 +206,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -219,7 +219,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -233,64 +233,64 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -298,24 +298,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -324,7 +324,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -332,7 +332,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -343,23 +343,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -367,12 +367,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -380,112 +380,112 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid "    Adds or removes the specified song or currently playing song to/from the current playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid "    Show the currently selected playlist and a list of existing playlist files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid "    Reload the auto playlist queue, restarting at the first track unless randomized.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid "    Set a playlist as default for this guild and reloads the guild auto playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid "    Reload the given playlist from disk into memory, but does not update the current auto playlist queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3338
+#: musicbot/bot.py:3337
 msgid ""
 "Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
+"Auto playlists use their own queue, only playing when the main queue is empty."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -493,42 +493,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -536,7 +536,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -544,23 +544,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -568,35 +568,35 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -605,12 +605,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -621,32 +621,32 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid "Play command that shuffles playlist entries before adding them to the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -655,45 +655,45 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with a length of `%(progress)s / %(total)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -701,90 +701,90 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -794,40 +794,40 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4437
+#: musicbot/bot.py:4436
 #, python-format
-msgid "YouTube search returned no results for:  %(url)s"
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
@@ -1006,7 +1006,7 @@ msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
@@ -1155,56 +1155,89 @@ msgstr ""
 
 #. Used by: _Dd
 #: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
 msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
 "Use the queue command to find position number of your track.\n"
 "However, positions of all songs are changed when a new song starts playing.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid "You do not have the permission to remove all the songs in the given range from the queue.\n"
+msgstr ""
+
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1212,58 +1245,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1271,12 +1304,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1284,7 +1317,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1292,25 +1325,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1318,13 +1351,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1332,71 +1365,71 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid "Allows management of aliases from discord. To see aliases use the help command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1404,95 +1437,95 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid "    Lists the names of options which have been changed since loading config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid "    Validates the option and sets the config for the session, but not to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -1501,12 +1534,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1514,7 +1547,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1525,12 +1558,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1538,22 +1571,22 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid "Could not resolve section name from option name. Please provide a valid section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1561,24 +1594,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1588,31 +1621,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1621,24 +1654,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1646,19 +1679,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1666,50 +1699,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1720,34 +1753,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1755,12 +1788,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1769,7 +1802,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -1778,7 +1811,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1788,19 +1821,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1808,38 +1841,38 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1847,37 +1880,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1885,33 +1918,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid "Invalid user ID or server nickname, please double-check the ID and try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1921,7 +1954,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1931,62 +1964,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -1994,7 +2027,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2004,23 +2037,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2028,24 +2061,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2055,13 +2088,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2070,12 +2103,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2083,24 +2116,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2109,13 +2142,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2123,21 +2156,21 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2145,23 +2178,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2169,83 +2202,83 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2255,37 +2288,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2293,59 +2326,59 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid "    Attempt to update all dependency and source code before fully restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2354,124 +2387,124 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2479,12 +2512,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2499,7 +2532,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2510,78 +2543,78 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid "Display the current bot version and check for updates to MusicBot or dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2594,34 +2627,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using %(bitrate)s kbps.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -2631,18 +2664,18 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -2650,18 +2683,18 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2669,17 +2702,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2694,28 +2727,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2723,61 +2756,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2785,17 +2818,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2805,13 +2838,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3292,36 +3325,54 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3331,12 +3382,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid "An optional directory path where MusicBot will store long and short-term cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3345,7 +3396,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3354,7 +3405,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3368,7 +3419,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3386,7 +3437,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3398,7 +3449,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3412,7 +3463,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3425,7 +3476,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3438,7 +3489,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3450,7 +3501,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3464,7 +3515,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3479,7 +3530,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3492,7 +3543,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3505,7 +3556,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3519,103 +3570,103 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
-msgstr ""
-
-#. Used by: ExtractionError
-#: musicbot/downloader.py:511
-#, python-format
-msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
-msgstr ""
-
-#. Used by: ExtractionError
-#: musicbot/downloader.py:528
-msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: ExtractionError
 #: musicbot/downloader.py:532
 #, python-format
+msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
+msgstr ""
+
+#. Used by: ExtractionError
+#: musicbot/downloader.py:549
+msgid "Cannot stream an invalid URL."
+msgstr ""
+
+#. Used by: ExtractionError
+#: musicbot/downloader.py:553
+#, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
@@ -3638,13 +3689,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
@@ -3796,28 +3847,28 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 

--- a/i18n/pl_PL/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/pl_PL/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -161,7 +161,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Nieobsługiwany wyjątek dla zadania:  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify nie dostarczył nam tokenu. Wyłączanie."
 
@@ -181,63 +181,43 @@ msgstr ""
 "Nie można uruchomić klienta Spotify. Czy Twój identyfikator klienta i tajne "
 "dane są poprawne? Szczegóły: %s. Kontynuuj mimo to za 5 sekund..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"Konfiguracja nie posiadała poświadczeń aplikacji Spotify, próbując użyć "
-"trybu gościa."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Uwierzytelniono ze Spotify za pomocą trybu gościa."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr "Nie można uruchomić klienta Spotify w trybie gościa. Szczegóły: %s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Zainicjowano połączenie, a teraz połączenie z discordem."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Test ping sieci jest wyłączony przez konfigurację."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "Test ping sieci jest zamknięty."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "Nie można rozwiązać celu ping."
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Test ping sieci został anulowany."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Testowanie sieci przez HTTP nie ma sesji do pożyczenia."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "Nie można zlokalizować pliku wykonywalnego `ping` w twoim środowisku."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -251,7 +231,7 @@ msgstr ""
 "Alternatywnie wyłącz sprawdzanie sieci przez konfigurację."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -265,7 +245,7 @@ msgstr ""
 "Alternatywnie wyłącz sprawdzanie sieci przez konfigurację."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -279,29 +259,29 @@ msgstr ""
 "Alternatywnie wyłącz sprawdzanie sieci przez konfigurację."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "Sieć MusicBot jest znów dostępna."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 "VoiceClient nie jest połączony, oczekiwanie na wznowienie MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Wznawianie odtwarzania gracza: (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot wykrył przerwę sieciową."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -310,7 +290,7 @@ msgstr ""
 "%(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -320,39 +300,39 @@ msgstr ""
 "otrzymany:  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "Sprawdzanie kanału do automatycznego dołączenia lub wznowienia ..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 "Gildia niedostępna, nie można automatycznie dołączyć:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 "Znaleziono wznawiany kanał głosowy:  %(channel)s  w gildii:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 "Spróbuje wznowić sesję głosową zamiast kanału automatycznego dołączenia:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Znaleziono właściciela na kanale głosowym:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
@@ -360,7 +340,7 @@ msgstr ""
 " kanale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
@@ -368,29 +348,29 @@ msgstr ""
 "kanale:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Już połączono z kanałem:  %(channel)s  w gildii:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Próba dołączenia do kanału:  %(channel)s  w gildii:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Odrzucanie MusicPlayer i tworzenie nowego..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot zrobi teraz nowego MusicPlayer"
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
@@ -398,74 +378,74 @@ msgstr ""
 "głosowy."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Zakończono dołączanie skonfigurowanych kanałów."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Użytkownik nie jest włączony głosowo i nie może użyć tego polecenia."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Nie możesz użyć tej komendy gdy nie jest na kanale głosowym."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Informacje o aplikacji bota."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot nie ma uprawnień do połączenia na kanale:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot nie ma uprawnień do połączenia na kanale: `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot nie ma uprawnień do mówienia na kanale:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot nie ma uprawnień do mówienia na kanale: `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Ponowne użycie botów VoiceClient z gildii:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "Wymuszam rozłączenie na Niebieskim VoiceClient w gildii:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "Rozłączenie nie powiodło się lub zostało anulowane?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "MusicBot nie może teraz połączyć się z kanałem:  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -474,12 +454,12 @@ msgstr ""
 "Spróbuj ponownie później lub zrestartuj bota jeśli to będzie kontynuowane."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot ma teraz VoiceClient..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -489,14 +469,14 @@ msgstr ""
 "podczas próby połączenia z:  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 "Próba połączenia MusicBot VoiceClient została anulowana. Bez ponawiania "
 "próby."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -504,42 +484,42 @@ msgstr ""
 "zrestartować?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot prosi o mówienie na kanale: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot nie ma uprawnień do mówienia."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot nie mógł prosić o głos."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Rozłączanie MusicPlayer w gildii:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Rozłączanie VoiceClient zanim zabijemy MusicPlayera."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "Rozłączenie nie powiodło się lub zostało anulowane."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -547,18 +527,18 @@ msgstr ""
 "MusicBot ma VoiceProtocol który nie jest VoiceClient. Rozłączanie mimo to..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Rozłączanie rogue VoiceClient w gildii:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Rozłączanie niegildii VoiceClient..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -568,19 +548,19 @@ msgstr ""
 "Obiekt jest w rzeczywistości typu:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr "Wciąż mamy ref MusicPlayer w gildii (%(guild_id)s):  %(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Gildia (%(guild)s) chce gracza, opcjonalnie:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -588,24 +568,24 @@ msgstr ""
 "[BUG] MusicPlayer brakuje jak. Prawdopodobnie powinieneś zrestartować bota."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer ma VoiceClient, który nie jest połączony."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "MusicPlayer obj:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -615,7 +595,7 @@ msgstr ""
 "Utwórz: %(create)s  Deserialize:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -625,7 +605,7 @@ msgstr ""
 "%(number)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -634,85 +614,85 @@ msgstr ""
 "Użyj polecenia przywołania, aby przenieść bota do kanału głosowego."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Coś jest nie tak. Nie otrzymaliśmy VoiceClient."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "Uruchamianie_gracz_gracza"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Ustawianie gildii historii URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Nie ustawiono miniatury dla wpisu z adresem URL: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "brak kanału do umieszczenia wiadomości odtwarzania"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "zignorowano wiadomość, która została już opublikowana."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "Uruchamianie_gracz_wznawianie"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "Uruchamianie_gracz_pauza"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Uruchamianie_gracz_zatrzymanie"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Uruchamianie_gracz_zakończone_grania"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "Pętla zdarzeń jest zamknięta, nic innego do zrobienia tutaj."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Wyloguj się, ignorując to wydarzenie."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 "VoiceClient mówi, że nie jest połączony, nic innego nie możemy tutaj zrobić."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "Gracz gotowy i kolejka jest pusta, pozostawiając kanał głosowy..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr "Pętla nad kolejką do zdejmowania piosenek z brakującym autorem..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -720,298 +700,298 @@ msgstr ""
 "Autor `%(user)s` nieobecny, pominięty (usunięty) wpis z kolejki:  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr "Brak odtwarzanych utworów na liście autoplayerów, wyłączając."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "Brak zawartości w bieżącej autoplaylist. Wypełnianie nową muzyką..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Pętla nad autoplaylistą graczy..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Błąd podczas przetwarzania utworu \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Błąd podczas rozpakowywania utworu \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot musi zatrzymać automatyczne wydobycie i ratowanie listy "
 "odtwarzania."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr "MusicBot otrzymał nieobsługiwany wyjątek w wydarzeniu zakończonym."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 "Rozszerzenie automatycznej listy odtwarzania o wpisy wyciągnięte z:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "Błąd podczas dodawania utworu z autoplaylisty: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Dane wyjątku dla powyższego błędu:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "Brak odtwarzanych utworów na liście autoplayerów, wyłączając."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "Uruchamianie_gracz_wpis_dodane"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 "Automatycznie pomijam wpis auto-listy odtwarzania dla wpisu w kolejce."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "Wyjątek MusicPlayer dla wpisu: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "Wyjątek MusicPlayer"
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "Utwór automatycznej listy odtwarzania nie może być odtworzony:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "Wyloguj się w toku, ignorując zdarzenie aktualizacji statusu."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Aktualizuj status bota:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Serializacja kolejki dla %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Deserializacja kolejki dla %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Zapisywanie aktualnej piosenki dla %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "Nie można wysłać obiektu braku odpowiedzi:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Próba wysłania nieprawidłowego obiektu odpowiedzi."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "wysyłanie osadzonych do: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "wysyłanie tekstu do: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "Nie można wysłać wiadomości do \"%s\", brak uprawnień"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "Nie można wysłać wiadomości do \"%s\", nieprawidłowy lub usunięty kanał"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "Wiadomość przekracza limit rozmiaru wiadomości (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 "Nie można wysłać prywatnej wiadomości, zamiast tego wysyłać na kanał "
 "awaryjny."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 "Ograniczono szybkość wysyłania wiadomości, ponowienie próby za %s sekund."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Anulowano ponowną próbę wiadomości dla:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "Oceń ograniczoną wiadomość, ale nie można ponowić próby!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "Nie udało się wysłać wiadomości na kanale awaryjnym."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Nie udało się wysłać z powodu błędu HTTP."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "Nie można usunąć wiadomości \"%s\", brak uprawnień"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "Nie można usunąć wiadomości \"%s\", nie znaleziono wiadomości"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 "Ograniczono szybkość usuwania wiadomości, ponowienie próby za %s sekund."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "Oceń ograniczoną wiadomość usuniętą ale nie można ponowić próby!"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Nie udało się usunąć wiadomości"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Masz HTTPException próbujący usunąć wiadomość: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "Nie można edytować wiadomości \"%s\", nie znaleziono wiadomości"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Wysyłanie wiadomości"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr "Ograniczona szybkość edycji wiadomości, ponowna próba za %s sekund."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Anulowana edycja wiadomości dla:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Nie udało się edytować wiadomości"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Masz HTTPException próbujący edytować wiadomość %s do: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Anulowano usunięcie wiadomości (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Złapano sygnał z OS: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Rozłączanie i zamykanie MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "Wyjątek wyrzucony podczas obsługi sygnału!"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot robi teraz kroki zamykania..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1034,44 +1014,44 @@ msgstr ""
 "  Sprawdź status API na oficjalnej stronie: discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "Oczekiwanie na zakończenie pobierania wątków..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Poczekamy na zadanie:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Spróbuje anulować zadanie:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "Oczekiwanie na zadania..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Zamykanie konektora HTTP."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Zamykanie sesji aiohttp."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "Wylogowanie zostało wywołane."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1081,80 +1061,80 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Wyjątek w %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot wznowił sesję z discordem."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Zakończ w trybie _gotowym"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Zalogowano. Przygotuj MusicBot..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "Klient nie ma nikogo, mamy ratowanie..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Właściciel:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Lista gildii:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "Opuszczono %s z powodu nieznalezionego właściciela bota"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr "Nie kontynuowano sprawdzania na serwerach %s z powodu niedostępności"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "Właściciel nie został znaleziony w żadnej gildii (id: %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Właściciel nieznany, bot nie ma na żadnej gildii."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1168,236 +1148,236 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Nie masz żadnego kanału z ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "Nie można powiązać z kanałem bez wiadomości o ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Powiąż z kanałami tekstowymi:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "Nie związane z żadnymi kanałami tekstowymi"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "Brak dla automatycznego dołączenia do kanału z ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 "Nie można automatycznie dołączyć do kanału prywatnego/niegildii z ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr "Nie można automatycznie dołączyć do niepodłączonego kanału z ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Automatyczne dołączanie kanałów głosowych:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "Brak automatycznego dołączania do żadnych kanałów głosowych"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "Zdarzenie on_ready zostało wywołane %s razy"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Otrzymywanie informacji o aplikacji."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "Upewnij się, że foldery danych istnieją"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Weryfikowanie konfiguracji"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Sprawdzanie poprawności konfiguracji uprawnień"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Wyłączone"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Włączone"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Opcje:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Prefiks polecenia: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  Domyślna głośność: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Próg pominięcia: %(num)d lub %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Teraz odtwarzane @wzmianki: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Auto-Playlist: %(status)s (kolejność: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "losowy"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "sekwencyjny"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Automatyczne wstrzymanie: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Usuń wiadomości: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Usuń wywołanie: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Usuń teraz odtwarzanie: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Tryb debugowania: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  Pobrane utwory będą %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Usuń jeśli nieużywane przez %d dni"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Komunikat statusu: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Integracja ze Spotify: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Przekroczono czas: %s sekund"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Przekroczono czas: %d sekund"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Samodzielny Deafen: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Prefiks polecenia dla serwera: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Runda Kolejka Robina: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 "Żądana piosenka `%(subject)s` jest zablokowana przez listę bloków utworu."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
@@ -1405,13 +1385,13 @@ msgstr ""
 "głosowaniu..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "Aktywność kanału już oczekuje w gildii: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1420,31 +1400,31 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "Licznik aktywności kanału dla %s wygasł. Rozłączanie."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Timer aktywności kanału anulowany dla: %(channel)s w %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Ignorowanie nieaktywności gracza na kanale auto-dołączenia:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "Licznik aktywności gracza już czeka w gildii: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1453,135 +1433,135 @@ msgstr ""
 " %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "Licznik aktywności gracza dla %s wygasł. Rozłączanie."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Timer aktywności gracza anulowany dla: %(channel)s w %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Czas aktywności gracza jest zresetowany."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Nie ma takiej komendy"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "Musisz podać użytkownika lub jego numer identyfikacyjny."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Podano nieprawidłowe polecenie. Użyj `help blockuser` dla przykładów użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot nie mógł znaleźć podanego użytkownika."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Właściciel nie może być dodany do listy bloków."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr "Nie dodano użytkownika do listy, już zablokowano:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 "Nie usuwa użytkownika z listy bloków, nie wymieniono:  %(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Nie można dodać użytkowników, których wymieniłeś, są już dodane."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Musisz podać temat utworu, jeśli nie ma aktualnie odtwarzanej piosenki."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Podano nieprawidłowe polecenie. Użyj `help blocksong` dla przykładów użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Temat%(subject)s` jest już na liście bloków utworu."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 "Temat nie znajduje się na liście bloków piosenek i nie może zostać usunięty."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Podano nieprawidłowe polecenie. Użyj `help autoplaylist` dla przykładów "
 "użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Podany link do utworu jest nieprawidłowy"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "Kolejka jest pusta. Dodaj kilka piosenek poleceniem odtwarzania!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Ta piosenka jest już na autoplaylist."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Ta piosenka nie znajduje się jeszcze na liście autoplay."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Musisz podać nazwę pliku listy odtwarzania."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Nie masz uprawnień do żądania playlist"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "Playlista ma zbyt wiele wpisów (%(songs)s ale max to %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1593,12 +1573,12 @@ msgstr ""
 "Limit wynosi %(max)s dla twojej grupy."
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Ignorowanie automatycznej pauzy z powodu przerwy w sieci."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1607,12 +1587,12 @@ msgstr ""
 "można przetwarzać automatycznego wstrzymania."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Przetwarzanie automatycznej pauzy, ignorując to wydarzenie."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1622,19 +1602,19 @@ msgstr ""
 "wstrzymanie w gildii:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "Automatyczne wstrzymanie oczekiwania zostało anulowane."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 "Nowy odtwarzacz muzyki jest podłączony, ignorując stare zdarzenie auto-"
 "pauzy."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
@@ -1642,39 +1622,39 @@ msgstr ""
 " gildii: %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "Wcześniej auto-wstrzymany gracz jest niezapłacony dla gildii: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Nie można użyć szukania, jeśli nic nie gra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "Nie można użyć szukania bieżącego utworu, ma nieznany czas trwania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Szukanie nie jest obsługiwane dla strumieni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "Nie można użyć wyszukiwania bez czasu na umiejscowienie odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Nie można przekonwertować `%(input)s` na poprawny czas w sekundach."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1684,29 +1664,29 @@ msgstr ""
 "długości `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Nieprawidłowe polecenie podrzędne. Użyj polecenia `help repeat` dla "
 "przykładów użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Odtwarzacz nie jest obecnie w pętli."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Pozycje piosenek muszą być liczbą całkowitą!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Dałeś pozycję poza rozmiarem playlisty!"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
@@ -1714,39 +1694,39 @@ msgstr ""
 "reakcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Lokalne odtwarzanie mediów nie jest włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "Adres URL Spotify jest nieprawidłowy lub nie jest obecnie obsługiwany."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Wykryto adres URL Spotify, ale Spotify nie jest włączony."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Osiągnąłeś limit utworów w kolejce (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Tryb Karaoke jest włączony, spróbuj ponownie, gdy jest wyłączony!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Problem z extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1756,15 +1736,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Nie można odtworzyć tego wideo. Spróbuj użyć komendy streamu."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "Wyszukiwanie YouTube nie zwróciło żadnych wyników dla:  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1875,18 +1849,18 @@ msgid "Player is not playing."
 msgstr "Gracz nie gra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Nic w kolejce do usunięcia!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nic nie znaleziono w kolejce od użytkownika `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1895,40 +1869,40 @@ msgstr ""
 "Musisz być tym, który ma w kolejce do kolejki lub ma natychmiastowe uprawnienia do pominięcia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Nieprawidłowy numer wpisu. Użyj polecenia kolejki, aby znaleźć pozycje "
 "kolejki."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Nie można pominąć! Gracz nie gra!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "Nie masz uprawnień, aby wymusić pominięcie piosenki w pętli."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Nie masz uprawnień do wymuszania pominięcia."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Nie masz uprawnień, aby pominąć piosenkę w pętli."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` nie jest poprawną liczbą"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1938,7 +1912,7 @@ msgstr ""
 "Głośność można ustawić tylko od 1 do 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1946,7 +1920,7 @@ msgstr ""
 "Podano nieracjonalny wolumen: %(volume)s. Podaj wartość między 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1955,28 +1929,28 @@ msgstr ""
 "Użyj komendy konfiguracyjnej, aby ustawić domyślną prędkość odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Prędkość nie może być zastosowana do mediów strumieniowych."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Musisz podać szybkość, aby ustawić."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "Podana prędkość jest nieprawidłowa. Użyj liczby od 0,5 do 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Nieprawidłowa opcja dla polecenia: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1986,30 +1960,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Musisz podać alias i polecenie do aliasu"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Musisz podać nazwę aliasu aby usunąć."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` nie istnieje."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Konfiguracja nie może używać kanału i wzmianek użytkownika w tym samym "
 "czasie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2019,7 +1993,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2028,17 +2002,17 @@ msgstr ""
 " nazwę opcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Podana opcja jest niejednoznaczna, proszę podać nazwę sekcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "Musisz podać nazwę sekcji i nazwę opcji dla tej komendy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2048,102 +2022,102 @@ msgstr ""
 "Dostępne sekcje to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Opcja `%(option)s` jest niedostępna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Opcja `%(option)s` nie jest edytowalna. Nie można zapisać na dysku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Nie udało się zapisać opcji: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna, wartość nie może być wyświetlana."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zaktualizować ustawienia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Musisz podać sekcję, opcję i wartość dla tej podkomendy."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Ustawiono na %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Opcja `%(option)s` nie została zaktualizowana!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zresetować do domyślnego."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Resetowanie %(config)s do domyślnego %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Opcja `%(option)s` nie została zresetowana do domyślnych!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Komenda opcji jest przestarzała, zamiast tego użyj komendy config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Podano nieprawidłową opcję, użyj: info, update, lub wyczyść"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Nie udało się** usunąć pamięci podręcznej, sprawdź logi aby uzyskać więcej"
 " informacji..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Argument strony kolejki musi być liczbą całkowitą."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Brak utworów w kolejce! Kolejka czegoś z poleceniem odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2153,24 +2127,24 @@ msgstr ""
 "Istnieją ** strony%(total)s**."
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "Pominięto bieżący wpis listy odtwarzania."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "Za mało wpisów do stronicowania kolejki."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Nie można opublikować wiadomości kolejki, nie ma wiadomości do dodania "
 "reakcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2179,17 +2153,17 @@ msgstr ""
 "Jeśli problem będzie się powtarzał, zgłoś błąd."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Nie można użyć czyszczenia na prywatnym kanale DM."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "Podany adres URL nie jest prawidłowym adresem URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2199,12 +2173,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "To nie wygląda na playlistę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2213,18 +2187,18 @@ msgstr ""
 "identyfikator i spróbuj ponownie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Nie można określić użytkownika Discorda. Spróbuj ponownie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Uprawnienia nie mogą używać jednocześnie wspomnień kanału i użytkownika."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2234,23 +2208,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Musisz podać nazwę grupy lub opcji dla tego polecenia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Musisz podać grupę, opcję i wartość, aby ustawić to polecenie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Podpolecenie %(option)s wymaga nazwy grupy i uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2260,47 +2234,47 @@ msgstr ""
 "Dostępne grupy to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Uprawnienia `%(option)s` nie są dostępne."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Nie można dodać grupy `%(group)s` już istnieje."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Nie można usunąć wbudowanej grupy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Grupa właścicieli nie jest edytowalna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Nie udało się zapisać grupy: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Ustawiono %(option)s z wartością: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Uprawnienia `%(option)s` nie zostały zaktualizowane!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2309,7 +2283,7 @@ msgstr ""
 "Zapamiętaj zmiany nazwy są ograniczone do dwóch razy na godzinę.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2319,12 +2293,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Nie można zmienić pseudonimu: brak uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2334,12 +2308,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Niestandardowe emoji muszą być z tego serwera, aby użyć jako prefiks."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2348,30 +2322,30 @@ msgstr ""
 "Użyj komendy config aby zaktualizować prefiks."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Ta komenda może być użyta tylko w gildiach."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Podano nieprawidłowe polecenie. Aby uzyskać więcej informacji, użyj "
 "polecenia pomocy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Nie można ustawić języka na `%(locale)s` nie jest on dostępny."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Musisz podać adres URL lub załączyć plik."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2381,19 +2355,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot znalazł %s bez gildii! To może być problem."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Obecnie nie jest połączony z serwerem `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2401,44 +2375,44 @@ msgstr ""
 "uppip lub upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Musisz podać identyfikator lub nazwę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nie znaleziono gildii o ID lub nazwie `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Aktywuję ID przerwania debugowania: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Nie można zaimportować `objgraf`, czy jest zainstalowany?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Kod debugowania uruchomiony z eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Kod debugowania uruchomiony z exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "Nie udało się wykonać kodu debugowania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2454,57 +2428,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Podpolecenie musi być jednym z: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Nie można zlokalizować pliku wykonywalnego git"
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ""
 "Nie powiodło się podczas sprawdzania aktualizacji za pomocą polecenia git"
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Pakiet brakuje meta w raporcie pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr "Nie udało się uzyskać statusu aktualizacji pipsa z powodu błędu."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Masz dziwne wejście klienta głosowego."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Pliki cookie są już włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Pliki cookie muszą być przesłane, aby je włączyć. (Przeliczanie pliku "
 "cookies.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Nie można włączyć ciasteczek z powodu błędu:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2514,7 +2488,7 @@ msgstr ""
 "ciasteczka tymczasowo wyłączone i zostaną ponownie włączone przy następnym ponownym uruchomieniu."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2522,50 +2496,50 @@ msgstr ""
 "przesyłania pliku cookie."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 "Nie można usunąć starego, wyłączonego pliku ciasteczek:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Błąd podczas pobierania pliku ciasteczek z dysku:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Nie można zapisać ciasteczek na dysku:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Masz wiadomość bez kanału, jako:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorowanie komendy u mnie (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignorowanie polecenia od innego bota (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignorowanie polecenia z kanału typu:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2573,24 +2547,24 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Wiadomość od %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Ta komenda nie jest dozwolona dla grupy uprawnień:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Ta komenda wymaga bycia na kanale głosowym."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
@@ -2598,76 +2572,76 @@ msgstr ""
 "%(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Błąd w %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Wyjątek podczas obsługi polecenia: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Nie można wygenerować pomocy dla brakującej komendy:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Brak danych pomocy dla komendy:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Opuszczanie kanału głosowego %s w %s z powodu braku aktywności."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot został połączony."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot został rozłączony."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Masz wydarzenie z gniazdem:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "Stan głosowy zaktualizowany przed na_gotowością"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorowanie %s w %s jako kanał głosowy połączony."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s został wykryty jako pusty. Upłynął limit czasu."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Użytkownik dołączył do %s, anulował czas."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2675,30 +2649,30 @@ msgstr ""
 "Bot został przeniesiony, a kanał głosowy %s jest pusty. Upłynął limit czasu."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Bot został przeniesiony, a kanał głosowy %s nie jest pusty."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "Nie obserwuj już użytkownika %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Obserwowany użytkownik `%(user)s` do kanału:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "Brak statusu głosowego."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2708,7 +2682,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2716,7 +2690,7 @@ msgstr ""
 "  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
@@ -2724,84 +2698,84 @@ msgstr ""
 "Gildia:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Ponowne łączenie z automatycznie dołączoną gildią na kanale:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Nie można automatycznie dołączyć do kanału:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Bot został dodany do gildii: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Lewa gildia '%s' z powodu nieznalezionego właściciela bota."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Tworzenie folderu danych dla gildii %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Bot został usunięty z gildii: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Zaktualizowano listę gildii:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Gildia \"%s\" stała się dostępna."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Wznawianie gracza w \"%s\" ze względu na dostępność."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Gildia \"%s\" stała się niedostępna."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Zatrzymanie gracza w \"%s\" z powodu niedostępności."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Aktualizacja Gildii dla:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Atrybut gildii %(attr)s jest teraz: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Aktualizacja kanału dla:  %(channel)s  --  %(changes)s"
@@ -2819,7 +2793,7 @@ msgid "Loading config from:  %s"
 msgstr "Ładowanie konfiguracji z:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2849,7 +2823,7 @@ msgstr ""
 "  Użyj opcji przykładowych jako szablonu lub skopiuj je z repozytorium."
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2859,7 +2833,7 @@ msgstr ""
 "będzie ograniczona."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2868,7 +2842,7 @@ msgstr ""
 "rotacji pliku dziennika. Użyj domyślnego."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2887,12 +2861,12 @@ msgstr ""
 "  Upewnij się, że ścieżka, którą skonfigurowałeś jest ścieżką do folderu / katalogu."
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Podczas sprawdzania poprawności AudioCachePath, wystąpił wyjątek."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2914,13 +2888,13 @@ msgstr ""
 "  Sprawdź, czy ustawienia są poprawne, dostępna ścieżka katalogu."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Pamięć podręczna audio będzie przechowywana w: %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2940,7 +2914,7 @@ msgstr ""
 "  Ustaw opcję konfiguracji tokenu lub ustaw zmienną środowiskową %(env_var)s z tokenem aplikacji."
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2948,7 +2922,7 @@ msgstr ""
 "Opcja StatusMessage jest zbyt długa, będzie ograniczona do 128 znaków."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2958,17 +2932,17 @@ msgstr ""
 "%.3f będzie ograniczona."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Sprawdzanie opcji z danymi usługi..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "Nabyty identyfikator właściciela przez API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2989,12 +2963,12 @@ msgstr ""
 "  ręcznie ustaw opcję 'WłaścicielID' lub spróbuj ponownie później."
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot nie ma instancji użytkownika, nie można kontynuować."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3013,13 +2987,13 @@ msgstr ""
 "  Nie używaj Bot ani App ID w polu 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "Nie znaleziono pliku opcji konfiguracyjnych. Sprawdzanie alternatyw..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3029,19 +3003,19 @@ msgstr ""
 "włączyć rozszerzenia plików."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Kopiowanie istniejącego przykładowego pliku opcji:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Coś poszło nie tak podczas próby znalezienia pliku opcji konfiguracji."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3063,7 +3037,7 @@ msgstr ""
 "  Zweryfikuj folder konfiguracyjny i pliki istnieją i mogą być odczytane przez MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3087,12 +3061,12 @@ msgstr ""
 "  Skopiuj przykładowy plik z repozytorium, jeśli wszystko inne nie powiedzie się."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! Opcja konfiguracji ma getter, który jest niedostępny."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3101,30 +3075,30 @@ msgstr ""
 "musi być tym samym typem."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "Wcześniej brakowało wariantu."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Sekcja konfiguracji nie jest w pliku konfiguracyjnym! Brakuje: %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Zapisana opcja konfiguracji: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Nie udało się zapisać konfiguracji:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3132,13 +3106,13 @@ msgstr ""
 "wyłączone."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Nie udało się zapisać domyślnego pliku INI na:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3158,7 +3132,7 @@ msgstr ""
 "  Ustaw %(option)s na numeryczny identyfikator lub ustaw go na `auto` lub `0` dla automatycznego powiązania właściciela."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3178,7 +3152,7 @@ msgstr ""
 "  Sprawdź ustawienia ścieżki i upewnij się, że plik istnieje i jest dostępny dla MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3198,7 +3172,7 @@ msgstr ""
 "  Upewnij się, że wszystkie ID są liczbowe i oddzielone tylko spacjami lub przecinkami."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3208,7 +3182,7 @@ msgstr ""
 "poziomu: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3218,7 +3192,7 @@ msgstr ""
 "'%(value)s' zamiast domyślnej."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3228,7 +3202,7 @@ msgstr ""
 " zamiast tego zostanie ustawiona na %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3236,54 +3210,54 @@ msgstr ""
 "Zmiana nazwy pliku INI [%(old_s)s] > %(old_o)s  na [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Aktualizowanie pliku konfiguracyjnego ze zmienionymi nazwami opcji..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Nie udało się zaktualizować konfiguracji. Musisz uaktualnić ją ręcznie."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Nie znaleziono pliku listy bloków:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Nie można załadować listy bloków z pliku:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Nie można zaktualizować pliku listy bloków:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Załadowano listę bloków użytkowników z wpisami %s."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "Znaleźliśmy starszy plik czarnej listy, zostanie on zmieniony na:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Załadowano listę bloków piosenek z wpisami %s."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3291,32 +3265,32 @@ msgstr ""
 "kodzie!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "Brak pliku dla gildii %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "Ładowanie danych gildii dla gildii z ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
 "Błąd systemu operacyjnego uniemożliwił odczyt pliku danych gildii:  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr "Gildia %(id)s/%(name)s ma niestandardowy prefiks poleceń: %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
@@ -3324,61 +3298,61 @@ msgstr ""
 "kodzie!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 "Nie można zapisać danych specyficznych dla gildii z powodu błędu systemu "
 "operacyjnego."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 "Nie udało się zserializować danych specyficznych dla gildii z powodu "
 "nieprawidłowych danych."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Wymuszanie YTDLP do używania User Agent:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot będzie używać ciasteczek do yt-dlp z:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp użyje skonfigurowanego serwera proxy."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD wydaje się, że nie ma nagłówków..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 "Sprawdzanie nagłówków mediów nie powiodło się z powodu przekroczenia limitu "
 "czasu."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Nieudane żądanie HEAD dla:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "Wyjątek żądania HEAD: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3388,79 +3362,79 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Informacje o ekstrakcji YTDL (nie JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Wyciąg informacji o utworze nie zwrócił żadnych danych."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Wywołany extract_info z: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Nie można uruchomić ekstrakcji, pętla jest zamknięta. (To jest normalne przy"
 " wyłączeniu.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Nie można kontynuować ekstrakcji, pętla zdarzeń jest zamknięta."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Adres URL Spotify jest nieprawidłowy lub nie jest obsługiwany."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Błąd pobierania z URL strumienia"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "Zakładając, że zawartość jest bezpośrednim strumieniem"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Nie można strumieniować nieprawidłowego URL."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 "Złap NoSupportingHandlers, spróbuj ponownie po zastąpieniu colona miejscem."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Wywołano safe_extract_info z:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Nie znaleziono lokalnego pliku multimedialnego."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Brakuje __input_subject z YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3468,7 +3442,7 @@ msgstr ""
 "uniknąć."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Ostrzeżenie, czas trwania błędu dla: %(url)s"
@@ -3514,12 +3488,12 @@ msgstr ""
 "Nazwa wpisu:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr "Wpis nie zawiera numeru wersji, nie można deserializować."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr "Dane wpisu mają nieprawidłowy numer wersji, nie można deserializować."
 
@@ -3553,7 +3527,7 @@ msgstr ""
 "kanału do wyszukiwania!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "Nie można załadować %s"
@@ -3565,7 +3539,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr "Nie można pobrać linków Spotify, przetwarzanie błędu z typu: %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Przygotowanie do wpisu:  %r"
@@ -3587,7 +3561,7 @@ msgid "Download already cached at:  %s"
 msgstr "Pobierz już w pamięci podręcznej w:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3605,7 +3579,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Czas trwania %(time)s sekund dla pliku:  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3616,75 +3590,75 @@ msgstr ""
 "że Twoje ścieżki nie będą równe."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Wyjątek podczas sprawdzania danych wejściowych."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Próba uzyskania czasu trwania przez pymediainfo dla:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "Nie udało się uzyskać czasu trwania przez pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Próba uzyskania czasu trwania przez ffprobe dla:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "Nie można zlokalizować ffprobe na twojej ścieżce!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe zwrócił coś, czego nie można użyć."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe nie może być wykonany z jakiegoś powodu."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Obliczanie średniej głośności:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "Nie można zlokalizować ffmpeg na twojej ścieżce!"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "Nie można przetworzyć 'I' w normalizacji json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "Nie można przetworzyć 'LRA' w normalizacji json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "Nie można przetworzyć 'TP' w normalizacji json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "Nie udało się przetworzyć 'invol' w normalizacji json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "Nie można przetworzyć 'offset' w normalizacji json."
 
@@ -3729,54 +3703,54 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Pobieranie nie powiodło się z powodu błędu yt-dlp: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "Ekstrakcja napotkała nieobsługiwany wyjątek."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 "Pobieranie nie powiodło się z powodu nieobsługiwanego wyjątku: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Pobieranie nie powiodło się:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Nie udało się wyodrębnić danych dla żądanych mediów."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Pobieranie zakończone:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserializowany StreamPlaylistEntry nie może znaleźć kanału o ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized StreamPlaylistEntry ma nieprawidłowy typ kanału:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr "Deserialized StreamPlaylistEntry nie może znaleźć autora z ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
@@ -3784,28 +3758,28 @@ msgstr ""
 "do wyszukiwania!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 "Deserializowany LocalFilePlaylistEntry nie może znaleźć kanału o ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 "Deserializowany LocalFilePlaylistEntry ma nieprawidłowy typ kanału:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "Deserializowany LocalFilePlaylistEntry nie może znaleźć autora z ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3814,7 +3788,7 @@ msgstr ""
 "kanału do wyszukiwania!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Czas trwania %(seconds)s sekund dla pliku:  %(file)s"
@@ -3934,20 +3908,20 @@ msgstr ""
 "%(old)s  Nowy: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Błąd Argumentu Lang:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
 "Nie udało się załadować tłumaczenia dziennika dla dowolnego z:  [%s]  w:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4281,64 +4255,64 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Dekodowane dane z ffmpeg: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Dodawanie wpisu strumienia dla URL:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Nie można wyodrębnić informacji"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "To jest playlista."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 "Informacja o wpisie wydaje się być strumieniem, dodając wpis strumienia..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Nieprawidłowy typ treści `%(type)s` dla URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "Masz tekst/html dla typu zawartości, może to być strumień."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Pytany typ zawartości \"%(type)s\" dla adresu url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Dodawanie wpisu listy URLPlaylaylist dla: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Dodawanie LocalFilePlaylistEntry dla: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "Ignorowane wideo z linku złożonej playlisty z ID:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4347,7 +4321,7 @@ msgstr ""
 "  URL: %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4356,7 +4330,7 @@ msgstr ""
 "maksimum."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4364,40 +4338,40 @@ msgstr ""
 "usunięty:  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "Nie można dodać elementu"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Element: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "Pominięto niewłaściwe wpisy %s"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Zmień kolejność pętli nad wpisami."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Wstępne pobieranie następnego utworu:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "brak danych czasu trwania"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "brak danych czasu trwania w bieżącym wpisie"
 
@@ -4977,44 +4951,44 @@ msgstr ""
 "Powinno to zawierać wartości zgodne z strftime(). (Standardowo: '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Wersja:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Otwiera nową instancję MusicBot. Ten terminal może być bezpiecznie "
 "zamknięty!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Wczytywanie wersji MusicBot:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Rejestr otwarty:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Zmiana katalogu roboczego na:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5025,7 +4999,7 @@ msgstr ""
 "lokalizacji katalogu."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5034,7 +5008,7 @@ msgstr ""
 "Jeśli nie używałeś git do sklonowania repozytorium, mocno poleca się cię."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5043,12 +5017,12 @@ msgstr ""
 "wyjść."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Oto dokładny błąd, może to być błąd."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5057,7 +5031,7 @@ msgstr ""
 "możesz otworzyć uszkodzoną stronę w programie Microsoft Edge lub IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5066,17 +5040,17 @@ msgstr ""
 " tego próbuje certyfikować."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Błąd składni (wykryto modyfikację, czy edytowałeś kod?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Błąd składni (jest to błąd, nie twoja usterka)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5097,12 +5071,12 @@ msgstr ""
 "  lub uruchomić bez `--no-install-deps` i MusicBot spróbuje je zainstalować dla Ciebie."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "Próba zainstalowania pakietów zależności MusicBot automatycznie...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5138,12 +5112,12 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, pozwala mieć nadzieję, że zainstalowanie zależności działa!"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5152,58 +5126,58 @@ msgstr ""
 "wyjść..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "Wyjątek, który spowodował powyższy błąd: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot wykonuje miękki restart..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot wykonuje pełny proces restartu..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Błąd podczas uruchamiania bota"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Zamknij pętlę zdarzeń."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Ponowne uruchomienie za %s sekund..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "Wszystko gotowe."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "OK, zamykamy!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -5228,12 +5202,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5247,7 +5221,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5315,45 +5289,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -5365,220 +5339,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5597,30 +5571,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5628,18 +5602,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5714,9 +5688,90 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+#~ "Konfiguracja nie posiadała poświadczeń aplikacji Spotify, próbując użyć "
+#~ "trybu gościa."
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "Uwierzytelniono ze Spotify za pomocą trybu gościa."
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr "Nie można uruchomić klienta Spotify w trybie gościa. Szczegóły: %s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "Wyszukiwanie YouTube nie zwróciło żadnych wyników dla:  %(url)s"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/pl_PL/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/pl_PL/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -484,20 +484,20 @@ msgstr ""
 "zrestartować?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot prosi o mówienie na kanale: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot nie ma uprawnień do mówienia."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot nie mógł prosić o głos."
 
@@ -630,7 +630,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Ustawianie gildii historii URL %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Nie ustawiono miniatury dla wpisu z adresem URL: %s"
@@ -715,19 +715,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Pętla nad autoplaylistą graczy..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Błąd podczas przetwarzania utworu \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Błąd podczas rozpakowywania utworu \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 "MusicBot musi zatrzymać automatyczne wydobycie i ratowanie listy "
@@ -1105,7 +1105,7 @@ msgstr "Lista gildii:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1676,7 +1676,7 @@ msgid "The player is not currently looping."
 msgstr "Odtwarzacz nie jest obecnie w pętli."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Pozycje piosenek muszą być liczbą całkowitą!"
 
@@ -1699,34 +1699,34 @@ msgid "Local media playback is not enabled."
 msgstr "Lokalne odtwarzanie mediów nie jest włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "Adres URL Spotify jest nieprawidłowy lub nie jest obecnie obsługiwany."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Wykryto adres URL Spotify, ale Spotify nie jest włączony."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Osiągnąłeś limit utworów w kolejce (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Tryb Karaoke jest włączony, spróbuj ponownie, gdy jest wyłączony!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Problem z extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1736,12 +1736,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Nie można odtworzyć tego wideo. Spróbuj użyć komendy streamu."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1751,7 +1751,7 @@ msgstr ""
 "%(time_per).2f s/spiosenka"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1760,47 +1760,47 @@ msgstr ""
 " (%(max)s sekund)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "Wyróżniono wpis z 'youtube:playlist' jako klucz ekstraktora"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Czas trwania piosenki przekracza limit (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Dodano utwór na pozycji %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "Nie można oszacować czasu do odtworzenia pozycji: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "Nie udało się uzyskać informacji z żądania streamu: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Strumieniowanie list odtwarzania nie jest jeszcze obsługiwane."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Osiągnąłeś limit przedmiotów na liście odtwarzania (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -1808,59 +1808,59 @@ msgstr ""
 "`help search`."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Nie możesz wyszukać więcej niż filmy %(max)s"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "Oczekiwanie na zablokowanie wezwania: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Przywołanie blokady za: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 "Nie jesteś połączony z głosowaniem. Spróbuj dołączyć do kanału głosowego!"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Dołączanie do %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 "MusicBot nie może śledzić użytkownika, który nie jest członkiem serwera."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Gracz nie gra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Nic w kolejce do usunięcia!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nic nie znaleziono w kolejce od użytkownika `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1869,40 +1869,40 @@ msgstr ""
 "Musisz być tym, który ma w kolejce do kolejki lub ma natychmiastowe uprawnienia do pominięcia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Nieprawidłowy numer wpisu. Użyj polecenia kolejki, aby znaleźć pozycje "
 "kolejki."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Nie można pominąć! Gracz nie gra!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "Nie masz uprawnień, aby wymusić pominięcie piosenki w pętli."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Nie masz uprawnień do wymuszania pominięcia."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Nie masz uprawnień, aby pominąć piosenkę w pętli."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` nie jest poprawną liczbą"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1912,7 +1912,7 @@ msgstr ""
 "Głośność można ustawić tylko od 1 do 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1920,7 +1920,7 @@ msgstr ""
 "Podano nieracjonalny wolumen: %(volume)s. Podaj wartość między 1 a 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1929,28 +1929,28 @@ msgstr ""
 "Użyj komendy konfiguracyjnej, aby ustawić domyślną prędkość odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Prędkość nie może być zastosowana do mediów strumieniowych."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Musisz podać szybkość, aby ustawić."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "Podana prędkość jest nieprawidłowa. Użyj liczby od 0,5 do 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Nieprawidłowa opcja dla polecenia: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1960,30 +1960,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Musisz podać alias i polecenie do aliasu"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Musisz podać nazwę aliasu aby usunąć."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` nie istnieje."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Konfiguracja nie może używać kanału i wzmianek użytkownika w tym samym "
 "czasie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1993,7 +1993,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2002,17 +2002,17 @@ msgstr ""
 " nazwę opcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Podana opcja jest niejednoznaczna, proszę podać nazwę sekcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "Musisz podać nazwę sekcji i nazwę opcji dla tej komendy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2022,102 +2022,102 @@ msgstr ""
 "Dostępne sekcje to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Opcja `%(option)s` jest niedostępna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Opcja `%(option)s` nie jest edytowalna. Nie można zapisać na dysku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Nie udało się zapisać opcji: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna, wartość nie może być wyświetlana."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zaktualizować ustawienia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Musisz podać sekcję, opcję i wartość dla tej podkomendy."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Ustawiono na %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Opcja `%(option)s` nie została zaktualizowana!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zresetować do domyślnego."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Resetowanie %(config)s do domyślnego %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Opcja `%(option)s` nie została zresetowana do domyślnych!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Komenda opcji jest przestarzała, zamiast tego użyj komendy config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Podano nieprawidłową opcję, użyj: info, update, lub wyczyść"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Nie udało się** usunąć pamięci podręcznej, sprawdź logi aby uzyskać więcej"
 " informacji..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Argument strony kolejki musi być liczbą całkowitą."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Brak utworów w kolejce! Kolejka czegoś z poleceniem odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2127,24 +2127,24 @@ msgstr ""
 "Istnieją ** strony%(total)s**."
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "Pominięto bieżący wpis listy odtwarzania."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "Za mało wpisów do stronicowania kolejki."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Nie można opublikować wiadomości kolejki, nie ma wiadomości do dodania "
 "reakcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2153,17 +2153,17 @@ msgstr ""
 "Jeśli problem będzie się powtarzał, zgłoś błąd."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Nie można użyć czyszczenia na prywatnym kanale DM."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "Podany adres URL nie jest prawidłowym adresem URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2173,12 +2173,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "To nie wygląda na playlistę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2187,18 +2187,18 @@ msgstr ""
 "identyfikator i spróbuj ponownie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Nie można określić użytkownika Discorda. Spróbuj ponownie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Uprawnienia nie mogą używać jednocześnie wspomnień kanału i użytkownika."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2208,23 +2208,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Musisz podać nazwę grupy lub opcji dla tego polecenia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Musisz podać grupę, opcję i wartość, aby ustawić to polecenie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Podpolecenie %(option)s wymaga nazwy grupy i uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2234,47 +2234,47 @@ msgstr ""
 "Dostępne grupy to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Uprawnienia `%(option)s` nie są dostępne."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Nie można dodać grupy `%(group)s` już istnieje."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Nie można usunąć wbudowanej grupy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Grupa właścicieli nie jest edytowalna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Nie udało się zapisać grupy: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Ustawiono %(option)s z wartością: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Uprawnienia `%(option)s` nie zostały zaktualizowane!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2283,7 +2283,7 @@ msgstr ""
 "Zapamiętaj zmiany nazwy są ograniczone do dwóch razy na godzinę.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2293,12 +2293,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Nie można zmienić pseudonimu: brak uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2308,12 +2308,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Niestandardowe emoji muszą być z tego serwera, aby użyć jako prefiks."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2322,30 +2322,30 @@ msgstr ""
 "Użyj komendy config aby zaktualizować prefiks."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Ta komenda może być użyta tylko w gildiach."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Podano nieprawidłowe polecenie. Aby uzyskać więcej informacji, użyj "
 "polecenia pomocy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Nie można ustawić języka na `%(locale)s` nie jest on dostępny."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Musisz podać adres URL lub załączyć plik."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2355,19 +2355,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot znalazł %s bez gildii! To może być problem."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Obecnie nie jest połączony z serwerem `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2375,44 +2375,44 @@ msgstr ""
 "uppip lub upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Musisz podać identyfikator lub nazwę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nie znaleziono gildii o ID lub nazwie `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Aktywuję ID przerwania debugowania: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Nie można zaimportować `objgraf`, czy jest zainstalowany?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Kod debugowania uruchomiony z eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Kod debugowania uruchomiony z exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "Nie udało się wykonać kodu debugowania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2428,57 +2428,57 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Podpolecenie musi być jednym z: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Nie można zlokalizować pliku wykonywalnego git"
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ""
 "Nie powiodło się podczas sprawdzania aktualizacji za pomocą polecenia git"
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Pakiet brakuje meta w raporcie pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr "Nie udało się uzyskać statusu aktualizacji pipsa z powodu błędu."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Masz dziwne wejście klienta głosowego."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Pliki cookie są już włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Pliki cookie muszą być przesłane, aby je włączyć. (Przeliczanie pliku "
 "cookies.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Nie można włączyć ciasteczek z powodu błędu:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2488,7 +2488,7 @@ msgstr ""
 "ciasteczka tymczasowo wyłączone i zostaną ponownie włączone przy następnym ponownym uruchomieniu."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2496,50 +2496,50 @@ msgstr ""
 "przesyłania pliku cookie."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 "Nie można usunąć starego, wyłączonego pliku ciasteczek:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Błąd podczas pobierania pliku ciasteczek z dysku:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Nie można zapisać ciasteczek na dysku:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Masz wiadomość bez kanału, jako:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorowanie komendy u mnie (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignorowanie polecenia od innego bota (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignorowanie polecenia z kanału typu:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2547,24 +2547,24 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Wiadomość od %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Ta komenda nie jest dozwolona dla grupy uprawnień:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Ta komenda wymaga bycia na kanale głosowym."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
@@ -2572,76 +2572,76 @@ msgstr ""
 "%(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Błąd w %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Wyjątek podczas obsługi polecenia: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Nie można wygenerować pomocy dla brakującej komendy:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Brak danych pomocy dla komendy:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Opuszczanie kanału głosowego %s w %s z powodu braku aktywności."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot został połączony."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot został rozłączony."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Masz wydarzenie z gniazdem:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "Stan głosowy zaktualizowany przed na_gotowością"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorowanie %s w %s jako kanał głosowy połączony."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s został wykryty jako pusty. Upłynął limit czasu."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Użytkownik dołączył do %s, anulował czas."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2649,30 +2649,30 @@ msgstr ""
 "Bot został przeniesiony, a kanał głosowy %s jest pusty. Upłynął limit czasu."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Bot został przeniesiony, a kanał głosowy %s nie jest pusty."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "Nie obserwuj już użytkownika %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Obserwowany użytkownik `%(user)s` do kanału:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "Brak statusu głosowego."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2682,7 +2682,7 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2690,7 +2690,7 @@ msgstr ""
 "  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
@@ -2698,84 +2698,84 @@ msgstr ""
 "Gildia:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Ponowne łączenie z automatycznie dołączoną gildią na kanale:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Nie można automatycznie dołączyć do kanału:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Bot został dodany do gildii: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Lewa gildia '%s' z powodu nieznalezionego właściciela bota."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Tworzenie folderu danych dla gildii %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Bot został usunięty z gildii: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Zaktualizowano listę gildii:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Gildia \"%s\" stała się dostępna."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Wznawianie gracza w \"%s\" ze względu na dostępność."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Gildia \"%s\" stała się niedostępna."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Zatrzymanie gracza w \"%s\" z powodu niedostępności."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Aktualizacja Gildii dla:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Atrybut gildii %(attr)s jest teraz: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Aktualizacja kanału dla:  %(channel)s  --  %(changes)s"
@@ -2793,7 +2793,7 @@ msgid "Loading config from:  %s"
 msgstr "Ładowanie konfiguracji z:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2823,7 +2823,7 @@ msgstr ""
 "  Użyj opcji przykładowych jako szablonu lub skopiuj je z repozytorium."
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2833,7 +2833,7 @@ msgstr ""
 "będzie ograniczona."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2842,7 +2842,7 @@ msgstr ""
 "rotacji pliku dziennika. Użyj domyślnego."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2861,12 +2861,12 @@ msgstr ""
 "  Upewnij się, że ścieżka, którą skonfigurowałeś jest ścieżką do folderu / katalogu."
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Podczas sprawdzania poprawności AudioCachePath, wystąpił wyjątek."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2888,13 +2888,13 @@ msgstr ""
 "  Sprawdź, czy ustawienia są poprawne, dostępna ścieżka katalogu."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Pamięć podręczna audio będzie przechowywana w: %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2914,7 +2914,7 @@ msgstr ""
 "  Ustaw opcję konfiguracji tokenu lub ustaw zmienną środowiskową %(env_var)s z tokenem aplikacji."
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2922,7 +2922,7 @@ msgstr ""
 "Opcja StatusMessage jest zbyt długa, będzie ograniczona do 128 znaków."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2932,17 +2932,17 @@ msgstr ""
 "%.3f będzie ograniczona."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Sprawdzanie opcji z danymi usługi..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "Nabyty identyfikator właściciela przez API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2963,12 +2963,12 @@ msgstr ""
 "  ręcznie ustaw opcję 'WłaścicielID' lub spróbuj ponownie później."
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot nie ma instancji użytkownika, nie można kontynuować."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2987,13 +2987,13 @@ msgstr ""
 "  Nie używaj Bot ani App ID w polu 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 "Nie znaleziono pliku opcji konfiguracyjnych. Sprawdzanie alternatyw..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3003,19 +3003,19 @@ msgstr ""
 "włączyć rozszerzenia plików."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Kopiowanie istniejącego przykładowego pliku opcji:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 "Coś poszło nie tak podczas próby znalezienia pliku opcji konfiguracji."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3037,7 +3037,7 @@ msgstr ""
 "  Zweryfikuj folder konfiguracyjny i pliki istnieją i mogą być odczytane przez MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3061,12 +3061,12 @@ msgstr ""
 "  Skopiuj przykładowy plik z repozytorium, jeśli wszystko inne nie powiedzie się."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! Opcja konfiguracji ma getter, który jest niedostępny."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3075,30 +3075,30 @@ msgstr ""
 "musi być tym samym typem."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "Wcześniej brakowało wariantu."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Sekcja konfiguracji nie jest w pliku konfiguracyjnym! Brakuje: %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Zapisana opcja konfiguracji: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Nie udało się zapisać konfiguracji:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
@@ -3106,13 +3106,13 @@ msgstr ""
 "wyłączone."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Nie udało się zapisać domyślnego pliku INI na:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3132,7 +3132,7 @@ msgstr ""
 "  Ustaw %(option)s na numeryczny identyfikator lub ustaw go na `auto` lub `0` dla automatycznego powiązania właściciela."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3152,7 +3152,7 @@ msgstr ""
 "  Sprawdź ustawienia ścieżki i upewnij się, że plik istnieje i jest dostępny dla MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3172,7 +3172,7 @@ msgstr ""
 "  Upewnij się, że wszystkie ID są liczbowe i oddzielone tylko spacjami lub przecinkami."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3182,7 +3182,7 @@ msgstr ""
 "poziomu: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3192,7 +3192,7 @@ msgstr ""
 "'%(value)s' zamiast domyślnej."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3202,7 +3202,7 @@ msgstr ""
 " zamiast tego zostanie ustawiona na %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3210,48 +3210,48 @@ msgstr ""
 "Zmiana nazwy pliku INI [%(old_s)s] > %(old_o)s  na [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Aktualizowanie pliku konfiguracyjnego ze zmienionymi nazwami opcji..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Nie udało się zaktualizować konfiguracji. Musisz uaktualnić ją ręcznie."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Nie znaleziono pliku listy bloków:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Nie można załadować listy bloków z pliku:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Nie można zaktualizować pliku listy bloków:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Załadowano listę bloków użytkowników z wpisami %s."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "Znaleźliśmy starszy plik czarnej listy, zostanie on zmieniony na:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Załadowano listę bloków piosenek z wpisami %s."
@@ -3318,41 +3318,41 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Wymuszanie YTDLP do używania User Agent:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot będzie używać ciasteczek do yt-dlp z:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp użyje skonfigurowanego serwera proxy."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD wydaje się, że nie ma nagłówków..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 "Sprawdzanie nagłówków mediów nie powiodło się z powodu przekroczenia limitu "
 "czasu."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Nieudane żądanie HEAD dla:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "Wyjątek żądania HEAD: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3362,79 +3362,79 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Informacje o ekstrakcji YTDL (nie JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Wyciąg informacji o utworze nie zwrócił żadnych danych."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Wywołany extract_info z: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Nie można uruchomić ekstrakcji, pętla jest zamknięta. (To jest normalne przy"
 " wyłączeniu.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Nie można kontynuować ekstrakcji, pętla zdarzeń jest zamknięta."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Adres URL Spotify jest nieprawidłowy lub nie jest obsługiwany."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Błąd pobierania z URL strumienia"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "Zakładając, że zawartość jest bezpośrednim strumieniem"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Nie można strumieniować nieprawidłowego URL."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 "Złap NoSupportingHandlers, spróbuj ponownie po zastąpieniu colona miejscem."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Wywołano safe_extract_info z:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Nie znaleziono lokalnego pliku multimedialnego."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Brakuje __input_subject z YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3442,7 +3442,7 @@ msgstr ""
 "uniknąć."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Ostrzeżenie, czas trwania błędu dla: %(url)s"
@@ -4747,13 +4747,13 @@ msgstr ""
 "Sprawdź ffmpeg w menedżerze pakietów systemowych lub buduj z źródeł."
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "Na tym urządzeniu pozostaje mniej niż %sMB wolnego miejsca"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4762,12 +4762,12 @@ msgstr ""
 "Sprawdzanie aktualizacji MusicBot lub zależności..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "Brak aktualizacji MusicBot dostępnych za pomocą polecenia `git`."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4776,23 +4776,23 @@ msgstr ""
 " ręcznie."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "Następujące pakiety mogą być aktualizowane:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  do wersji:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "Brak aktualizacji zależności dostępnych za pomocą polecenia `pip`."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4801,7 +4801,7 @@ msgstr ""
 " ręcznie."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4811,35 +4811,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "Wartość jest wyższa od maksymalnego limitu."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "Wartość nie może być ujemna."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "Wartość maks. zachowanych dzienników musi być liczbą od 0 do %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "Poziom logowania '%s' jest niedostępny."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "Poziom dziennika musi być jednym z:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4848,42 +4848,42 @@ msgstr ""
 "Discord.py, youtubeDL i ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Dostępne przez Github:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 "Aby uzyskać więcej pomocy i wsparcia z tym botem, dołącz do naszego "
 "discorda:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "Oprogramowanie to jest dostępne na licencji MIT."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "Zobacz plik tekstowy `LICENSE` w celu uzyskania pełnych informacji."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr "Zastąp domyślny / system wykryty dla całego tekstu w MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 "Użyj tego języka dla wszystkich wiadomości dziennika po stronie serwera z "
 "MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4892,29 +4892,29 @@ msgstr ""
 "To nie zapobiega wybraniu języka dla gildii."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Wydrukuj informacje o wersji MusicBot i wyjdź."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 "Pomiń wszystkie opcjonalne kontrole uruchomienia, w tym sprawdzanie "
 "aktualizacji."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Pomiń tylko sprawdzanie miejsca na dysku przy starcie."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Pomiń tylko sprawdzanie aktualizacji przy starcie."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -4923,7 +4923,7 @@ msgstr ""
 "zaimportować."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4933,7 +4933,7 @@ msgstr ""
 "(Domyślnie: %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
@@ -4941,7 +4941,7 @@ msgstr ""
 "jednym z: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4951,44 +4951,44 @@ msgstr ""
 "Powinno to zawierać wartości zgodne z strftime(). (Standardowo: '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Wersja:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Otwiera nową instancję MusicBot. Ten terminal może być bezpiecznie "
 "zamknięty!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Wczytywanie wersji MusicBot:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Rejestr otwarty:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Zmiana katalogu roboczego na:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4999,7 +4999,7 @@ msgstr ""
 "lokalizacji katalogu."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5008,7 +5008,7 @@ msgstr ""
 "Jeśli nie używałeś git do sklonowania repozytorium, mocno poleca się cię."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5017,12 +5017,12 @@ msgstr ""
 "wyjść."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Oto dokładny błąd, może to być błąd."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5031,7 +5031,7 @@ msgstr ""
 "możesz otworzyć uszkodzoną stronę w programie Microsoft Edge lub IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5040,17 +5040,17 @@ msgstr ""
 " tego próbuje certyfikować."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Błąd składni (wykryto modyfikację, czy edytowałeś kod?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Błąd składni (jest to błąd, nie twoja usterka)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5071,12 +5071,12 @@ msgstr ""
 "  lub uruchomić bez `--no-install-deps` i MusicBot spróbuje je zainstalować dla Ciebie."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "Próba zainstalowania pakietów zależności MusicBot automatycznie...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5112,57 +5112,43 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, pozwala mieć nadzieję, że zainstalowanie zależności działa!"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot dostał błąd importu po próbie instalacji pakietów. MusicBot musi "
-"wyjść..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "Wyjątek, który spowodował powyższy błąd: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot wykonuje miękki restart..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot wykonuje pełny proces restartu..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Błąd podczas uruchamiania bota"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Zamknij pętlę zdarzeń."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Ponowne uruchomienie za %s sekund..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "Wszystko gotowe."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "OK, zamykamy!"
 
@@ -5183,31 +5169,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5221,7 +5207,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5281,7 +5267,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5512,24 +5498,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5576,25 +5562,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5602,66 +5588,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5688,7 +5628,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5700,25 +5640,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5731,29 +5671,145 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot dostał błąd importu po próbie instalacji pakietów. MusicBot musi "
+#~ "wyjść..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "Wyjątek, który spowodował powyższy błąd: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/pl_PL/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/pl_PL/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -41,29 +41,29 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Użytkownik nie jest włączony głosowo i nie może użyć tego polecenia."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Nie możesz użyć tej komendy gdy nie jest na kanale głosowym."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot nie ma uprawnień do połączenia na kanale: `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot nie ma uprawnień do mówienia na kanale: `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -72,7 +72,7 @@ msgstr ""
 "Spróbuj ponownie później lub zrestartuj bota jeśli to będzie kontynuowane."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -80,17 +80,17 @@ msgstr ""
 "zrestartować?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot nie ma uprawnień do mówienia."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot nie mógł prosić o głos."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -99,12 +99,12 @@ msgstr ""
 "Użyj polecenia przywołania, aby przenieść bota do kanału głosowego."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Coś jest nie tak. Nie otrzymaliśmy VoiceClient."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -113,32 +113,32 @@ msgstr ""
 "w głosowaniu!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr "%(mention)s - Twoja piosenka `%(title)s` gra teraz w %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "Teraz odtwarzane w %(channel)s: `%(title)s` dodane przez %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr "Teraz odtwarzane automatycznie dodany wpis `%(title)s` w %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 "Pominięto piosenki dodane przez %(user)s , ponieważ nie są one w głosowaniu!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -150,12 +150,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Próba wysłania nieprawidłowego obiektu odpowiedzi."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -178,14 +178,14 @@ msgstr ""
 "  Sprawdź status API na oficjalnej stronie: discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 "Żądana piosenka `%(subject)s` jest zablokowana przez listę bloków utworu."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -194,12 +194,12 @@ msgstr ""
 "Ta komenda zostanie usunięta w przyszłej wersji, zastąpiona poleceniem (poleceniami) autoplaylisty."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -207,18 +207,18 @@ msgstr ""
 "poleceń.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Aliasy dla tej komendy:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "`%(alias)s` alias `%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -229,7 +229,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -241,12 +241,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Nie ma takiej komendy"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -256,7 +256,7 @@ msgstr ""
 "Aby wyświetlić listę wszystkich poleceń, uruchom %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -278,22 +278,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Zablokuj wspomnianego użytkownika."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Odblokuj wspomnianego użytkownika."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Pokaż status bloku wspomnianego użytkownika."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -302,43 +302,43 @@ msgstr ""
 "Zablokowanym użytkownikom zabrania się używania wszystkich poleceń bota.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "Musisz podać użytkownika lub jego numer identyfikacyjny."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Podano nieprawidłowe polecenie. Użyj `help blockuser` dla przykładów użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot nie mógł znaleźć podanego użytkownika."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Właściciel nie może być dodany do listy bloków."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "Lista bloków użytkowników jest obecnie włączona."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "Lista bloków użytkowników jest obecnie wyłączona."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Nie można dodać użytkowników, których wymieniłeś, są już dodane."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -348,24 +348,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "Żaden z tych użytkowników nie jest na czarnej liście."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "Użytkownik: `%(user)s` nie jest zablokowany.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "Użytkownik: `%(user)s` jest zablokowany.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -377,7 +377,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -387,7 +387,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -404,25 +404,25 @@ msgstr ""
 "To oznacza dodanie 'Pie' będzie pasować do 'wiśni Piechotnej', ale nie 'piekrego' w kontrolach.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Musisz podać temat utworu, jeśli nie ma aktualnie odtwarzanej piosenki."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Podano nieprawidłowe polecenie. Użyj `help blocksong` dla przykładów użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Temat%(subject)s` jest już na liście bloków utworu."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -432,13 +432,13 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 "Temat nie znajduje się na liście bloków piosenek i nie może zostać usunięty."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -448,7 +448,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -457,12 +457,12 @@ msgstr ""
 "bieżącej listy odtwarzania.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Dodaje całą kolejkę do listy odtwarzania gildii.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -471,68 +471,68 @@ msgstr ""
 "playlistę gildii.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Podano nieprawidłowe polecenie. Użyj `help autoplaylist` dla przykładów "
 "użycia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Podany link do utworu jest nieprawidłowy"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "Kolejka jest pusta. Dodaj kilka piosenek poleceniem odtwarzania!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "Wszystkie utwory w kolejce są już w autoplaylist."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "Dodano utwory %(number)d do listy autoplay."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "Dodano `%(url)s` do autoplaylisty."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Ta piosenka jest już na autoplaylist."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "Usunięto `%(url)s` z listy autoplay."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Ta piosenka nie znajduje się jeszcze na liście autoplay."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Załadowano nową kopię playlisty: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Musisz podać nazwę pliku listy odtwarzania."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -541,7 +541,7 @@ msgstr ""
 "Ta lista odtwarzania jest nowa, musisz dodać utwory, aby zapisać je na dysku!"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
@@ -549,7 +549,7 @@ msgstr ""
 "`%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
@@ -557,7 +557,7 @@ msgstr ""
 "innego serwera."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -567,7 +567,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -576,28 +576,28 @@ msgstr ""
 "Grupy z kontrolą uprawnień BypassKaraokeMode które są członkami Karaoke.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\N{OK HAND SIGN} Tryb Karaoke jest teraz włączony."
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\N{OK HAND SIGN} Tryb karaoke jest teraz wyłączony."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Nie masz uprawnień do żądania playlist"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "Playlista ma zbyt wiele wpisów (%(songs)s ale max to %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -609,12 +609,12 @@ msgstr ""
 "Limit wynosi %(max)s dla twojej grupy."
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "Bot był wcześniej wstrzymany, wznowiono odtwarzanie."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -631,7 +631,7 @@ msgstr ""
 "MusicBot obsługuje również adresy URL Spotify, ale dźwięk jest pobierany z YouTube.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -640,13 +640,13 @@ msgstr ""
 "do kolejki.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "Odtwarzanie losowe elementów listy odtwarzania z `%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -655,7 +655,7 @@ msgstr ""
 "Przeczytaj pomoc dla komendy odtwarzania dla informacji o obsługiwanych danych wejściowych.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -664,7 +664,7 @@ msgstr ""
 "Przeczytaj pomoc dla komendy odtwarzania dla informacji o obsługiwanych danych wejściowych.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -677,33 +677,33 @@ msgstr ""
 "Ze względu na specyfikację kodeka w ffmpeg, może to nie być dokładne.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Nie można użyć szukania, jeśli nic nie gra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "Nie można użyć szukania bieżącego utworu, ma nieznany czas trwania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Szukanie nie jest obsługiwane dla strumieni."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "Nie można użyć wyszukiwania bez czasu na umiejscowienie odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Nie można przekonwertować `%(input)s` na poprawny czas w sekundach."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -713,7 +713,7 @@ msgstr ""
 "długości `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -721,7 +721,7 @@ msgstr ""
 "Szukam czasu `%(input)s` (`%(seconds).2f` sekund) w bieżącej piosence."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -732,66 +732,66 @@ msgstr ""
 "Jeśli nie podano żadnej opcji i utwór już się powtarza, powtórzenie zostanie wyłączone.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 "Nie ma aktualnie odtwarzanych utworów. Odtwarzaj coś z poleceniem "
 "odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Nieprawidłowe polecenie podrzędne. Użyj polecenia `help repeat` dla "
 "przykładów użycia."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "Playlista jest teraz powtarzana."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "Playlista już się nie powtarza."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "Odtwarzacz zapętli teraz bieżącą piosenkę."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "Gracz nie będzie już w pętli bieżącej piosenki."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "Odtwarzacz jest już w pętli utworu!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Odtwarzacz nie jest obecnie w pętli."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "Utwór już się nie powtarza."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "Utwór się powtarza."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    Przenieś utwór w pozycji FROM do pozycji TO.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -800,23 +800,23 @@ msgstr ""
 "Użyj polecenia kolejki do znalezienia numerów pozycji śladów.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 "Nie ma żadnych piosenek w kolejce. Odtwórz coś z poleceniem odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Pozycje piosenek muszą być liczbą całkowitą!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Dałeś pozycję poza rozmiarem playlisty!"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -824,7 +824,7 @@ msgstr ""
 "Pomyślnie przeniesiono utwór z pozycji %(from)s w kolejce do pozycji %(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -838,34 +838,34 @@ msgstr ""
 "Czy chcesz dodać również listę odtwarzania?"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Lokalne odtwarzanie mediów nie jest włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "Adres URL Spotify jest nieprawidłowy lub nie jest obecnie obsługiwany."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Wykryto adres URL Spotify, ale Spotify nie jest włączony."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Osiągnąłeś limit utworów w kolejce (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Tryb Karaoke jest włączony, spróbuj ponownie, gdy jest wyłączony!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -875,15 +875,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Nie można odtworzyć tego wideo. Spróbuj użyć komendy streamu."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "Wyszukiwanie YouTube nie zwróciło żadnych wyników dla:  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1065,7 +1059,7 @@ msgid "Show information on what is currently playing."
 msgstr "Pokaż informacje o tym, co aktualnie gra."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1102,7 +1096,7 @@ msgstr "Postęp:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Brak utworów w kolejce! Kolejka czegoś z poleceniem odtwarzania."
 
@@ -1211,38 +1205,25 @@ msgstr "Usuwa wszystkie utwory obecnie w kolejce."
 msgid "Cleared all songs from the queue."
 msgstr "Wyczyszczono wszystkie piosenki z kolejki."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Usuń utwór z kolejki, opcjonalnie w danej pozycji kolejki.\n"
-"Jeśli pozycja jest pominięta, piosenka na końcu kolejki zostaje usunięta.\n"
-"Użyj polecenia kolejki, aby znaleźć numer pozycji swojego utworu.\n"
-"Jednakże, pozycje wszystkich piosenek są zmieniane, gdy rozpocznie się odtwarzanie.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Nic w kolejce do usunięcia!"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Usunięto `%(track)s` dodane przez `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nic nie znaleziono w kolejce od użytkownika `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1251,26 +1232,26 @@ msgstr ""
 "Musisz być tym, który ma w kolejce do kolejki lub ma natychmiastowe uprawnienia do pominięcia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Nieprawidłowy numer wpisu. Użyj polecenia kolejki, aby znaleźć pozycje "
 "kolejki."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Usunięto wpis `%(track)s` dodany przez `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Usunięto wpis `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1281,23 +1262,23 @@ msgstr ""
 "Jeśli opcja LegacySkip jest włączona, parametr siły można zignorować.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Nie można pominąć! Gracz nie gra!"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "Następna piosenka `%(track)s` jest pobierana, proszę czekać."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "Następny utwór zostanie wkrótce odtworzony. Proszę czekać."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1306,7 +1287,7 @@ msgstr ""
 "Może chcesz zrestartować bota, jeśli nie zacznie działać."
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1315,28 +1296,28 @@ msgstr ""
 "Być może chcesz ponownie uruchomić bota, jeśli nie zacznie działać."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "Nie masz uprawnień, aby wymusić pominięcie piosenki w pętli."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Wymuś pominięcie `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Nie masz uprawnień do wymuszania pominięcia."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Nie masz uprawnień, aby pominąć piosenkę w pętli."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1346,12 +1327,12 @@ msgstr ""
 "Głosowanie na pominięcie zostało przekazane.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " Następny utwór nadchodzi!"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1361,7 +1342,7 @@ msgstr ""
 "Potrzebujesz **%(votes)s** więcej głosów, aby pominąć tę piosenkę."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1372,25 +1353,25 @@ msgstr ""
 "Ustawienie głośności jest utrzymywane do czasu ponownego uruchomienia MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Bieżąca objętość: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` nie jest poprawną liczbą"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Zaktualizowano głośność z **%(old)d** do **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1400,7 +1381,7 @@ msgstr ""
 "Głośność można ustawić tylko od 1 do 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1408,7 +1389,7 @@ msgstr ""
 "Podano nieracjonalny wolumen: %(volume)s. Podaj wartość między 1 a 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1419,7 +1400,7 @@ msgstr ""
 "odtwarzanie strumieniowe nie obsługuje regulacji prędkości.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1428,34 +1409,34 @@ msgstr ""
 "Użyj komendy konfiguracyjnej, aby ustawić domyślną prędkość odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Prędkość nie może być zastosowana do mediów strumieniowych."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Musisz podać szybkość, aby ustawić."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "Podana prędkość jest nieprawidłowa. Użyj liczby od 0,5 do 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Ustawienie prędkości odtwarzania na `%(speed).3f` dla bieżącego utworu."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Dodaj nowy alias z opcjonalnymi argumentami.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1464,23 +1445,23 @@ msgstr ""
 " pomocy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Nieprawidłowa opcja dla polecenia: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Aliasy przeładowane z pliku konfiguracyjnego."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Aliasy zapisane w pliku konfiguracyjnym."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1490,41 +1471,41 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Musisz podać alias i polecenie do aliasu"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nowy alias dodany. `%(alias)s` jest teraz aliasem `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Musisz podać nazwę aliasu aby usunąć."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` nie istnieje."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` został usunięty."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Pokazuje tekst pomocy o wszystkich brakujących opcjach konfiguracji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1533,32 +1514,32 @@ msgstr ""
 "konfiguracyjnego.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr "    Lista dostępnych opcji konfiguracji i ich sekcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Przeładuj plik options.ini z dysku.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Pokazuje tekst pomocy dla konkretnej opcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Wyświetl bieżącą wartość opcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Zapisuje bieżącą wartość do pliku opcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1567,34 +1548,34 @@ msgstr ""
 "pliku.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Zresetuj opcję do wartości domyślnej.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Zarządzaj konfiguracją opcjiini z Discorda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Konfiguracja nie może używać kanału i wzmianek użytkownika w tym samym "
 "czasie."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*Wszystkie opcje konfiguracyjne są obecne i uwzględnione!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "Żadne opcje konfiguracji nie wydają się być zmienione."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1604,7 +1585,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1620,12 +1601,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "Opcje konfiguracji zostały pomyślnie przeładowane z pliku!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1635,7 +1616,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1644,17 +1625,17 @@ msgstr ""
 " nazwę opcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Podana opcja jest niejednoznaczna, proszę podać nazwę sekcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "Musisz podać nazwę sekcji i nazwę opcji dla tej komendy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1664,25 +1645,25 @@ msgstr ""
 "Dostępne sekcje to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Opcja `%(option)s` jest niedostępna."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Ta opcja może być ustawiona tylko przez edycję pliku konfiguracyjnego."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Domyślnie ta opcja jest ustawiona na: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1696,32 +1677,32 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Opcja `%(option)s` nie jest edytowalna. Nie można zapisać na dysku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Nie udało się zapisać opcji: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Pomyślnie zapisano opcję: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna, wartość nie może być wyświetlana."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1733,25 +1714,25 @@ msgstr ""
 "INI File Value: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zaktualizować ustawienia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Musisz podać sekcję, opcję i wartość dla tej podkomendy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Opcja `%(option)s` nie została zaktualizowana!"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1761,20 +1742,20 @@ msgstr ""
 "Aby zapisać zmianę, użyj `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zresetować do domyślnego."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Opcja `%(option)s` nie została zresetowana do domyślnych!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1784,17 +1765,17 @@ msgstr ""
 "Aby zapisać zmianę, użyj `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Przestarzałe polecenie, zamiast tego użyj polecenia config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Komenda opcji jest przestarzała, zamiast tego użyj komendy config."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1803,33 +1784,33 @@ msgstr ""
 "Używanie opcji aktualizacji skanuje pamięć podręczną w poszukiwaniu zmian zewnętrznych przed wyświetleniem szczegółów."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Podano nieprawidłową opcję, użyj: info, update, lub wyczyść"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Wyłączone"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Włączone"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s dni"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Nieograniczona"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1845,24 +1826,24 @@ msgstr ""
 "**Pamięć podręczna Teraz:  %(used)s w plikach %(files)s."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "Skrzynka została wyczyszczona."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Nie udało się** usunąć pamięci podręcznej, sprawdź logi aby uzyskać więcej"
 " informacji..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "Nie znaleziono skrzynki do wyczyszczenia."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1871,12 +1852,12 @@ msgstr ""
 "Fakultatywny numer strony pokazuje późniejsze wpisy w kolejce.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Argument strony kolejki musi być liczbą całkowitą."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1886,12 +1867,12 @@ msgstr ""
 "Istnieją ** strony%(total)s**."
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(nieznany czas trwania)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1903,7 +1884,7 @@ msgstr ""
 "Postęp: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1917,12 +1898,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Utwory w kolejce"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1931,7 +1912,7 @@ msgstr ""
 "Jeśli problem będzie się powtarzał, zgłoś błąd."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1942,39 +1923,39 @@ msgstr ""
 "Ta komenda może być wolna, jeśli podane są większe zakresy.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Nieprawidłowy parametr. Proszę podać liczbę wiadomości do wyszukiwania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Nie można użyć czyszczenia na prywatnym kanale DM."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Wyczyszczono wiadomości %(number)s."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Bot nie ma uprawnień do zarządzania wiadomościami."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Zrzuć indywidualne adresy URL playlisty do pliku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "Podany adres URL nie jest prawidłowym adresem URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1984,18 +1965,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "To nie wygląda na playlistę."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Oto zrzut playlisty dla:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2004,19 +1985,19 @@ msgstr ""
 "Ta komenda jest przestarzała na korzyść trybu deweloperskiego w klientach Discorda.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Twój identyfikator użytkownika to `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "ID użytkownika dla `%(username)s` to `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2027,24 +2008,24 @@ msgstr ""
 "Ta komenda jest przestarzała na korzyść trybu deweloperskiego w klientach Discorda.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Prawidłowe kategorie: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Oto ID, o które prosiłeś:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "Uzyskaj listę uprawnień lub uprawnień wspomnianego użytkownika."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2053,12 +2034,12 @@ msgstr ""
 "identyfikator i spróbuj ponownie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Nie można określić użytkownika Discorda. Spróbuj ponownie."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2072,7 +2053,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2086,63 +2067,63 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Pokaż wczytane grupy i opcje uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Ponownie ładuje uprawnienia z pliku uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    Dodaj nową grupę z domyślnymi.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Usuń istniejącą grupę.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Pokaż tekst pomocy dla opcji uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Pokaż wartość uprawnień dla danej grupy i uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Zapisz grupę uprawnień do pliku.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Ustaw wartość uprawnień dla grupy.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Zarządzaj konfiguracją uprawnieńini z dysku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Uprawnienia nie mogą używać jednocześnie wspomnień kanału i użytkownika."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "Uprawnienia ponownie załadowane z pliku!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2152,7 +2133,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2166,23 +2147,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Musisz podać nazwę grupy lub opcji dla tego polecenia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Musisz podać grupę, opcję i wartość, aby ustawić to polecenie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Podpolecenie %(option)s wymaga nazwy grupy i uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2192,24 +2173,24 @@ msgstr ""
 "Dostępne grupy to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Uprawnienia `%(option)s` nie są dostępne."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr "To uprawnienie może być ustawione tylko przez edycję pliku uprawnień."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Domyślnie to uprawnienie jest ustawione na: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2223,13 +2204,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Nie można dodać grupy `%(group)s` już istnieje."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2241,12 +2222,12 @@ msgstr ""
 "Upewnij się, że zapisz nową grupę w: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Nie można usunąć wbudowanej grupy."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2256,24 +2237,24 @@ msgstr ""
 "Upewnij się, że zapisać tę zmianę w: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Grupa właścicieli nie jest edytowalna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Nie udało się zapisać grupy: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Pomyślnie zapisano grupę: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2285,13 +2266,13 @@ msgstr ""
 "INI File Value: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Uprawnienia `%(option)s` nie zostały zaktualizowane!"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2301,7 +2282,7 @@ msgstr ""
 "Aby zapisać zmianę, użyj `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2310,7 +2291,7 @@ msgstr ""
 "Uwaga: API może ograniczyć zmianę nazwy do dwóch razy na godzinę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2319,7 +2300,7 @@ msgstr ""
 "Zapamiętaj zmiany nazwy są ograniczone do dwóch razy na godzinę.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2329,23 +2310,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Ustaw nazwę użytkownika bota na `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Zmień nick MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Nie można zmienić pseudonimu: brak uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2355,23 +2336,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Ustawiono pseudonim bota na `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Ustaw prefiks komendy na serwer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Wyczyść prefiks komend na serwer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2380,23 +2361,23 @@ msgstr ""
 "Opcja Włączony PrefixPerGuild musi być włączona w pierwszej kolejności."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Niestandardowe emoji muszą być z tego serwera, aby użyć jako prefiks."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Prefiks komend serwera został wyczyszczony."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Prefiks polecenia serwera jest teraz:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2405,39 +2386,39 @@ msgstr ""
 "Użyj komendy config aby zaktualizować prefiks."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Pokaż kody językowe dostępne do użycia.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    Ustaw żądany język dla tego serwera.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Zresetuj język serwera do domyślnego języka bota.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "Zarządzaj językiem używanym do wiadomości na serwerze połączeń."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Ta komenda może być użyta tylko w gildiach."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Podano nieprawidłowe polecenie. Aby uzyskać więcej informacji, użyj "
 "polecenia pomocy."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2451,25 +2432,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Nie można ustawić języka na `%(locale)s` nie jest on dostępny."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Język dla tego serwera ustawiony jest: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Język dla tego serwera został zresetowany do: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2478,12 +2459,12 @@ msgstr ""
 "Dołączanie pliku i pominięcie parametru url również działa.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Musisz podać adres URL lub załączyć plik."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2493,40 +2474,40 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "Zmieniono awatar bota."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Wymuś rozłączenie MusicBot z serwerem Discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Rozłączono z serwerem `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Odłączono klienta głosowego bez odtwarzacza? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Obecnie nie jest połączony z serwerem `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Próba odświeżenia bez ponownego uruchomienia procesu. Opcja domyślna.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
@@ -2534,21 +2515,21 @@ msgstr ""
 "wszystkiego.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Pełne ponowne uruchomienie, ale próba aktualizacji pakietów pip przed "
 "ponownym uruchomieniem.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Pełne ponowne uruchomienie, ale najpierw zaktualizuj kod źródłowy "
 "MusicBot git.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2557,7 +2538,7 @@ msgstr ""
 "całkowitym ponownym uruchomieniem.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2570,7 +2551,7 @@ msgstr ""
 "Jeśli masz menedżera usług, zalecamy użycie go zamiast tej komendy do ponownego uruchomienia.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2578,19 +2559,19 @@ msgstr ""
 "uppip lub upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Restartowanie bieżącej instancji..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Restartowanie procesu bota..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2598,30 +2579,30 @@ msgstr ""
 "%(emoji)s spróbuje ulepszyć wymagane pakiety pip i zrestartować bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 "%(emoji)s spróbuje zaktualizować kod bota z git i zrestartować bota..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s spróbuje ulepszyć wszystko i zrestartować bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Odłącz od wszystkich kanałów głosowych i zamknij proces MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Pozostaw serwer discorda podany przez nazwę lub ID serwera."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2630,30 +2611,30 @@ msgstr ""
 "Nazwy mają znaczenie dla liter, więc użycie numeru ID jest bardziej wiarygodne.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Musisz podać identyfikator lub nazwę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nie znaleziono gildii o ID lub nazwie `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Nieznane"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Opuszczono gildię: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2662,38 +2643,38 @@ msgstr ""
 "Może być użyty do ręcznego wskazywania wydarzeń w pliku dziennika MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Zgłoszono punkt wstrzymania z ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Zobacz najczęstsze typy zgłoszone przez objgraf.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Zobacz ograniczone wyjście objgraph.show_growth().\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Zobacz najpopularniejsze typy wyciekających obiektów.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Zobacz statystyki typów wyciekających obiektów.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Oceń daną funkcję i argumenty na objgrafie.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2704,12 +2685,12 @@ msgstr ""
 "Ponieważ ta metoda ocenia dowolny kod, jest uważany za niebezpieczny jak polecenie debugowania.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Nie można zaimportować `objgraf`, czy jest zainstalowany?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2734,7 +2715,7 @@ msgstr ""
 "Zagrożenie związane z tym poleceniem nie może być zaniżone. Nie używaj go ani nie daj mu dostępu, jeśli nie rozumiesz ryzyka!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2750,7 +2731,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2759,23 +2740,23 @@ msgstr ""
 "Wyjście jest używane do aktualizacji stron GitHub i dlatego nie nadaje się do normalnego użycia odniesienia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Podpolecenie musi być jednym z: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Tworzy domyślne pliki INI."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Zapisano żądany plik INI na dysku. Sprawdź go"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2784,50 +2765,50 @@ msgstr ""
 " zależności.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Nie można zlokalizować pliku wykonywalnego git"
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Brak aktualizacji w gałęzi `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nowe commity są dostępne w oddziale `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "Błąd podczas sprawdzania, zobacz logi w celu uzyskania szczegółów."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Aktualizacja dla `%(name)s` do wersji: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "Nie znaleziono aktualizacji dla zależności."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "Istnieją aktualizacje dla MusicBot dostępne do pobrania."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot jest całkowicie aktualny!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2847,20 +2828,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Wyświetla czas uptime MusicBot lub czas od ostatniego rozpoczęcia / "
 "restartu."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s jest online dla `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2868,12 +2849,12 @@ msgstr ""
 "podłączonych klientów głosowych."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "Brak podłączonych klientów głosowych.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 "Wyświetlaj opóźnienie API i opóźnienie głosowe, jeśli MusicBot jest "
@@ -2882,23 +2863,23 @@ msgstr ""
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Opóźnienie API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Wyświetlaj numer wersji MusicBot na czacie."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2908,17 +2889,17 @@ msgstr ""
 "Obecna wersja: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Aktualizuj plik cookies.txt za pomocą załącznika cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Włącz lub wyłącz plik cookies.txt bez usuwania go."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2943,30 +2924,30 @@ msgstr ""
 "  , jeśli nie rozumiesz jak unikać ryzyka."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Pliki cookie są już włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Pliki cookie muszą być przesłane, aby je włączyć. (Przeliczanie pliku "
 "cookies.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Nie można włączyć ciasteczek z powodu błędu:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Pliki cookie zostały włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2976,12 +2957,12 @@ msgstr ""
 "ciasteczka tymczasowo wyłączone i zostaną ponownie włączone przy następnym ponownym uruchomieniu."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Pliki cookie zostały wyłączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2989,51 +2970,51 @@ msgstr ""
 "przesyłania pliku cookie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Błąd podczas pobierania pliku ciasteczek z dysku:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Nie można zapisać ciasteczek na dysku:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Pliki cookie przesłane i włączone."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "Nie możesz użyć tego bota w prywatnych wiadomościach."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Ta komenda nie jest dozwolona dla grupy uprawnień:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Ta komenda wymaga bycia na kanale głosowym."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Polecenie:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Błąd wyjątku"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3043,17 +3024,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "Nie podano opisu.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "Nie podano użycia."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3067,13 +3048,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Opuszczanie kanału głosowego %(channel)s z powodu braku aktywności."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3702,13 +3683,13 @@ msgstr ""
 "Pozostaw puste, aby używać domyślnych, dynamicznie generowanych ciągów UA."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Przełącz funkcję listy bloków użytkowników bez opróżniania listy bloków."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3716,12 +3697,12 @@ msgstr ""
 "Discorda, po jednym na wiersz."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "Włącz funkcję listy bloków utworów, bez opróżniania listy bloków."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3730,7 +3711,7 @@ msgstr ""
 "Wszelkie tytuły piosenki lub adresy URL zawierające dowolną linię na liście zostaną zablokowane."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3739,7 +3720,7 @@ msgstr ""
 "Każdy plik powinien zawierać listę adresów lub terminów odtwarzania, po jednym utworze na linię."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3753,7 +3734,7 @@ msgstr ""
 "Maps to:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3762,7 +3743,7 @@ msgstr ""
 "krótkoterminową pamięć podręczną do odtwarzania."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3774,7 +3755,7 @@ msgstr ""
 "Ustaw na 0 aby wyłączyć. Maksymalna dozwolona liczba to %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3787,7 +3768,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3817,7 +3798,7 @@ msgstr ""
 "  Użyj opcji przykładowych jako szablonu lub skopiuj je z repozytorium."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3836,7 +3817,7 @@ msgstr ""
 "  Upewnij się, że ścieżka, którą skonfigurowałeś jest ścieżką do folderu / katalogu."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3858,7 +3839,7 @@ msgstr ""
 "  Sprawdź, czy ustawienia są poprawne, dostępna ścieżka katalogu."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3878,7 +3859,7 @@ msgstr ""
 "  Ustaw opcję konfiguracji tokenu lub ustaw zmienną środowiskową %(env_var)s z tokenem aplikacji."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3899,7 +3880,7 @@ msgstr ""
 "  ręcznie ustaw opcję 'WłaścicielID' lub spróbuj ponownie później."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3918,7 +3899,7 @@ msgstr ""
 "  Nie używaj Bot ani App ID w polu 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3940,7 +3921,7 @@ msgstr ""
 "  Zweryfikuj folder konfiguracyjny i pliki istnieją i mogą być odczytane przez MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3964,7 +3945,7 @@ msgstr ""
 "  Skopiuj przykładowy plik z repozytorium, jeśli wszystko inne nie powiedzie się."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3984,7 +3965,7 @@ msgstr ""
 "  Ustaw %(option)s na numeryczny identyfikator lub ustaw go na `auto` lub `0` dla automatycznego powiązania właściciela."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4004,7 +3985,7 @@ msgstr ""
 "  Sprawdź ustawienia ścieżki i upewnij się, że plik istnieje i jest dostępny dla MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4024,32 +4005,32 @@ msgstr ""
 "  Upewnij się, że wszystkie ID są liczbowe i oddzielone tylko spacjami lub przecinkami."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD wydaje się, że nie ma nagłówków..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Wyciąg informacji o utworze nie zwrócił żadnych danych."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Nie można kontynuować ekstrakcji, pętla zdarzeń jest zamknięta."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Adres URL Spotify jest nieprawidłowy lub nie jest obsługiwany."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Nie można strumieniować nieprawidłowego URL."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Nie znaleziono lokalnego pliku multimedialnego."
 
@@ -4072,14 +4053,14 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Pobieranie nie powiodło się z powodu błędu yt-dlp: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 "Pobieranie nie powiodło się z powodu nieobsługiwanego wyjątku: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Nie udało się wyodrębnić danych dla żądanych mediów."
 
@@ -4266,28 +4247,28 @@ msgstr ""
 "Ekspaktor yt-dlp `%(extractor)s` nie jest dozwolony w twojej grupie."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Nie można wyodrębnić informacji"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "To jest playlista."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Nieprawidłowy typ treści `%(type)s` dla URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "brak danych czasu trwania"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "brak danych czasu trwania w bieżącym wpisie"
 
@@ -4369,21 +4350,21 @@ msgid "Only dev users can use this command."
 msgstr "Tylko deweloperzy mogą używać tej komendy."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4391,13 +4372,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -4409,22 +4390,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4452,61 +4433,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4514,7 +4495,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4524,7 +4505,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4548,40 +4529,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4589,13 +4563,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4614,7 +4588,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4623,7 +4597,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4654,28 +4628,123 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "Wyszukiwanie YouTube nie zwróciło żadnych wyników dla:  %(url)s"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+#~ "Usuń utwór z kolejki, opcjonalnie w danej pozycji kolejki.\n"
+#~ "Jeśli pozycja jest pominięta, piosenka na końcu kolejki zostaje usunięta.\n"
+#~ "Użyj polecenia kolejki, aby znaleźć numer pozycji swojego utworu.\n"
+#~ "Jednakże, pozycje wszystkich piosenek są zmieniane, gdy rozpocznie się odtwarzanie.\n"
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/pl_PL/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/pl_PL/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -806,7 +806,7 @@ msgstr ""
 "Nie ma żadnych piosenek w kolejce. Odtwórz coś z poleceniem odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Pozycje piosenek muszą być liczbą całkowitą!"
 
@@ -843,29 +843,29 @@ msgid "Local media playback is not enabled."
 msgstr "Lokalne odtwarzanie mediów nie jest włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "Adres URL Spotify jest nieprawidłowy lub nie jest obecnie obsługiwany."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Wykryto adres URL Spotify, ale Spotify nie jest włączony."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Osiągnąłeś limit utworów w kolejce (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Tryb Karaoke jest włączony, spróbuj ponownie, gdy jest wyłączony!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -875,12 +875,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Nie można odtworzyć tego wideo. Spróbuj użyć komendy streamu."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -889,7 +889,7 @@ msgstr ""
 " (%(max)s sekund)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -899,13 +899,13 @@ msgstr ""
 "Pozycja w kolejce: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Czas trwania piosenki przekracza limit (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -915,24 +915,24 @@ msgstr ""
 "Pozycja w kolejce: %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "Odtwarzanie dalej!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - przewidywany czas do odtwarzania: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - nie można oszacować czasu do gry."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -945,23 +945,23 @@ msgstr ""
 "Uwaga: FFmpeg może upuścić strumień losowo lub jeśli wystąpi czkawka.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Strumieniowanie list odtwarzania nie jest jeszcze obsługiwane."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "Teraz strumieniowanie utworu `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr "    Wyszukaj w serwisie kilka wyników z zapytaniem wyszukiwania.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -970,13 +970,13 @@ msgstr ""
 "    Uwaga: w tym przypadku wymagane są podwójne cudzysłowy.\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Osiągnąłeś limit przedmiotów na liście odtwarzania (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -984,46 +984,46 @@ msgstr ""
 "`help search`."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Nie możesz wyszukać więcej niż filmy %(max)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Wyszukiwanie filmów..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "Wyszukiwanie nie powiodło się z powodu błędu: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "Nie znaleziono filmów."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "Aby wybrać piosenkę, wpisz odpowiedni numer."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Wyniki wyszukiwania z %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** | %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1032,198 +1032,198 @@ msgstr ""
 "**0**. Anuluj"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Wybierz utwór"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Dodano utwór [%(track)s](%(url)s) do kolejki."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Wynik %(number)s dla %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "W porządku, nadchodzące!"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Pokaż informacje o tym, co aktualnie gra."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "Teraz odtwarzane"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Aktualnie streamowanie:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "Aktualnie odtwarzane:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Dodane przez:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Postęp:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Brak utworów w kolejce! Kolejka czegoś z poleceniem odtwarzania."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Powiedz MusicBot, aby dołączył do kanału, w którym jesteś."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 "Nie jesteś połączony z głosowaniem. Spróbuj dołączyć do kanału głosowego!"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Połączono z `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 "Sprawia, że MusicBot obserwuje użytkownika, gdy zmienia kanały na "
 "serwerze.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "Nie obserwuj już użytkownika `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Teraz obserwuj użytkownika `%(user)s` pomiędzy kanałami głosowymi."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 "MusicBot nie może śledzić użytkownika, który nie jest członkiem serwera."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "Będzie obserwować użytkownika `%(user)s` pomiędzy kanałami głosowymi."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Wstrzymaj odtwarzanie, jeśli odtwarzany jest utwór."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Wstrzymana muzyka w `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Gracz nie gra."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "Wznawia odtwarzanie, jeśli gracz był wcześniej wstrzymany."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Wznowiono muzykę w `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Wznowiono kolejkę muzyki"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Gracz nie jest wstrzymany."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Losuj wszystkie bieżące utwory w kolejce."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Wszystkie piosenki w kolejce."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Usuwa wszystkie utwory obecnie w kolejce."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Wyczyszczono wszystkie piosenki z kolejki."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Nic w kolejce do usunięcia!"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Usunięto `%(track)s` dodane przez `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Nic nie znaleziono w kolejce od użytkownika `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1232,26 +1232,26 @@ msgstr ""
 "Musisz być tym, który ma w kolejce do kolejki lub ma natychmiastowe uprawnienia do pominięcia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Nieprawidłowy numer wpisu. Użyj polecenia kolejki, aby znaleźć pozycje "
 "kolejki."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Usunięto wpis `%(track)s` dodany przez `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Usunięto wpis `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1262,23 +1262,23 @@ msgstr ""
 "Jeśli opcja LegacySkip jest włączona, parametr siły można zignorować.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Nie można pominąć! Gracz nie gra!"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "Następna piosenka `%(track)s` jest pobierana, proszę czekać."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "Następny utwór zostanie wkrótce odtworzony. Proszę czekać."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1287,7 +1287,7 @@ msgstr ""
 "Może chcesz zrestartować bota, jeśli nie zacznie działać."
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1296,28 +1296,28 @@ msgstr ""
 "Być może chcesz ponownie uruchomić bota, jeśli nie zacznie działać."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "Nie masz uprawnień, aby wymusić pominięcie piosenki w pętli."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Wymuś pominięcie `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Nie masz uprawnień do wymuszania pominięcia."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Nie masz uprawnień, aby pominąć piosenkę w pętli."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1327,12 +1327,12 @@ msgstr ""
 "Głosowanie na pominięcie zostało przekazane.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " Następny utwór nadchodzi!"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1342,7 +1342,7 @@ msgstr ""
 "Potrzebujesz **%(votes)s** więcej głosów, aby pominąć tę piosenkę."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1353,25 +1353,25 @@ msgstr ""
 "Ustawienie głośności jest utrzymywane do czasu ponownego uruchomienia MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Bieżąca objętość: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` nie jest poprawną liczbą"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Zaktualizowano głośność z **%(old)d** do **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1381,7 +1381,7 @@ msgstr ""
 "Głośność można ustawić tylko od 1 do 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1389,7 +1389,7 @@ msgstr ""
 "Podano nieracjonalny wolumen: %(volume)s. Podaj wartość między 1 a 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1400,7 +1400,7 @@ msgstr ""
 "odtwarzanie strumieniowe nie obsługuje regulacji prędkości.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1409,34 +1409,34 @@ msgstr ""
 "Użyj komendy konfiguracyjnej, aby ustawić domyślną prędkość odtwarzania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Prędkość nie może być zastosowana do mediów strumieniowych."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Musisz podać szybkość, aby ustawić."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "Podana prędkość jest nieprawidłowa. Użyj liczby od 0,5 do 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Ustawienie prędkości odtwarzania na `%(speed).3f` dla bieżącego utworu."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Dodaj nowy alias z opcjonalnymi argumentami.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1445,23 +1445,23 @@ msgstr ""
 " pomocy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Nieprawidłowa opcja dla polecenia: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Aliasy przeładowane z pliku konfiguracyjnego."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Aliasy zapisane w pliku konfiguracyjnym."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1471,41 +1471,41 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Musisz podać alias i polecenie do aliasu"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nowy alias dodany. `%(alias)s` jest teraz aliasem `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Musisz podać nazwę aliasu aby usunąć."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` nie istnieje."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` został usunięty."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "    Pokazuje tekst pomocy o wszystkich brakujących opcjach konfiguracji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1514,32 +1514,32 @@ msgstr ""
 "konfiguracyjnego.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr "    Lista dostępnych opcji konfiguracji i ich sekcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Przeładuj plik options.ini z dysku.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Pokazuje tekst pomocy dla konkretnej opcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Wyświetl bieżącą wartość opcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Zapisuje bieżącą wartość do pliku opcji.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1548,34 +1548,34 @@ msgstr ""
 "pliku.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Zresetuj opcję do wartości domyślnej.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Zarządzaj konfiguracją opcjiini z Discorda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Konfiguracja nie może używać kanału i wzmianek użytkownika w tym samym "
 "czasie."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*Wszystkie opcje konfiguracyjne są obecne i uwzględnione!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "Żadne opcje konfiguracji nie wydają się być zmienione."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1585,7 +1585,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1601,12 +1601,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "Opcje konfiguracji zostały pomyślnie przeładowane z pliku!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1616,7 +1616,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1625,17 +1625,17 @@ msgstr ""
 " nazwę opcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Podana opcja jest niejednoznaczna, proszę podać nazwę sekcji."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "Musisz podać nazwę sekcji i nazwę opcji dla tej komendy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1645,25 +1645,25 @@ msgstr ""
 "Dostępne sekcje to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Opcja `%(option)s` jest niedostępna."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Ta opcja może być ustawiona tylko przez edycję pliku konfiguracyjnego."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Domyślnie ta opcja jest ustawiona na: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1677,32 +1677,32 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Opcja `%(option)s` nie jest edytowalna. Nie można zapisać na dysku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Nie udało się zapisać opcji: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Pomyślnie zapisano opcję: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna, wartość nie może być wyświetlana."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1714,25 +1714,25 @@ msgstr ""
 "INI File Value: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zaktualizować ustawienia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Musisz podać sekcję, opcję i wartość dla tej podkomendy."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Opcja `%(option)s` nie została zaktualizowana!"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1742,20 +1742,20 @@ msgstr ""
 "Aby zapisać zmianę, użyj `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 "Opcja `%(option)s` nie jest edytowalna. Nie można zresetować do domyślnego."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Opcja `%(option)s` nie została zresetowana do domyślnych!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1765,17 +1765,17 @@ msgstr ""
 "Aby zapisać zmianę, użyj `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Przestarzałe polecenie, zamiast tego użyj polecenia config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Komenda opcji jest przestarzała, zamiast tego użyj komendy config."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1784,33 +1784,33 @@ msgstr ""
 "Używanie opcji aktualizacji skanuje pamięć podręczną w poszukiwaniu zmian zewnętrznych przed wyświetleniem szczegółów."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "Podano nieprawidłową opcję, użyj: info, update, lub wyczyść"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Wyłączone"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Włączone"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s dni"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Nieograniczona"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1826,24 +1826,24 @@ msgstr ""
 "**Pamięć podręczna Teraz:  %(used)s w plikach %(files)s."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "Skrzynka została wyczyszczona."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Nie udało się** usunąć pamięci podręcznej, sprawdź logi aby uzyskać więcej"
 " informacji..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "Nie znaleziono skrzynki do wyczyszczenia."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1852,12 +1852,12 @@ msgstr ""
 "Fakultatywny numer strony pokazuje późniejsze wpisy w kolejce.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Argument strony kolejki musi być liczbą całkowitą."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1867,12 +1867,12 @@ msgstr ""
 "Istnieją ** strony%(total)s**."
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(nieznany czas trwania)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1884,7 +1884,7 @@ msgstr ""
 "Postęp: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1898,12 +1898,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Utwory w kolejce"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1912,7 +1912,7 @@ msgstr ""
 "Jeśli problem będzie się powtarzał, zgłoś błąd."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1923,39 +1923,39 @@ msgstr ""
 "Ta komenda może być wolna, jeśli podane są większe zakresy.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 "Nieprawidłowy parametr. Proszę podać liczbę wiadomości do wyszukiwania."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Nie można użyć czyszczenia na prywatnym kanale DM."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Wyczyszczono wiadomości %(number)s."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Bot nie ma uprawnień do zarządzania wiadomościami."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Zrzuć indywidualne adresy URL playlisty do pliku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "Podany adres URL nie jest prawidłowym adresem URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1965,18 +1965,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "To nie wygląda na playlistę."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Oto zrzut playlisty dla:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1985,19 +1985,19 @@ msgstr ""
 "Ta komenda jest przestarzała na korzyść trybu deweloperskiego w klientach Discorda.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Twój identyfikator użytkownika to `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "ID użytkownika dla `%(username)s` to `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2008,24 +2008,24 @@ msgstr ""
 "Ta komenda jest przestarzała na korzyść trybu deweloperskiego w klientach Discorda.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Prawidłowe kategorie: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Oto ID, o które prosiłeś:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "Uzyskaj listę uprawnień lub uprawnień wspomnianego użytkownika."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2034,12 +2034,12 @@ msgstr ""
 "identyfikator i spróbuj ponownie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Nie można określić użytkownika Discorda. Spróbuj ponownie."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2053,7 +2053,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2067,63 +2067,63 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Pokaż wczytane grupy i opcje uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Ponownie ładuje uprawnienia z pliku uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    Dodaj nową grupę z domyślnymi.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Usuń istniejącą grupę.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Pokaż tekst pomocy dla opcji uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Pokaż wartość uprawnień dla danej grupy i uprawnień.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Zapisz grupę uprawnień do pliku.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Ustaw wartość uprawnień dla grupy.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Zarządzaj konfiguracją uprawnieńini z dysku."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Uprawnienia nie mogą używać jednocześnie wspomnień kanału i użytkownika."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "Uprawnienia ponownie załadowane z pliku!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2133,7 +2133,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2147,23 +2147,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Musisz podać nazwę grupy lub opcji dla tego polecenia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Musisz podać grupę, opcję i wartość, aby ustawić to polecenie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Podpolecenie %(option)s wymaga nazwy grupy i uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2173,24 +2173,24 @@ msgstr ""
 "Dostępne grupy to:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Uprawnienia `%(option)s` nie są dostępne."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr "To uprawnienie może być ustawione tylko przez edycję pliku uprawnień."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Domyślnie to uprawnienie jest ustawione na: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2204,13 +2204,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Nie można dodać grupy `%(group)s` już istnieje."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2222,12 +2222,12 @@ msgstr ""
 "Upewnij się, że zapisz nową grupę w: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Nie można usunąć wbudowanej grupy."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2237,24 +2237,24 @@ msgstr ""
 "Upewnij się, że zapisać tę zmianę w: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Grupa właścicieli nie jest edytowalna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Nie udało się zapisać grupy: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Pomyślnie zapisano grupę: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2266,13 +2266,13 @@ msgstr ""
 "INI File Value: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Uprawnienia `%(option)s` nie zostały zaktualizowane!"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2282,7 +2282,7 @@ msgstr ""
 "Aby zapisać zmianę, użyj `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2291,7 +2291,7 @@ msgstr ""
 "Uwaga: API może ograniczyć zmianę nazwy do dwóch razy na godzinę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2300,7 +2300,7 @@ msgstr ""
 "Zapamiętaj zmiany nazwy są ograniczone do dwóch razy na godzinę.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2310,23 +2310,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Ustaw nazwę użytkownika bota na `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Zmień nick MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Nie można zmienić pseudonimu: brak uprawnień."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2336,23 +2336,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Ustawiono pseudonim bota na `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Ustaw prefiks komendy na serwer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Wyczyść prefiks komend na serwer."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2361,23 +2361,23 @@ msgstr ""
 "Opcja Włączony PrefixPerGuild musi być włączona w pierwszej kolejności."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "Niestandardowe emoji muszą być z tego serwera, aby użyć jako prefiks."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Prefiks komend serwera został wyczyszczony."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Prefiks polecenia serwera jest teraz:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2386,39 +2386,39 @@ msgstr ""
 "Użyj komendy config aby zaktualizować prefiks."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Pokaż kody językowe dostępne do użycia.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    Ustaw żądany język dla tego serwera.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Zresetuj język serwera do domyślnego języka bota.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "Zarządzaj językiem używanym do wiadomości na serwerze połączeń."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Ta komenda może być użyta tylko w gildiach."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Podano nieprawidłowe polecenie. Aby uzyskać więcej informacji, użyj "
 "polecenia pomocy."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2432,25 +2432,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Nie można ustawić języka na `%(locale)s` nie jest on dostępny."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Język dla tego serwera ustawiony jest: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Język dla tego serwera został zresetowany do: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2459,12 +2459,12 @@ msgstr ""
 "Dołączanie pliku i pominięcie parametru url również działa.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Musisz podać adres URL lub załączyć plik."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2474,40 +2474,40 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "Zmieniono awatar bota."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Wymuś rozłączenie MusicBot z serwerem Discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Rozłączono z serwerem `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Odłączono klienta głosowego bez odtwarzacza? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Obecnie nie jest połączony z serwerem `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Próba odświeżenia bez ponownego uruchomienia procesu. Opcja domyślna.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
@@ -2515,21 +2515,21 @@ msgstr ""
 "wszystkiego.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Pełne ponowne uruchomienie, ale próba aktualizacji pakietów pip przed "
 "ponownym uruchomieniem.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Pełne ponowne uruchomienie, ale najpierw zaktualizuj kod źródłowy "
 "MusicBot git.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2538,7 +2538,7 @@ msgstr ""
 "całkowitym ponownym uruchomieniem.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2551,7 +2551,7 @@ msgstr ""
 "Jeśli masz menedżera usług, zalecamy użycie go zamiast tej komendy do ponownego uruchomienia.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2559,19 +2559,19 @@ msgstr ""
 "uppip lub upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Restartowanie bieżącej instancji..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Restartowanie procesu bota..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2579,30 +2579,30 @@ msgstr ""
 "%(emoji)s spróbuje ulepszyć wymagane pakiety pip i zrestartować bot..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 "%(emoji)s spróbuje zaktualizować kod bota z git i zrestartować bota..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s spróbuje ulepszyć wszystko i zrestartować bot..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Odłącz od wszystkich kanałów głosowych i zamknij proces MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Pozostaw serwer discorda podany przez nazwę lub ID serwera."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2611,12 +2611,12 @@ msgstr ""
 "Nazwy mają znaczenie dla liter, więc użycie numeru ID jest bardziej wiarygodne.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Musisz podać identyfikator lub nazwę."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Nie znaleziono gildii o ID lub nazwie `%(input)s`"
@@ -2628,13 +2628,13 @@ msgid "Unknown"
 msgstr "Nieznane"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Opuszczono gildię: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2643,38 +2643,38 @@ msgstr ""
 "Może być użyty do ręcznego wskazywania wydarzeń w pliku dziennika MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Zgłoszono punkt wstrzymania z ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Zobacz najczęstsze typy zgłoszone przez objgraf.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Zobacz ograniczone wyjście objgraph.show_growth().\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Zobacz najpopularniejsze typy wyciekających obiektów.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Zobacz statystyki typów wyciekających obiektów.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Oceń daną funkcję i argumenty na objgrafie.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2685,12 +2685,12 @@ msgstr ""
 "Ponieważ ta metoda ocenia dowolny kod, jest uważany za niebezpieczny jak polecenie debugowania.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Nie można zaimportować `objgraf`, czy jest zainstalowany?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2715,7 +2715,7 @@ msgstr ""
 "Zagrożenie związane z tym poleceniem nie może być zaniżone. Nie używaj go ani nie daj mu dostępu, jeśli nie rozumiesz ryzyka!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2731,7 +2731,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2740,23 +2740,23 @@ msgstr ""
 "Wyjście jest używane do aktualizacji stron GitHub i dlatego nie nadaje się do normalnego użycia odniesienia."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Podpolecenie musi być jednym z: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Tworzy domyślne pliki INI."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Zapisano żądany plik INI na dysku. Sprawdź go"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2765,50 +2765,50 @@ msgstr ""
 " zależności.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Nie można zlokalizować pliku wykonywalnego git"
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Brak aktualizacji w gałęzi `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nowe commity są dostępne w oddziale `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "Błąd podczas sprawdzania, zobacz logi w celu uzyskania szczegółów."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Aktualizacja dla `%(name)s` do wersji: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "Nie znaleziono aktualizacji dla zależności."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "Istnieją aktualizacje dla MusicBot dostępne do pobrania."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot jest całkowicie aktualny!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2828,20 +2828,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Wyświetla czas uptime MusicBot lub czas od ostatniego rozpoczęcia / "
 "restartu."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s jest online dla `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2849,12 +2849,12 @@ msgstr ""
 "podłączonych klientów głosowych."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "Brak podłączonych klientów głosowych.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 "Wyświetlaj opóźnienie API i opóźnienie głosowe, jeśli MusicBot jest "
@@ -2863,23 +2863,23 @@ msgstr ""
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Opóźnienie API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Wyświetlaj numer wersji MusicBot na czacie."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2889,17 +2889,17 @@ msgstr ""
 "Obecna wersja: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Aktualizuj plik cookies.txt za pomocą załącznika cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Włącz lub wyłącz plik cookies.txt bez usuwania go."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2924,30 +2924,30 @@ msgstr ""
 "  , jeśli nie rozumiesz jak unikać ryzyka."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Pliki cookie są już włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Pliki cookie muszą być przesłane, aby je włączyć. (Przeliczanie pliku "
 "cookies.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Nie można włączyć ciasteczek z powodu błędu:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Pliki cookie zostały włączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2957,12 +2957,12 @@ msgstr ""
 "ciasteczka tymczasowo wyłączone i zostaną ponownie włączone przy następnym ponownym uruchomieniu."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Pliki cookie zostały wyłączone."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2970,51 +2970,51 @@ msgstr ""
 "przesyłania pliku cookie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Błąd podczas pobierania pliku ciasteczek z dysku:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Nie można zapisać ciasteczek na dysku:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Pliki cookie przesłane i włączone."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "Nie możesz użyć tego bota w prywatnych wiadomościach."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Ta komenda nie jest dozwolona dla grupy uprawnień:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Ta komenda wymaga bycia na kanale głosowym."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Polecenie:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Błąd wyjątku"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3024,17 +3024,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "Nie podano opisu.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "Nie podano użycia."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3048,13 +3048,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Opuszczanie kanału głosowego %(channel)s z powodu braku aktywności."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3178,7 +3178,7 @@ msgstr ""
 "Używane tylko wtedy, gdy BindToChannels nie posiada identyfikatora serwera."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3259,7 +3259,7 @@ msgstr ""
 "Możesz to ustawić od 0 do 1, lub 0% do 100%."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 "Pozwól MusicBot na przechowywanie pobranych mediów lub natychmiastowe ich "
@@ -3267,7 +3267,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3275,7 +3275,7 @@ msgstr "Jeśli zapis wideo jest włączony, ustaw limit ilości miejsca na dysku
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3283,7 +3283,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3297,7 +3297,7 @@ msgid "Mention the user who added the song when it is played."
 msgstr "Wspomnij użytkownika, który dodał utwór po jego odtworzeniu."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3306,7 +3306,7 @@ msgstr ""
 "po uruchomieniu bota."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3315,12 +3315,12 @@ msgstr ""
 "odtwarzania, gdy kolejka jest pusta."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "Losuj auto playlisty utwory przed ich odtwarzaniem."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3329,7 +3329,7 @@ msgstr ""
 "Dotyczy to tylko bieżącego utworu odtwarzanego jeśli został dodany przez auto playlistę."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3388,7 +3388,7 @@ msgstr ""
 "Obecnie ta opcja nie ma zastosowania do automatycznej listy odtwarzania lub piosenek dodanych do pustej kolejki."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3417,7 +3417,7 @@ msgstr ""
 " {p0_url}      = Adres URL dla aktualnie odtwarzanej ścieżki."
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 "Jeśli opcja jest włączona, komunikaty o statusie będą zgłaszać informacje o "
@@ -3426,7 +3426,7 @@ msgstr ""
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3463,7 +3463,7 @@ msgstr ""
 "wyświetlić listę kolejki."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3472,7 +3472,7 @@ msgstr ""
 "automatycznego odtwarzania."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 "Wyświetlaj ustawienia konfiguracji MusicBot w logach podczas uruchamiania."
@@ -3488,7 +3488,7 @@ msgstr ""
 " pominięcie."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3520,13 +3520,13 @@ msgid "Completely remove the footer from embeds."
 msgstr "Całkowicie usuń stopkę z osadników."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr "MusicBot automatycznie wyłączy się przy wchodzeniu na kanał głosowy."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3537,7 +3537,7 @@ msgstr ""
 "Słuchacze są członkami kanałów, z wyjątkiem botów, którzy nie są deafenowani."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3546,7 +3546,7 @@ msgstr ""
 "Możesz to ustawić na kilka sekund lub frazę jako: 4 godziny"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3555,7 +3555,7 @@ msgstr ""
 "utworu."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3603,7 +3603,7 @@ msgstr ""
 "odtwarzanie dla jednego utworu na użytkownika."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3616,7 +3616,7 @@ msgstr ""
 "Domyślnie jest to wyłączone."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3628,7 +3628,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3655,7 +3655,7 @@ msgstr ""
 "Pozwól MusicBot na automatyczne odparowanie po użyciu poleceń odtwarzania."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3666,7 +3666,7 @@ msgstr ""
 "Pozostaw puste, aby wyłączyć."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3683,13 +3683,13 @@ msgstr ""
 "Pozostaw puste, aby używać domyślnych, dynamicznie generowanych ciągów UA."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 "Przełącz funkcję listy bloków użytkowników bez opróżniania listy bloków."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3697,12 +3697,12 @@ msgstr ""
 "Discorda, po jednym na wiersz."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "Włącz funkcję listy bloków utworów, bez opróżniania listy bloków."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3711,7 +3711,7 @@ msgstr ""
 "Wszelkie tytuły piosenki lub adresy URL zawierające dowolną linię na liście zostaną zablokowane."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3720,7 +3720,7 @@ msgstr ""
 "Każdy plik powinien zawierać listę adresów lub terminów odtwarzania, po jednym utworze na linię."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3734,7 +3734,7 @@ msgstr ""
 "Maps to:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3743,7 +3743,7 @@ msgstr ""
 "krótkoterminową pamięć podręczną do odtwarzania."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3755,7 +3755,7 @@ msgstr ""
 "Ustaw na 0 aby wyłączyć. Maksymalna dozwolona liczba to %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3768,7 +3768,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3798,7 +3798,7 @@ msgstr ""
 "  Użyj opcji przykładowych jako szablonu lub skopiuj je z repozytorium."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3817,7 +3817,7 @@ msgstr ""
 "  Upewnij się, że ścieżka, którą skonfigurowałeś jest ścieżką do folderu / katalogu."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3839,7 +3839,7 @@ msgstr ""
 "  Sprawdź, czy ustawienia są poprawne, dostępna ścieżka katalogu."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3859,7 +3859,7 @@ msgstr ""
 "  Ustaw opcję konfiguracji tokenu lub ustaw zmienną środowiskową %(env_var)s z tokenem aplikacji."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3880,7 +3880,7 @@ msgstr ""
 "  ręcznie ustaw opcję 'WłaścicielID' lub spróbuj ponownie później."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3899,7 +3899,7 @@ msgstr ""
 "  Nie używaj Bot ani App ID w polu 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3921,7 +3921,7 @@ msgstr ""
 "  Zweryfikuj folder konfiguracyjny i pliki istnieją i mogą być odczytane przez MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3945,7 +3945,7 @@ msgstr ""
 "  Skopiuj przykładowy plik z repozytorium, jeśli wszystko inne nie powiedzie się."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3965,7 +3965,7 @@ msgstr ""
 "  Ustaw %(option)s na numeryczny identyfikator lub ustaw go na `auto` lub `0` dla automatycznego powiązania właściciela."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3985,7 +3985,7 @@ msgstr ""
 "  Sprawdź ustawienia ścieżki i upewnij się, że plik istnieje i jest dostępny dla MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4005,32 +4005,32 @@ msgstr ""
 "  Upewnij się, że wszystkie ID są liczbowe i oddzielone tylko spacjami lub przecinkami."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD wydaje się, że nie ma nagłówków..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Wyciąg informacji o utworze nie zwrócił żadnych danych."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Nie można kontynuować ekstrakcji, pętla zdarzeń jest zamknięta."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Adres URL Spotify jest nieprawidłowy lub nie jest obsługiwany."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Nie można strumieniować nieprawidłowego URL."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Nie znaleziono lokalnego pliku multimedialnego."
 
@@ -4384,28 +4384,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4433,7 +4433,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4487,7 +4487,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4495,7 +4495,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4505,7 +4505,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4574,7 +4574,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4588,7 +4588,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4597,7 +4597,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4611,7 +4611,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4619,7 +4619,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4628,26 +4628,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4659,28 +4659,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4691,25 +4691,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4718,7 +4718,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/pygettext.py
+++ b/i18n/pygettext.py
@@ -31,8 +31,7 @@ except ImportError:
         return msg
 
 
-__doc__ = _(
-    """pygettext -- Python equivalent of xgettext(1)
+__doc__ = _("""pygettext -- Python equivalent of xgettext(1)
 
 Many systems (Solaris, Linux, Gnu) provide extensive tools that ease the
 internationalization of C programs. Most of these tools are independent of
@@ -165,8 +164,7 @@ Options:
         conjunction with the -D option above.
 
 If `inputfile' is -, standard input is read.
-"""
-)
+""")
 
 import ast
 import getopt
@@ -190,8 +188,7 @@ EMPTYSTRING = ""
 
 # The normal pot-file header. msgmerge and Emacs's po-mode work better if it's
 # there.
-pot_header = _(
-    """\
+pot_header = _("""\
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the %(package_name)s package.
@@ -212,8 +209,7 @@ msgstr ""
 "Content-Transfer-Encoding: %(encoding)s\\n"
 "X-Generated-By: pygettext.py %(version)s-mb01\\n"
 
-"""
-)
+""")
 # Matches literal escape sequences so they can be preserved.
 pre_escape = re.compile(r"(?<!\\)(\\[NUu](?:[a-fA-F0-9]+|\{[^\}]+\}))")
 

--- a/i18n/ru_RU/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/ru_RU/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -470,20 +470,20 @@ msgstr ""
 "перезапустить?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "Музыкальный робот просит говорить в канале: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "У MusicBot нет разрешения на чтение."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot не может просить говорить."
 
@@ -615,7 +615,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Установка истории URL гильдии %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Нет миниатюры для записи с URL: %s"
@@ -704,19 +704,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Зацикливание автоматов игрока..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Ошибка при обработке песни \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Ошибка распаковки песни \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot должен остановить извлечение автоплейлиста и залог."
 
@@ -1099,7 +1099,7 @@ msgstr "Список гильдий:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1675,7 +1675,7 @@ msgid "The player is not currently looping."
 msgstr "Игрок в данный момент не зацикливается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Позиции песни должны быть целыми!"
 
@@ -1698,34 +1698,34 @@ msgid "Local media playback is not enabled."
 msgstr "Воспроизведение локального медиа не включено."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "URL-адрес Spotify недействителен или в настоящее время не поддерживается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Обнаружен URL-адрес Spotify, но Spotify не включен."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Вы достигли лимита на добавленные песни (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Караоке-режим включен, попробуйте еще раз, когда он отключен!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Проблема с extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1735,14 +1735,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Это видео не может быть воспроизведено. Попробуйте использовать команду "
 "трансляции."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1752,7 +1752,7 @@ msgstr ""
 "%(time_per).2f / песню"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1761,47 +1761,47 @@ msgstr ""
 "секунд)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "Извлечь запись с помощью клавиши 'youtube:playlist'"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Длительность песни превышает предел (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Добавлена песня(и) на позиции %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "Не удается оценить время до игры за позицию: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "Не удалось получить информацию из запроса потока: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Потоковые плейлисты еще не поддерживаются."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Вы достигли предела в плейлисте (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -1809,59 +1809,59 @@ msgstr ""
 "получения дополнительной информации."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Вы не можете искать более чем %(max)s видео"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "Ожидание вызова: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Призвать замок для: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 "Вы не подключены к голосу. Попробуйте подключиться к голосовому каналу!"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Присоединение к %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 "MusicBot не может следить за пользователем, не являющимся членом сервера."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Плеер не играет."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Нечего удалять в очереди!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "В очереди у пользователя `%(user)s ничего не найдено"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1870,40 +1870,40 @@ msgstr ""
 "Вы должны быть тот, кто поставил его в очередь или имеет мгновенные пропуска."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Неверный номер записи. Используйте команду очереди для поиска позиций."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Нельзя пропустить! Игрок не играет!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "У вас недостаточно прав для принудительного пропуска циклической песни."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "У вас нет разрешения на принудительный пропуск."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "У вас нет разрешения на пропуск зацикливаемой песни."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` не является допустимым числом"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1913,44 +1913,44 @@ msgstr ""
 "Том может быть установлен только от 1 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Неприемлемый объём: %(volume)s. Предоставьте значение от 1 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Скорость не может быть применена к потоковым носителям."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Вы должны предоставить скорость для установки."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Предоставленная вами скорость является недопустимой. Используйте число в "
 "диапазоне от 0.5 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Недопустимый параметр для команды: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1960,30 +1960,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Вы должны указать псевдоним и команду для псевдонима"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Вы должны указать имя псевдонима для удаления."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Псевдоним `%(alias)s` не существует."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Конфигурация не может использовать канал и упоминания пользователя "
 "одновременно."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1993,7 +1993,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2002,18 +2002,18 @@ msgstr ""
 " корректный раздел и название опции."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Указанная опция является неоднозначной, укажите название раздела."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Вы должны указать название раздела и название параметра для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2023,25 +2023,25 @@ msgstr ""
 "Доступные разделы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Опция `%(option)s` недоступна."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Параметр `%(option)s` не редактируется. Невозможно сохранить на диск."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Не удалось сохранить опцию: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -2049,30 +2049,30 @@ msgstr ""
 "отображается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Параметр `%(option)s` не редактируется. Не удается обновить параметр."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Вы должны указать раздел, параметр и значение для этой подкоманды."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Выполнение установлено с помощью %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Опция `%(option)s` не была обновлена!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2080,48 +2080,48 @@ msgstr ""
 "значению по умолчанию."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Сброс %(config)s на стандартный %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Параметр `%(option)s` не был сброшен до значения по умолчанию!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Команда опции является устаревшим, используйте команду config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Указан неверный параметр, используйте информацию: info, update, or clear"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Не удалось** удалить кэш, проверьте журналы для получения дополнительной "
 "информации..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Аргумент очереди страницы должен быть целым числом."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Нет песен в очереди! Очередь что-то с помощью команды воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2129,41 +2129,41 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "Текущий элемент плейлиста пропущен."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "Недостаточно записей для создания нужной очереди."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Не удалось отправить сообщение в очередь. Нет сообщений для добавления "
 "реакций."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Нельзя использовать очистку в приватном ЛС канале."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "Указанный URL не является допустимым URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2173,12 +2173,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Похоже, что это не плейлист."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2186,19 +2186,19 @@ msgstr ""
 "Неверный ID пользователя или имя сервера, проверьте ID и повторите попытку."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Не удалось определить пользователя discord. Попробуйте еще раз."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Права доступа не могут использовать каналы и упоминания пользователей "
 "одновременно."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2208,23 +2208,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Вы должны указать название группы или опции для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Вы должны указать группу, опцию и значение для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Субкоманда %(option)s требует имя группы и прав доступа."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2234,47 +2234,47 @@ msgstr ""
 "Доступные группы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Разрешение `%(option)s` недоступно."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Невозможно добавить группу `%(group)s`, она уже существует."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Невозможно удалить встроенную группу."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Группа владельцев не редактируется."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Не удалось сохранить группу: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Выполнение установлено на %(option)s со значением: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Разрешение `%(option)s` не было обновлено!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2283,7 +2283,7 @@ msgstr ""
 "Запомнить, что изменения имени ограничены дважды в час.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2293,12 +2293,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Невозможно изменить никнейм: нет разрешения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2308,14 +2308,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Пользовательские эмодзи должны быть с этого сервера, чтобы использовать в "
 "качестве префикса."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2324,30 +2324,30 @@ msgstr ""
 "Используйте команду конфигурации для обновления префикса."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Эта команда может быть использована только в гильдиях."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Неверная субкоманда. Используйте команду справки для получения "
 "дополнительной информации."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Не удается установить язык в `%(locale)s`, он недоступен."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Вы должны указать URL или прикрепить файл."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2357,19 +2357,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot обнаружил %s без гильдии! Это может быть проблемой."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Сейчас не подключен к серверу`%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2377,44 +2377,44 @@ msgstr ""
 "uppip, или upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Вы должны указать ID или имя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Не найдено ни одной гильдии с ID или именем `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Активация точки останова ID: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Не удалось импортировать `objgraph`, он установлен?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Код отладки запускался с помощью eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Код отладки запускался с exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "Не удалось выполнить код отладки."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2430,54 +2430,54 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Подкоманда должна быть одной из %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Не удалось найти исполняемый файл git."
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "Не удалось проверить наличие обновлений по команде git."
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Пакет отсутствует в отчете pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr "Не удалось получить статус обновления pip из-за некоторой ошибки."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Получена запись о странном голосовом клиенте."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies уже включены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies должны быть загружены для включения. (issing cookies файл.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Не удалось включить куки из-за ошибки:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2487,7 +2487,7 @@ msgstr ""
 "Cookies временно отключены и будут повторно включены при следующем перезапуске."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2495,49 +2495,49 @@ msgstr ""
 "cookie."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "Не удалось удалить старый, отключен файл cookie:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Ошибка при загрузке файла cookie с дискода:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Не удалось сохранить куки на диске:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Получено сообщение без канала, как-то  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Игнорирование команды от себя (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Игнорирование команды от другого бота (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Игнорирование команды из канала типа:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2545,24 +2545,24 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Сообщение от %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Эта команда не разрешена для вашей группы прав:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Эта команда требует, чтобы вы были в голосовом канале."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
@@ -2570,106 +2570,106 @@ msgstr ""
 "%(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Ошибка в %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Исключение при обработке команды: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Невозможно сгенерировать справку для отсутствующей команды:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Отсутствуют вспомогательные данные для команды:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Выход голосового канала %s в %s из-за отсутствия активности."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "Музыкабот подключен."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "Музыкабот был разорван."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Получено событие сокета:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState обновляется до окончания on_ready"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Игнорирование %s в %s , как это связанный голосовой канал."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s был обнаружен как пустой. Тайм-аут обработки."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Пользователь присоединился к %s, время отмены таймера."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "Бот перемещен, голосовой канал %s пуст. Тайм-аут обработки."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Бот был перемещен и голосовой канал %s не пуст."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "Больше не следует за пользователем %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Следовать за пользователем `%(user)s` на канал:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState отключает before.channel не подключен."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2679,7 +2679,7 @@ msgstr ""
 "[S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2687,91 +2687,91 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "Не удается найти канал автоподключения, он был удален? Гильдия:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 "Повторное подключение к автоматически подключенной гильдии на канале:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Невозможно автоматически присоединиться к каналу:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Бот был добавлен в гильдию: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Левая гильдия '%s' из-за не найден владелец бота."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Создание папки данных для гильдии %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Бот был удален из гильдии: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Обновленный список гильдий:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Гильдия \"%s\" стала доступна."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Возобновление доступа игрока в \"%s\" из-за доступности."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Гильдия \"%s\" недоступна."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Пауза игрока в \"%s\" из-за недоступности."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Обновление гильдии для:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Атрибут гильдии %(attr)s сейчас: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Обновление канала для:  %(channel)s  --  %(changes)s"
@@ -2789,7 +2789,7 @@ msgid "Loading config from:  %s"
 msgstr "Загрузка конфигурации из:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2807,7 +2807,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2817,7 +2817,7 @@ msgstr ""
 "ограничена."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2826,7 +2826,7 @@ msgstr ""
 "него будет использоваться значение по умолчанию."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2838,12 +2838,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Исключение было вызвано при проверке AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2865,13 +2865,13 @@ msgstr ""
 "  Двойная проверка правильности, доступный путь к каталогу."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Кэш аудио будет храниться в:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2884,7 +2884,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2892,7 +2892,7 @@ msgstr ""
 "Опция StatusMessage слишком длинная, она будет ограничена 128 символов."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2902,17 +2902,17 @@ msgstr ""
 "этого значение параметра %.3f будет ограничено."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Проверка параметров с данными сервиса..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "Приобретенный ID владельца через API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2925,12 +2925,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "У MusicBot нет экземпляра пользователя, невозможно продолжить."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2942,12 +2942,12 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "Файл параметров конфигурации не найден. Проверка альтернативы..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2957,18 +2957,18 @@ msgstr ""
 "включить расширения."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Копирование существующего файла параметров примера:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr "Что-то пошло не так при попытке найти файл конфигурации."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2990,7 +2990,7 @@ msgstr ""
 "  Проверьте папку конфигурации и файлы существуют и могут быть прочитаны MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3014,12 +3014,12 @@ msgstr ""
 "  Скопируйте файл примера из репозитория, если все остальное не удалось."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! Параметр конфигурации имеет getter, который не доступен."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3028,42 +3028,42 @@ msgstr ""
 " должен быть одинаковым."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "Ранее отсутствовал вариант."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Раздел конфигурации не в анализируемой конфигурации! Отсутствует: %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Сохраненная конфигурация: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Не удалось сохранить конфигурацию:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr "Имена опций не уникальны между INI-разделами! Резольвер отключен."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Не удалось сохранить INI-файл по умолчанию в:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3083,7 +3083,7 @@ msgstr ""
 "  Установите %(option)s на числовой ID или установите его в `auto` или `0` для автоматической привязки владельца."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3103,7 +3103,7 @@ msgstr ""
 "  Проверьте настройки пути и убедитесь, что файл существует и доступен для MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3123,7 +3123,7 @@ msgstr ""
 "  Убедитесь, что все ID числовые и разделены только пробелами или запятыми."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3133,7 +3133,7 @@ msgstr ""
 "на уровень: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3143,7 +3143,7 @@ msgstr ""
 "'%(value)s' вместо значения по умолчанию."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3153,7 +3153,7 @@ msgstr ""
 "и вместо него будет установлен %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3161,48 +3161,48 @@ msgstr ""
 "Переименование INI-файла [%(old_s)s] > %(old_o)s  на [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Обновление конфигурационного файла с переименованными опциями..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "Не удалось обновить конфигурацию. Вам нужно обновить ее вручную."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Файл блока списка не найден:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Не удалось загрузить список блокировок из файла:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Не удалось обновить файл списка блоков:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Загружен блокированный список пользователей с записями %s."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Мы нашли устаревший файл в черном списке, он будет переименован на:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Загружен Блок песни с записями %s."
@@ -3265,39 +3265,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Принудительное YTDLP использовать User Agent:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "Музыкабот будет использовать cookies для yt-dlp от:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp будет использовать настроенный прокси сервер."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD не имеет заголовков..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr "Проверка заголовков медиа не выполнена из-за таймаута."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Ошибка запроса HEAD для:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "HEAD запрос исключения: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3307,55 +3307,55 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Ранизированная информация о извлечении YTDL (не JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Извлечение информации о треке не дало никаких данных."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Вызвал extract_info с: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Невозможно запустить распаковку, цикл закрыт. (нормальный при выключении)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Невозможно продолжить извлечение. Цикл события закрыт."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "URL-адрес Spotify недействителен или не поддерживается."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Ошибка загрузки с URL потока"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "Предположим, что содержимое является прямым потоком"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Невозможно провести некорректный URL-адрес."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3363,23 +3363,23 @@ msgstr ""
 "пространство."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Вызвал safe_extract_info с:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Локальный медиа-файл не найден."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Отсутствует __input_subject из YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3387,7 +3387,7 @@ msgstr ""
 "избежать этого."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Внимание, ошибка продолжительности для: %(url)s"
@@ -4655,13 +4655,13 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "На этом устройстве осталось меньше %sМБ свободного места"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4670,12 +4670,12 @@ msgstr ""
 "Проверка обновлений для MusicBot или зависимостей..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "Нет доступных обновлений MusicBot с помощью команды `git`."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4684,23 +4684,23 @@ msgstr ""
 "вручную."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "Следующие пакеты могут быть обновлены:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  к версии:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "Нет доступных обновлений зависимостей с помощью команды `pip`."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4709,7 +4709,7 @@ msgstr ""
 "вручную."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4719,35 +4719,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "Значение превышает максимальный лимит."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "Значение не должно быть отрицательным."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "Значение максимального числа журналов должно быть числом от 0 до %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "Уровень журнала '%s' недоступен."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "Уровень журнала должен быть одним из:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4755,41 +4755,41 @@ msgstr ""
 "Запустите музыкальный дискорд с помощью discord.py, youtubeDL и ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Доступно через Github:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 "Для получения дополнительной помощи и поддержки с этим ботом, "
 "присоединяйтесь к нашему разногласию:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "Это программное обеспечение предоставляется по лицензии MIT."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "Полную информацию см. в текстовом файле `LICENSE`."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 "Переопределить язык по умолчанию / система для всего текста в MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr "Используйте этот язык для всех серверных журналов от MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4798,28 +4798,28 @@ msgstr ""
 "Это не предотвращает выбор языка для каждой гильдии."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Печатайте информацию о версии MusicBot и выходите."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 "Пропустить все опциональные проверки запуска, включая проверку обновления."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Пропустить проверку только дискового пространства при запуске."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Пропустить проверку обновлений только при запуске."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -4828,7 +4828,7 @@ msgstr ""
 "импортировать их."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4838,7 +4838,7 @@ msgstr ""
 " умолчанию: %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
@@ -4846,7 +4846,7 @@ msgstr ""
 " из: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4857,43 +4857,43 @@ msgstr ""
 "умолчанию: '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Версия:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Открыт новый экземпляр MusicBot. Этот терминал может быть безопасно закрыт!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Загрузка версии MusicBot:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Открыт журнал:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Изменение рабочего каталога на:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4904,7 +4904,7 @@ msgstr ""
 "расположение каталога."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4913,7 +4913,7 @@ msgstr ""
 "Если вы не использовали git для клонирования репозитория, вам настоятельно рекомендуется это сделать."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4922,12 +4922,12 @@ msgstr ""
 "выйти."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Вот точная ошибка, это может быть ошибка."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4936,7 +4936,7 @@ msgstr ""
 "вы можете открыть сайт с ошибками в Microsoft Edge или IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -4945,17 +4945,17 @@ msgstr ""
 "вместо этого попробуйте certifi."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Ошибка синтаксиса (обнаружена модификация, вы отредактировали код?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Ошибка синтаксиса (это ошибка, не ваша вина)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4976,13 +4976,13 @@ msgstr ""
 "  или запустить без `--no-install-deps` и MusicBot попытается установить их для вас."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Попытка автоматической установки пакетов с зависимостью от MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5003,57 +5003,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, позволяет надеяться, что зависимости работают!"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"У MusicBot возникла ошибка при попытке установить пакеты. MusicBot должен "
-"выйти..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "Исключение, вызвавшее указанную ошибку: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot делает мягкий перезапуск..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot выполняет полный перезапуск процесса..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Ошибка при запуске бота"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Цикл закрытия событий."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Перезапуск через %s секунд..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "Всё готово."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "ОК, мы закрываем!"
 
@@ -5074,31 +5060,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5112,7 +5098,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5172,7 +5158,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5403,24 +5389,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5467,25 +5453,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5493,66 +5479,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5579,7 +5519,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5591,25 +5531,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5622,29 +5562,145 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "У MusicBot возникла ошибка при попытке установить пакеты. MusicBot должен "
+#~ "выйти..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "Исключение, вызвавшее указанную ошибку: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/ru_RU/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/ru_RU/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -151,7 +151,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Необработанное исключение для задачи:  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify не предоставил нам токен. Отключен."
 
@@ -172,64 +172,43 @@ msgstr ""
 "Не удалось запустить клиент Spotify. ID вашего клиента и секретные данные? "
 "Подробности: %s. Продолжиться все равно через 5 секунд..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"В конфигурации нет учетных данных приложения Spotify, пытаясь использовать "
-"гостевой режим."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Аутентификация в Spotify прошла успешно в гостевом режиме."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-"Невозможно запустить клиент Spotify в гостевом режиме. Подробности: %s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Инициализирован, теперь подключаемся к discord."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Тест сетевого пинга отключён через config."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "Тест сетевого пинга закрывается вниз."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "Не удалось определить цель"
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Тест сетевого пинга отменен."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Сетевое тестирование через HTTP не имеет сеанса для заимствования."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "Не удалось найти исполняемый файл `ping` в вашей среде."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -243,7 +222,7 @@ msgstr ""
 "Или отключите проверку сети через конфигурацию."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -257,7 +236,7 @@ msgstr ""
 "Или отключите проверку сети через конфигурацию."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -271,35 +250,35 @@ msgstr ""
 "Или отключите проверку сети через конфигурацию."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "Обнаруженная сеть MusicBot снова доступна."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "VoiceClient не подключен, ожидается возобновление MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Возобновление воспроизведения игрока: (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot обнаружил ошибки в сети."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr "Пауза MusicPlayer из-за доступности сети: (%(guild_id)s) %(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -309,14 +288,14 @@ msgstr ""
 "получили:  %(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr ""
 "Проверка каналов для автоматического подключения или возобновления "
 "доступа..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
@@ -324,62 +303,62 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 "Найден восходящий голосовой канал:  %(channel)s  в гильдии:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 "Попробует возобновить голосовую сессию вместо автоподключения к каналу:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Найден владелец в голосовом канале:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr "Игнорирование восходящего канала, автодайвинг владельцу в канале:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 "Игнорирование автоподключения канала AutoSummon для владельца канала:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Уже подключен к каналу:  %(channel)s  в гильдии:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Попытка присоединиться к каналу:  %(channel)s  в гильдии:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Отмена Музыкального Игрока и создание нового..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot теперь создаст новый музыкальный плеер..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
@@ -387,87 +366,87 @@ msgstr ""
 "канал."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Подключение к настроенным каналам завершено."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 "Участник не включен голосовым путем и не может использовать эту команду."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Вы не можете использовать эту команду, если не в голосовом канале."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Получение информации о приложении бота."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "Музыкабот не имеет разрешения на подключение в канале:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "У Музыкабота нет прав подключаться в канале: `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "У Музыкабота нет прав говорить в канале:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "У Музыкабота нет прав говорить в канале: `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Повторное использование ботов VoiceClient от гильдии:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "Принудительное отключение от устаревшего VoiceClient в гильдии:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "Отключение не удалось или было отменено?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "Музыкабот не может подключиться к каналу прямо сейчас:  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "У MusicBot есть VoiceClient сейчас..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -477,13 +456,13 @@ msgstr ""
 "попытке подключиться к  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 "Попытка соединения с MusicBot VoiceClient отменена. Повторите попытку."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -491,60 +470,60 @@ msgstr ""
 "перезапустить?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "Музыкальный робот просит говорить в канале: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "У MusicBot нет разрешения на чтение."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot не может просить говорить."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Отключение MusicPlayer в гильдии:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Отключение VoiceClient до того, как мы убьем MusicPlayer."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "Отключение не удалось или было отменено."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr "У MusicBot есть VoiceProtocol который не является VoiceClient."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Отключение неточного VoiceClient в гильдии:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Отключение VoiceClient, не являющийся гильдией..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -554,20 +533,20 @@ msgstr ""
 "На самом деле тип объекта:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 "У нас все еще есть отзыв MusicPlayer в гильдии (%(guild_id)s):  %(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Гильдия (%(guild)s) хочет игрока, опционально:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -576,24 +555,24 @@ msgstr ""
 "перезапустить бота."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "У MusicPlayer есть VoiceClient который не подключен."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "Музыкальный проигрыватель:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -603,7 +582,7 @@ msgstr ""
 "%(channel)s  Создать: %(create)s  Дестрализация:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -613,96 +592,96 @@ msgstr ""
 "%(number)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Что-то не так, мы не получили VoiceClient."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "Выполняется на _плеере"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Установка истории URL гильдии %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Нет миниатюры для записи с URL: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "нет канала для воспроизведения сообщения"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 "проигнорировал сейчас воспроизводимое сообщение, поскольку оно уже было "
 "опубликовано."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "Выполняется на плеер_возобновление"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "Пауза"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Выполняется по игроку_стопу"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Выполняется на игровом автомате"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "Цикл события закрыт, здесь нет ничего другого."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Выход из системы, игнорирует это событие."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 "VoiceClient говорит, что он не подключен, ничего другого мы можем сделать "
 "здесь."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "Плеер завершён и очередь пуста, покидая голосовой канал..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 "Зацикливание над очередью для исключения песен с недостающим автором..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -710,173 +689,173 @@ msgstr ""
 "Автор `%(user)s` отсутствует, пропущен (удален) запись из очереди:  %(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr "Нет воспроизводимых песен в автомате гильдии, отключается."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "Нет содержимого в текущем автомате. Заполнение новой музыкой..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Зацикливание автоматов игрока..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Ошибка при обработке песни \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Ошибка распаковки песни \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot должен остановить извлечение автоплейлиста и залог."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 "MusicBot получил необработанное исключение в игроке законченное событие."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr "Развертывание автоплейлиста с записями, извлеченными из:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "Ошибка добавления трека из автомата: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Данные об исключении для вышеописанной ошибки:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "Нет воспроизводимых песен в автомате, отключается."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "Выполняется по игроку_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 "Автоматически пропускать запись в список автовоспроизведения для записи в "
 "очереди."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "Исключение из музыкального плеера для записи: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "Исключение из музыкального плеера."
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "Не удалось воспроизвести трек автоплейлиста:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "Идет выход из системы, проигнорировано событие обновления статуса."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Статус бота:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Сериализация очереди для %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Десериализация очереди для %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Запись текущей песни для %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "Не удается отправить объект без ответа:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Попытка отправить некорректный объект ответа."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "отправка вставки на: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "отправка текста в: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "Не удается отправить сообщение \"%s\", нет разрешения"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "Не удается отправить сообщение \"%s\", недопустимый или удаленный канал"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "Сообщение превышает предел размера сообщения (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 "Не удалось отправить личное сообщение, вместо этого отправка в резервный "
 "канал."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
@@ -884,77 +863,77 @@ msgstr ""
 "через %s секунд."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Отменено сообщение повторно:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 "Оцените ограниченное количество отправленных сообщений, но не удается "
 "повторить попытку!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "Не удалось отправить сообщение в запасном канале."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Не удалось отправить из-за ошибки HTTP."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "Невозможно удалить сообщение \"%s\", нет разрешения"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "Невозможно удалить сообщение \"%s\", сообщение не найдено"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 "Оцените ограниченное удаление сообщения, повторная попытка через %s секунд."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 "Оцените ограниченное сообщение удаления, но не могу повторить попытку!"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Не удалось удалить сообщение"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Получено HTTPException пытается удалить сообщение: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "Невозможно изменить сообщение \"%s\", сообщение не найдено"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Отправка сообщения"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
@@ -962,51 +941,51 @@ msgstr ""
 "секунд."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Отменено изменение сообщения для:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Не удалось изменить сообщение"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Принято HTTPException, пытающееся редактировать сообщение %s в: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Отменено удаление сообщения (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Получен сигнал от ОС: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Отключение и включение MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "Исключение выбрасывается при обработке сигнала прерывания!"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot теперь делает шаги выключения..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1029,44 +1008,44 @@ msgstr ""
 "  Проверка статуса API на официальном сайте: discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "Ожидание окончания потоков загрузки..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Подождите задачи:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Попробует отменить задачу:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "Ожидается ожидание задач..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Закрытие HTTP-коннектора."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Завершение сеанса aiohttp."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "Выход был вызван."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1076,80 +1055,80 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Исключение в %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "Музыкальный робот возобновил сессию с дискордом."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Завершить _готовое"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Вход выполнен, теперь MusicBot готов..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "Клиент как-то нет, мы должны забрать гвозд..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "Музыкабот:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Владелец:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Список гильдий:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "Лев. %s из-за того, что владелец бота не найден"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr "Не выполняется проверка на серверах %s из-за недоступности"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "Владелец не найден ни в одной гильдии (id: %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Владелец неизвестен, бот не на гильдиях."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1163,41 +1142,41 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Нет привязки канала с ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "Не удается привязать к каналу без сообщения с ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Привязано к текстовым каналам:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "Нет привязки к текстовым каналам"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "Нет для автоподключения к каналу с ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
@@ -1205,207 +1184,207 @@ msgstr ""
 "%d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 "Невозможно автоматически подключиться к каналу без подключения с ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Автоподсоединение к голосовым каналам:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "Не подключаться к голосовым каналам"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Получение информации о приложении."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "Обеспечение наличия папок данных существует"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Проверка конфигурации"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Проверка конфигурации прав доступа"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Отключено"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Включено"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Параметры:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Префикс команды: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  По умолчанию: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Пропустить порог: %(num)d голосов или %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Играет в @mentions: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Автоплейлист: %(status)s (заказ: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "случайный"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "последовательный"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Автопауза: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Удалить сообщения: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Удалить вызов: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Удалить сейчас Играет: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Режим отладки: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  Загруженные песни будут %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Удалить если не использовано для %d дней"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Сообщение статуса: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Интеграция Spotify: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Таймаут: %s секунд"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Таймаут: %d секунд"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Самоглушено: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Префикс команды на сервер: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Очередь грабинов: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "Запрошенная песня `%(subject)s` заблокирована списком блоков песен."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr "Пытался работать с 'Голосовым каналом', но бот не в голосе..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "Активность канала уже ожидается в гильдии: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1413,31 +1392,31 @@ msgstr ""
 "Действия канала ожидают %(time)d секунд, чтобы покинуть канал: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "Таймер активности канала для %s истек. Отсоединение."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Таймер активности канала отменен для: %(channel)s в %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Игнорирование бездействия игрока в автоподключенном канале:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "Таймер активности игрока уже ждет гильдии: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1446,52 +1425,52 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "Таймер активности игрока %s истек. Отсоединение."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Таймер активности игрока отменен для: %(channel)s в %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Таймер активности игрока восстанавливается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Нет такой команды"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 "Вы должны указать пользователя или указать его идентификационный номер."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Неверная субкоманда. Для примеров использования используйте `help "
 "blockuser`."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot не может найти указанного пользователя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Владелец не может быть добавлен в заблокированный список."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
@@ -1499,90 +1478,90 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 "Не удаляется пользователь из черного списка, не в списке:  %(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 "Не удается добавить пользователей, которые вы указали, они уже добавлены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Вы должны предоставить тему песни, если песня в настоящее время не "
 "воспроизводится."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Неверная субкоманда. Используйте `help blocksong` для примеров "
 "использования."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Тема `%(subject)s` уже находится в списке блоков песен."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "Тема отсутствует в списке блоков песни и не может быть удалена."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Неверная субкоманда. Используйте `help autoplaylist` для примеров "
 "использования."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Недействительная ссылка на песню"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "Очередь пуста. Добавьте несколько песен с помощью команды воспроизведения!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Эта песня уже есть в автомате."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Эта песня еще не находится в автомате."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Вы должны указать имя файла плейлиста."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Вам не разрешено запрашивать плейлисты"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 "Плейлист имеет слишком много записей (%(songs)s , но максимум %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1591,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Игнорирование автопаузы из-за отключения сети."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1605,12 +1584,12 @@ msgstr ""
 "автопаузами."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Уже обрабатывается автопауза, игнорируется это событие."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1620,61 +1599,61 @@ msgstr ""
 "гильдии:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "Ожидание автопаузы было отменено."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 "Подключается новый музыкальный плеер, игнорируя старое событие автопаузы."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 "Проигрывание в пустом голосовом канале, запуск автопаузы для гильдии: %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "Ранее автопауза игрока не приостанавливается для гильдии: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Невозможно использовать поиск, если нет проигрывания."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Невозможно использовать поиск по текущему треку, он имеет неизвестную "
 "длительность."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Поиск не поддерживается для потоков."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 "Невозможно использовать переключение без времени для размещения "
 "воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Не удалось преобразовать `%(input)s` в допустимое время в секундах."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1684,29 +1663,29 @@ msgstr ""
 "треке длиной `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Неверная субкоманда. Используйте команду `help repeat` для примеров "
 "использования."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Игрок в данный момент не зацикливается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Позиции песни должны быть целыми!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Вы поставили позицию за пределами плейлиста!"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
@@ -1714,39 +1693,39 @@ msgstr ""
 " реакций."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Воспроизведение локального медиа не включено."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "URL-адрес Spotify недействителен или в настоящее время не поддерживается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Обнаружен URL-адрес Spotify, но Spotify не включен."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Вы достигли лимита на добавленные песни (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Караоке-режим включен, попробуйте еще раз, когда он отключен!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Проблема с extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1756,17 +1735,11 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Это видео не может быть воспроизведено. Попробуйте использовать команду "
 "трансляции."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "Поиск YouTube не дал результатов по запросу:  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1877,18 +1850,18 @@ msgid "Player is not playing."
 msgstr "Плеер не играет."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Нечего удалять в очереди!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "В очереди у пользователя `%(user)s ничего не найдено"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1897,40 +1870,40 @@ msgstr ""
 "Вы должны быть тот, кто поставил его в очередь или имеет мгновенные пропуска."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Неверный номер записи. Используйте команду очереди для поиска позиций."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Нельзя пропустить! Игрок не играет!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "У вас недостаточно прав для принудительного пропуска циклической песни."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "У вас нет разрешения на принудительный пропуск."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "У вас нет разрешения на пропуск зацикливаемой песни."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` не является допустимым числом"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1940,44 +1913,44 @@ msgstr ""
 "Том может быть установлен только от 1 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Неприемлемый объём: %(volume)s. Предоставьте значение от 1 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Скорость не может быть применена к потоковым носителям."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Вы должны предоставить скорость для установки."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Предоставленная вами скорость является недопустимой. Используйте число в "
 "диапазоне от 0.5 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Недопустимый параметр для команды: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1987,30 +1960,30 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Вы должны указать псевдоним и команду для псевдонима"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Вы должны указать имя псевдонима для удаления."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Псевдоним `%(alias)s` не существует."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Конфигурация не может использовать канал и упоминания пользователя "
 "одновременно."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2020,7 +1993,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2029,18 +2002,18 @@ msgstr ""
 " корректный раздел и название опции."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Указанная опция является неоднозначной, укажите название раздела."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Вы должны указать название раздела и название параметра для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2050,25 +2023,25 @@ msgstr ""
 "Доступные разделы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Опция `%(option)s` недоступна."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Параметр `%(option)s` не редактируется. Невозможно сохранить на диск."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Не удалось сохранить опцию: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -2076,30 +2049,30 @@ msgstr ""
 "отображается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Параметр `%(option)s` не редактируется. Не удается обновить параметр."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Вы должны указать раздел, параметр и значение для этой подкоманды."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Выполнение установлено с помощью %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Опция `%(option)s` не была обновлена!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2107,48 +2080,48 @@ msgstr ""
 "значению по умолчанию."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Сброс %(config)s на стандартный %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Параметр `%(option)s` не был сброшен до значения по умолчанию!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Команда опции является устаревшим, используйте команду config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Указан неверный параметр, используйте информацию: info, update, or clear"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Не удалось** удалить кэш, проверьте журналы для получения дополнительной "
 "информации..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Аргумент очереди страницы должен быть целым числом."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Нет песен в очереди! Очередь что-то с помощью команды воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2156,41 +2129,41 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "Текущий элемент плейлиста пропущен."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "Недостаточно записей для создания нужной очереди."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Не удалось отправить сообщение в очередь. Нет сообщений для добавления "
 "реакций."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Нельзя использовать очистку в приватном ЛС канале."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "Указанный URL не является допустимым URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2200,12 +2173,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Похоже, что это не плейлист."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2213,19 +2186,19 @@ msgstr ""
 "Неверный ID пользователя или имя сервера, проверьте ID и повторите попытку."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Не удалось определить пользователя discord. Попробуйте еще раз."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Права доступа не могут использовать каналы и упоминания пользователей "
 "одновременно."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2235,23 +2208,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Вы должны указать название группы или опции для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Вы должны указать группу, опцию и значение для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Субкоманда %(option)s требует имя группы и прав доступа."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2261,47 +2234,47 @@ msgstr ""
 "Доступные группы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Разрешение `%(option)s` недоступно."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Невозможно добавить группу `%(group)s`, она уже существует."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Невозможно удалить встроенную группу."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Группа владельцев не редактируется."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Не удалось сохранить группу: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Выполнение установлено на %(option)s со значением: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Разрешение `%(option)s` не было обновлено!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2310,7 +2283,7 @@ msgstr ""
 "Запомнить, что изменения имени ограничены дважды в час.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2320,12 +2293,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Невозможно изменить никнейм: нет разрешения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2335,14 +2308,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Пользовательские эмодзи должны быть с этого сервера, чтобы использовать в "
 "качестве префикса."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2351,30 +2324,30 @@ msgstr ""
 "Используйте команду конфигурации для обновления префикса."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Эта команда может быть использована только в гильдиях."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Неверная субкоманда. Используйте команду справки для получения "
 "дополнительной информации."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Не удается установить язык в `%(locale)s`, он недоступен."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Вы должны указать URL или прикрепить файл."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2384,19 +2357,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot обнаружил %s без гильдии! Это может быть проблемой."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Сейчас не подключен к серверу`%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2404,44 +2377,44 @@ msgstr ""
 "uppip, или upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Вы должны указать ID или имя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Не найдено ни одной гильдии с ID или именем `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Активация точки останова ID: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Не удалось импортировать `objgraph`, он установлен?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Код отладки запускался с помощью eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Код отладки запускался с exec()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "Не удалось выполнить код отладки."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2457,54 +2430,54 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Подкоманда должна быть одной из %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Не удалось найти исполняемый файл git."
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "Не удалось проверить наличие обновлений по команде git."
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Пакет отсутствует в отчете pip."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr "Не удалось получить статус обновления pip из-за некоторой ошибки."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Получена запись о странном голосовом клиенте."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies уже включены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies должны быть загружены для включения. (issing cookies файл.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Не удалось включить куки из-за ошибки:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2514,7 +2487,7 @@ msgstr ""
 "Cookies временно отключены и будут повторно включены при следующем перезапуске."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2522,49 +2495,49 @@ msgstr ""
 "cookie."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "Не удалось удалить старый, отключен файл cookie:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Ошибка при загрузке файла cookie с дискода:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Не удалось сохранить куки на диске:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Получено сообщение без канала, как-то  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Игнорирование команды от себя (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Игнорирование команды от другого бота (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Игнорирование команды из канала типа:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
@@ -2572,24 +2545,24 @@ msgstr ""
 "%(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Сообщение от %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Эта команда не разрешена для вашей группы прав:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Эта команда требует, чтобы вы были в голосовом канале."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
@@ -2597,106 +2570,106 @@ msgstr ""
 "%(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Ошибка в %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Исключение при обработке команды: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Невозможно сгенерировать справку для отсутствующей команды:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Отсутствуют вспомогательные данные для команды:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Выход голосового канала %s в %s из-за отсутствия активности."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "Музыкабот подключен."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "Музыкабот был разорван."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Получено событие сокета:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "VoiceState обновляется до окончания on_ready"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Игнорирование %s в %s , как это связанный голосовой канал."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s был обнаружен как пустой. Тайм-аут обработки."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "Пользователь присоединился к %s, время отмены таймера."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "Бот перемещен, голосовой канал %s пуст. Тайм-аут обработки."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Бот был перемещен и голосовой канал %s не пуст."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "Больше не следует за пользователем %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Следовать за пользователем `%(user)s` на канал:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "VoiceState отключает before.channel не подключен."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2706,7 +2679,7 @@ msgstr ""
 "[S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
@@ -2714,91 +2687,91 @@ msgstr ""
 "%(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "Не удается найти канал автоподключения, он был удален? Гильдия:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 "Повторное подключение к автоматически подключенной гильдии на канале:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Невозможно автоматически присоединиться к каналу:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Бот был добавлен в гильдию: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Левая гильдия '%s' из-за не найден владелец бота."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Создание папки данных для гильдии %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Бот был удален из гильдии: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Обновленный список гильдий:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Гильдия \"%s\" стала доступна."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Возобновление доступа игрока в \"%s\" из-за доступности."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Гильдия \"%s\" недоступна."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Пауза игрока в \"%s\" из-за недоступности."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Обновление гильдии для:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Атрибут гильдии %(attr)s сейчас: %(new)s  -- Was: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Обновление канала для:  %(channel)s  --  %(changes)s"
@@ -2816,7 +2789,7 @@ msgid "Loading config from:  %s"
 msgstr "Загрузка конфигурации из:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2834,7 +2807,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2844,7 +2817,7 @@ msgstr ""
 "ограничена."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2853,7 +2826,7 @@ msgstr ""
 "него будет использоваться значение по умолчанию."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2865,12 +2838,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Исключение было вызвано при проверке AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2892,13 +2865,13 @@ msgstr ""
 "  Двойная проверка правильности, доступный путь к каталогу."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Кэш аудио будет храниться в:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2911,7 +2884,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2919,7 +2892,7 @@ msgstr ""
 "Опция StatusMessage слишком длинная, она будет ограничена 128 символов."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2929,17 +2902,17 @@ msgstr ""
 "этого значение параметра %.3f будет ограничено."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Проверка параметров с данными сервиса..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "Приобретенный ID владельца через API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2952,12 +2925,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "У MusicBot нет экземпляра пользователя, невозможно продолжить."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2969,12 +2942,12 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "Файл параметров конфигурации не найден. Проверка альтернативы..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2984,18 +2957,18 @@ msgstr ""
 "включить расширения."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Копирование существующего файла параметров примера:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr "Что-то пошло не так при попытке найти файл конфигурации."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3017,7 +2990,7 @@ msgstr ""
 "  Проверьте папку конфигурации и файлы существуют и могут быть прочитаны MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3041,12 +3014,12 @@ msgstr ""
 "  Скопируйте файл примера из репозитория, если все остальное не удалось."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "Dev Bug! Параметр конфигурации имеет getter, который не доступен."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3055,42 +3028,42 @@ msgstr ""
 " должен быть одинаковым."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "Ранее отсутствовал вариант."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Раздел конфигурации не в анализируемой конфигурации! Отсутствует: %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Сохраненная конфигурация: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Не удалось сохранить конфигурацию:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr "Имена опций не уникальны между INI-разделами! Резольвер отключен."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Не удалось сохранить INI-файл по умолчанию в:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3110,7 +3083,7 @@ msgstr ""
 "  Установите %(option)s на числовой ID или установите его в `auto` или `0` для автоматической привязки владельца."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3130,7 +3103,7 @@ msgstr ""
 "  Проверьте настройки пути и убедитесь, что файл существует и доступен для MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3150,7 +3123,7 @@ msgstr ""
 "  Убедитесь, что все ID числовые и разделены только пробелами или запятыми."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3160,7 +3133,7 @@ msgstr ""
 "на уровень: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3170,7 +3143,7 @@ msgstr ""
 "'%(value)s' вместо значения по умолчанию."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3180,7 +3153,7 @@ msgstr ""
 "и вместо него будет установлен %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3188,143 +3161,143 @@ msgstr ""
 "Переименование INI-файла [%(old_s)s] > %(old_o)s  на [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Обновление конфигурационного файла с переименованными опциями..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "Не удалось обновить конфигурацию. Вам нужно обновить ее вручную."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Файл блока списка не найден:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Не удалось загрузить список блокировок из файла:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Не удалось обновить файл списка блоков:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Загружен блокированный список пользователей с записями %s."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Мы нашли устаревший файл в черном списке, он будет переименован на:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Загружен Блок песни с записями %s."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "Не удается загрузить данные для гильдии с ID 0. Вероятно, это ошибка в коде!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "Нет файла для гильдии %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "Загрузка данных гильдии с ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "Ошибка ОС не удалось прочитать файл данных гильдии:  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 "У гильдии %(id)s/%(name)s есть пользовательский префикс команд: %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "Невозможно сохранить данные для гильдии с ID 0. Возможно, это ошибка в коде!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr "Не удалось сохранить данные конкретной гильдии из-за ошибки ОС."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 "Не удалось сериализовать данные для конкретной гильдии из-за некорректных "
 "данных."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Принудительное YTDLP использовать User Agent:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "Музыкабот будет использовать cookies для yt-dlp от:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp будет использовать настроенный прокси сервер."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD не имеет заголовков..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr "Проверка заголовков медиа не выполнена из-за таймаута."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Ошибка запроса HEAD для:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "HEAD запрос исключения: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3334,55 +3307,55 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Ранизированная информация о извлечении YTDL (не JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Извлечение информации о треке не дало никаких данных."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Вызвал extract_info с: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Невозможно запустить распаковку, цикл закрыт. (нормальный при выключении)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Невозможно продолжить извлечение. Цикл события закрыт."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "URL-адрес Spotify недействителен или не поддерживается."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Ошибка загрузки с URL потока"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "Предположим, что содержимое является прямым потоком"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Невозможно провести некорректный URL-адрес."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3390,23 +3363,23 @@ msgstr ""
 "пространство."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Вызвал safe_extract_info с:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Локальный медиа-файл не найден."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Отсутствует __input_subject из YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3414,7 +3387,7 @@ msgstr ""
 "избежать этого."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Внимание, ошибка продолжительности для: %(url)s"
@@ -3457,12 +3430,12 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr "Отсутствует номер версии входных данных, невозможно десериализовать."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 "Данные записи имеют неверный номер версии, невозможно десериализовать."
@@ -3494,7 +3467,7 @@ msgstr ""
 "поиска!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "Не удалось загрузить %s"
@@ -3506,7 +3479,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr "Не удается загрузить ссылки Spotify, ошибка обработки типа %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Готово к записи:  %r"
@@ -3529,7 +3502,7 @@ msgid "Download already cached at:  %s"
 msgstr "Скачивание уже кэшировано:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3547,7 +3520,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Получена длительность %(time)s секунд для файла:  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3558,75 +3531,75 @@ msgstr ""
 "треки не будут выравниваться."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Исключение при проверке входных данных."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Попытка получить длительность через pymediainfo для:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "Не удалось получить длительность через pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Пытаемся получить длительность через ffprobe для:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "Не удалось найти ffprobe в вашем пути!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe возвращает то, что не может быть использован."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe не может быть выполнен по той или иной причине."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Расчет среднего объёма:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "Не удалось найти ffmpeg на вашем пути!"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "Не удалось разобрать «I» в нормализации json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "Не удалось разобрать 'LRA' в нормализации json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "Не удалось разобрать 'TP' в нормализации json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "Не удалось разобрать 'thresh' в нормализации json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "Не удалось разобрать 'offset' в нормализации json."
 
@@ -3670,53 +3643,53 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Загрузка не удалась из-за ошибки yt-dlp: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "В извлечении обнаружено необработанное исключение."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "Загрузка не удалась из-за необработанного исключения: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Ошибка загрузки:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Не удалось извлечь данные для запрошенного носителя."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Загрузка завершена:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "Десериализованный StreamPlaylistEntry не может найти канал с ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "Десериализованный StreamPlaylistEntry имеет неверный тип канала:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr "Десериализованный StreamPlaylistEntry не может найти автора с ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
@@ -3724,28 +3697,28 @@ msgstr ""
 "поиска!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 "Десериализованный LocalFilePlaylistEntry не может найти канал с ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 "Десериализованный LocalFilePlaylistEntry имеет неверный тип канала:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "Десериализованный LocalFilePlaylistEntry не может найти автора с ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3754,7 +3727,7 @@ msgstr ""
 "канала для поиска!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Получена длительность %(seconds)s секунд для файла:  %(file)s"
@@ -3862,19 +3835,19 @@ msgstr ""
 "%(old)s  Новый: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Ошибка аргумента языка:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4203,77 +4176,77 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Декодированные данные из ffmpeg: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Добавление записи потока для URL:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Не удалось извлечь информацию"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Это плейлист."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr "Информация о записи похожа на поток, добавление записи на поток..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Недопустимый тип содержимого `%(type)s` для URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "Получен текстовый/html для типа содержимого, это может быть поток."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Сомнительный тип содержимого \"%(type)s\" для url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Добавление URLPlaylistList для: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Добавление LocalFilePlaylistEntry для: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "Игнорировать видео из составного плейлиста с ID:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr "Не разрешается запись в списке блоков песни:  %(title)s  URL: %(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr "Игнорирование песни в записях '%s', длиннее допустимого максимума."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4281,40 +4254,40 @@ msgstr ""
 "удалено:  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "Не удалось добавить элемент"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Предмет: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "Пропущенные %s плохие записи"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Переупорядочить циклы поверх записей."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Предзагрузка следующего трека:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "нет длительности данных"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "нет данных о продолжительности в текущей записи"
 
@@ -4884,43 +4857,43 @@ msgstr ""
 "умолчанию: '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Версия:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 "Открыт новый экземпляр MusicBot. Этот терминал может быть безопасно закрыт!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Загрузка версии MusicBot:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Открыт журнал:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Изменение рабочего каталога на:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4931,7 +4904,7 @@ msgstr ""
 "расположение каталога."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4940,7 +4913,7 @@ msgstr ""
 "Если вы не использовали git для клонирования репозитория, вам настоятельно рекомендуется это сделать."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4949,12 +4922,12 @@ msgstr ""
 "выйти."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Вот точная ошибка, это может быть ошибка."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4963,7 +4936,7 @@ msgstr ""
 "вы можете открыть сайт с ошибками в Microsoft Edge или IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -4972,17 +4945,17 @@ msgstr ""
 "вместо этого попробуйте certifi."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Ошибка синтаксиса (обнаружена модификация, вы отредактировали код?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Ошибка синтаксиса (это ошибка, не ваша вина)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5003,13 +4976,13 @@ msgstr ""
 "  или запустить без `--no-install-deps` и MusicBot попытается установить их для вас."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "Попытка автоматической установки пакетов с зависимостью от MusicBot...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5030,12 +5003,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, позволяет надеяться, что зависимости работают!"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5044,58 +5017,58 @@ msgstr ""
 "выйти..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "Исключение, вызвавшее указанную ошибку: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot делает мягкий перезапуск..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot выполняет полный перезапуск процесса..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Ошибка при запуске бота"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Цикл закрытия событий."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Перезапуск через %s секунд..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "Всё готово."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "ОК, мы закрываем!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -5120,12 +5093,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5139,7 +5112,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5207,45 +5180,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -5257,220 +5230,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5489,30 +5462,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5520,18 +5493,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5606,9 +5579,91 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+#~ "В конфигурации нет учетных данных приложения Spotify, пытаясь использовать "
+#~ "гостевой режим."
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "Аутентификация в Spotify прошла успешно в гостевом режиме."
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+#~ "Невозможно запустить клиент Spotify в гостевом режиме. Подробности: %s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "Поиск YouTube не дал результатов по запросу:  %(url)s"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/ru_RU/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/ru_RU/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -789,7 +789,7 @@ msgstr ""
 "воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Позиции песни должны быть целыми!"
 
@@ -822,29 +822,29 @@ msgid "Local media playback is not enabled."
 msgstr "Воспроизведение локального медиа не включено."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "URL-адрес Spotify недействителен или в настоящее время не поддерживается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Обнаружен URL-адрес Spotify, но Spotify не включен."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Вы достигли лимита на добавленные песни (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Караоке-режим включен, попробуйте еще раз, когда он отключен!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -854,14 +854,14 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Это видео не может быть воспроизведено. Попробуйте использовать команду "
 "трансляции."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -870,7 +870,7 @@ msgstr ""
 "секунд)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -880,13 +880,13 @@ msgstr ""
 "Позиция в очереди: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Длительность песни превышает предел (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -894,24 +894,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "Следующая игра!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - предполагаемое время до игры: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - невозможно оценить время до игры."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -924,36 +924,36 @@ msgstr ""
 "Примечание: FFmpeg может случайным образом отбрасывать поток или если произойдет ошибка подключения.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Потоковые плейлисты еще не поддерживаются."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "Теперь стриминг `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Вы достигли предела в плейлисте (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
@@ -961,46 +961,46 @@ msgstr ""
 "получения дополнительной информации."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Вы не можете искать более чем %(max)s видео"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Поиск видео..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "Поиск не удался из-за ошибки: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "Видео не найдено."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "Для выбора песни введите соответствующее число."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Результаты поиска от %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** | %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1009,198 +1009,198 @@ msgstr ""
 "**0**. Отмена"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Выберите песню"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Добавлена песня [%(track)s](%(url)s) в очередь."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Результат %(number)s из %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "Хорошо, приближайся!"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Показать информацию о том, что сейчас играет."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "Играет сейчас"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Сейчас стриминг:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "Сейчас играет:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Добавлено через:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Прогресс:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Нет песен в очереди! Очередь что-то с помощью команды воспроизведения."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Расскажите MusicBot, чтобы войти в канал, в который вы находитесь."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 "Вы не подключены к голосу. Попробуйте подключиться к голосовому каналу!"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Подключено к `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "Больше не следует за пользователем `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Теперь следите за пользователем `%(user)s` между голосовыми каналами."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 "MusicBot не может следить за пользователем, не являющимся членом сервера."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 "Будет следовать за пользователем `%(user)s` между голосовыми каналами."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Приостановить воспроизведение, если трек воспроизводится."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Пауза в `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Плеер не играет."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "Возобновляет воспроизведение, если плеер был ранее приостановлен."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Возобновленная музыка в `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Возобновленная очередь музыки"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Игрок не приостанавливается."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Перемешать все текущие треки в очереди."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Перемещает все песни в очередь."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Удаляет все песни, которые сейчас находятся в очереди."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Все песни из очереди очищены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Нечего удалять в очереди!"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Удалено `%(track)s` добавил `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "В очереди у пользователя `%(user)s ничего не найдено"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1209,25 +1209,25 @@ msgstr ""
 "Вы должны быть тот, кто поставил его в очередь или имеет мгновенные пропуска."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Неверный номер записи. Используйте команду очереди для поиска позиций."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Удалена запись `%(track)s` добавлена `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Удалена запись `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1235,61 +1235,61 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Нельзя пропустить! Игрок не играет!"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "Следующая песня `%(track)s` загружается, пожалуйста, подождите."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 "Следующая песня будет воспроизведена в ближайшее время. Пожалуйста, "
 "подождите."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "У вас недостаточно прав для принудительного пропуска циклической песни."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "У вас нет разрешения на принудительный пропуск."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "У вас нет разрешения на пропуск зацикливаемой песни."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1299,12 +1299,12 @@ msgstr ""
 "Пропущен голос.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " Следующая песня!"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1312,7 +1312,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1320,25 +1320,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Текущий объем: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` не является допустимым числом"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Изменена громкость с **%(old)d** до **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1348,14 +1348,14 @@ msgstr ""
 "Том может быть установлен только от 1 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Неприемлемый объём: %(volume)s. Предоставьте значение от 1 до 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1363,43 +1363,43 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Скорость не может быть применена к потоковым носителям."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Вы должны предоставить скорость для установки."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Предоставленная вами скорость является недопустимой. Используйте число в "
 "диапазоне от 0.5 до 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Установка скорости воспроизведения в `%(speed).3f` для текущего трека."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1408,23 +1408,23 @@ msgstr ""
 "используйте команду помощи."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Недопустимый параметр для команды: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Псевдонимы перезагружены из файла конфигурации."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Псевдонимы сохранены в конфигурационном файле."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1434,12 +1434,12 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Вы должны указать псевдоним и команду для псевдонима"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
@@ -1447,61 +1447,61 @@ msgstr ""
 "`%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Вы должны указать имя псевдонима для удаления."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Псевдоним `%(alias)s` не существует."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Псевдоним `%(alias)s` был удален."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Показывает текст справки для определенного варианта.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Отображение текущего значения параметра.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Сохраняет текущее значение в файл параметров.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1510,34 +1510,34 @@ msgstr ""
 "файла.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Сброс параметра в значение по умолчанию.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Управление конфигурацией options.ini из Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Конфигурация не может использовать канал и упоминания пользователя "
 "одновременно."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*Все настройки присутствуют и учтены для!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "Похоже, что настройки конфигурации не были изменены."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1547,7 +1547,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1563,12 +1563,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "Настройки конфигурации успешно перезагружены из файла!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1578,7 +1578,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1587,18 +1587,18 @@ msgstr ""
 " корректный раздел и название опции."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Указанная опция является неоднозначной, укажите название раздела."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Вы должны указать название раздела и название параметра для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1608,25 +1608,25 @@ msgstr ""
 "Доступные разделы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Опция `%(option)s` недоступна."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Эта опция может быть задана только редактированием конфигурационного файла."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "По умолчанию эта опция установлена на: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1640,25 +1640,25 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Параметр `%(option)s` не редактируется. Невозможно сохранить на диск."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Не удалось сохранить опцию: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Опция `%(config)s` успешно сохранена"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -1666,7 +1666,7 @@ msgstr ""
 "отображается."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1678,24 +1678,24 @@ msgstr ""
 "INI значение файла: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Параметр `%(option)s` не редактируется. Не удается обновить параметр."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Вы должны указать раздел, параметр и значение для этой подкоманды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Опция `%(option)s` не была обновлена!"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1705,7 +1705,7 @@ msgstr ""
 "Для сохранения изменения используйте `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1713,13 +1713,13 @@ msgstr ""
 "значению по умолчанию."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Параметр `%(option)s` не был сброшен до значения по умолчанию!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1729,17 +1729,17 @@ msgstr ""
 "Чтобы сохранить изменение используйте `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Устаревшая команда, используйте команду config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Команда опции является устаревшим, используйте команду config."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1748,34 +1748,34 @@ msgstr ""
 "Использование опции обновления будет сканировать кэш для внешних изменений перед отображением деталей."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Указан неверный параметр, используйте информацию: info, update, or clear"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Отключено"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Включено"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Неограниченный"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1791,36 +1791,36 @@ msgstr ""
 "**Cached Now:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "Кэш был очищен."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Не удалось** удалить кэш, проверьте журналы для получения дополнительной "
 "информации..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "Не найден кэш для очистки."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Аргумент очереди страницы должен быть целым числом."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1828,12 +1828,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(время неизвестно)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1845,7 +1845,7 @@ msgstr ""
 "Прогресс: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1859,19 +1859,19 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Песни в очереди"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1882,38 +1882,38 @@ msgstr ""
 "Эта команда может быть медленной, если указаны большие диапазоны.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "Неверный параметр. Укажите количество сообщений для поиска."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Нельзя использовать очистку в приватном ЛС канале."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Очищено %(number)s сообщение(ов)."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Бот не имеет разрешения на управление сообщениями."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Сбросить отдельные URL плейлиста в файл."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "Указанный URL не является допустимым URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1923,37 +1923,37 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Похоже, что это не плейлист."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Вот дамп плейлиста для:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Ваш идентификатор пользователя: `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "ID пользователя для `%(username)s`: `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1961,24 +1961,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Допустимые категории: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Ниже приведены идентификаторы ваших запросов:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "Получить список разрешений, или разрешения упомянутого пользователя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -1986,12 +1986,12 @@ msgstr ""
 "Неверный ID пользователя или имя сервера, проверьте ID и повторите попытку."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Не удалось определить пользователя discord. Попробуйте еще раз."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2005,7 +2005,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2019,64 +2019,64 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Перезагружает права доступа из файла permissions.ini.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Удалить существующую группу.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Показать текст справки для опции разрешения.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Сохранить группу прав доступа в файл.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Установка значения прав доступа для группы.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Управление конфигурацией permissions.ini из дистрибутива."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Права доступа не могут использовать каналы и упоминания пользователей "
 "одновременно."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "Права доступа успешно перезагружены из файла!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2086,7 +2086,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2100,23 +2100,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Вы должны указать название группы или опции для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Вы должны указать группу, опцию и значение для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Субкоманда %(option)s требует имя группы и прав доступа."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2126,25 +2126,25 @@ msgstr ""
 "Доступные группы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Разрешение `%(option)s` недоступно."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Это право может быть установлено только редактированием файла разрешений."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "По умолчанию это разрешение установлено в: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2158,13 +2158,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Невозможно добавить группу `%(group)s`, она уже существует."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2176,12 +2176,12 @@ msgstr ""
 "Убедитесь, что новая группа сохранена в: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Невозможно удалить встроенную группу."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2191,24 +2191,24 @@ msgstr ""
 "Не забудьте сохранить это изменение с: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Группа владельцев не редактируется."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Не удалось сохранить группу: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Группа успешно сохранена: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2220,13 +2220,13 @@ msgstr ""
 "INI значение файла: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Разрешение `%(option)s` не было обновлено!"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2236,14 +2236,14 @@ msgstr ""
 "Чтобы сохранить изменение, используйте `setperms сохранить %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2252,7 +2252,7 @@ msgstr ""
 "Запомнить, что изменения имени ограничены дважды в час.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2262,23 +2262,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Установить имя бота в `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Изменить псевдоним MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Невозможно изменить никнейм: нет разрешения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2288,23 +2288,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Установите ник бота в `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Установите префикс команд для каждого сервера."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Очистить префикс команды для каждого сервера."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2313,25 +2313,25 @@ msgstr ""
 "Сначала должен быть включен параметр EnablePrefixPerGuild"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Пользовательские эмодзи должны быть с этого сервера, чтобы использовать в "
 "качестве префикса."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Префикс команд сервера очищен."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Теперь префикс команд сервера:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2340,39 +2340,39 @@ msgstr ""
 "Используйте команду конфигурации для обновления префикса."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Показать коды языков, доступные для использования.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Сброс языка сервера на язык бота по умолчанию.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "Управление языком, используемым для сообщений на сервере."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Эта команда может быть использована только в гильдиях."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Неверная субкоманда. Используйте команду справки для получения "
 "дополнительной информации."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2386,37 +2386,37 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Не удается установить язык в `%(locale)s`, он недоступен."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Язык для этого сервера теперь установлен в: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Язык для этого сервера был сброшен: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Вы должны указать URL или прикрепить файл."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2426,58 +2426,58 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "Изменил аватар бота."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Принудительно отключиться от сервера discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Отключен от сервера`%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Отсоединил голосового клиента без проигрывателя? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Сейчас не подключен к серверу`%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Попытка перезагрузки без перезапуска процесса. Параметр по умолчанию.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr "    Попытка перезапустить весь процесс MusicBot, перезагрузка всего.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Полный перезапуск, но попытаться обновить pip пакеты перед "
 "перезагрузкой.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    Полный перезапуск, но сначала обновите исходный код MusicBot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2486,7 +2486,7 @@ msgstr ""
 "перезагрузкой.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2499,7 +2499,7 @@ msgstr ""
 "Если у вас есть менеджер служб, мы рекомендуем использовать его вместо этой команды для перезапуска.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2507,19 +2507,19 @@ msgstr ""
 "uppip, или upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s перезапуск текущего экземпляра..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Перезапуск бота..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2527,41 +2527,41 @@ msgstr ""
 "%(emoji)s попытается обновить необходимые pip пакеты и перезапустить бот..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "%(emoji)s попытается обновить бот-код git и перезапустить бот..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s попытается обновить всё и перезапустить бот..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Отсоединитесь от всех голосовых каналов и закройте процесс MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Оставить сервер discord, заданный по имени или ID сервера."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Вы должны указать ID или имя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Не найдено ни одной гильдии с ID или именем `%(input)s`"
@@ -2573,13 +2573,13 @@ msgid "Unknown"
 msgstr "Неизвестен"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Слева от гильдии: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2588,38 +2588,38 @@ msgstr ""
 "Может использоваться для закрепления событий вручную в файле журнала MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Логированная точка останова с ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Просмотр ограниченного вывода objgraph.show_growth().\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Просмотр наиболее распространенных типов утечек объектов.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Оценить заданную функцию и аргументы на обджграфе.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2630,12 +2630,12 @@ msgstr ""
 "Поскольку этот метод вычисляет произвольный код, он считается опасным, как команда отладки.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Не удалось импортировать `objgraph`, он установлен?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2650,7 +2650,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2666,7 +2666,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2675,73 +2675,73 @@ msgstr ""
 "Вывод используется для обновления страниц GitHub и, таким образом, не подходит для нормального использования ссылок."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Подкоманда должна быть одной из %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Делает INI-файлы по умолчанию."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Запрошенный INI-файл сохранен на диск. Проверьте"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Не удалось найти исполняемый файл git."
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "В ветке `%(branch)s` нет обновлений."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Новые коммиты доступны в удаленной ветке `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "Ошибка при проверке, смотрите журналы для подробностей."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Обновление для `%(name)s` до версии: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "Обновления для зависимостей не найдены."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "Доступны для скачивания обновления MusicBot."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot полностью актуальен!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2761,20 +2761,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Отображает время загрузки MusicBot или время с момента последнего "
 "запуска/перезапуска."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s был онлайн для `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2782,35 +2782,35 @@ msgstr ""
 "голосовых клиентов."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Отображение задержки API и задержки голоса при подключении MusicBot."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "авто"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Задержка API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Отображать номер версии MusicBot в чате."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2820,17 +2820,17 @@ msgstr ""
 "Текущая версия: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Обновите файл cookies.txt, используя файл cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Включение или отключение файла cookies.txt без его удаления."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2845,28 +2845,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies уже включены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies должны быть загружены для включения. (issing cookies файл.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Не удалось включить куки из-за ошибки:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Cookies были включены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2876,12 +2876,12 @@ msgstr ""
 "Cookies временно отключены и будут повторно включены при следующем перезапуске."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Cookies были отключены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2889,51 +2889,51 @@ msgstr ""
 "cookie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Ошибка при загрузке файла cookie с дискода:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Не удалось сохранить куки на диске:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies загружены и включены."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "Вы не можете использовать этого бота в личных сообщениях."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Эта команда не разрешена для вашей группы прав:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Эта команда требует, чтобы вы были в голосовом канале."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Команда:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Ошибка исключения"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2943,17 +2943,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "Нет описания.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "Использование не дано."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2967,13 +2967,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Выход голосового канала %(channel)s из-за неактивности."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Левый `%(guild)s` из-за отсутствия владельца бота в нем."
@@ -3078,7 +3078,7 @@ msgstr ""
 "Используется только когда BindToChannels отсутствует ID для сервера."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3150,7 +3150,7 @@ msgstr ""
 "Вы можете установить это значение от 0 до 1, или 0% до 100%."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 "Разрешить Музыкаботу сохранять загруженный носитель или удалять его прямо "
@@ -3158,7 +3158,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3167,7 +3167,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3175,7 +3175,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3190,7 +3190,7 @@ msgstr ""
 "Упоминает пользователя, который добавил песню во время ее воспроизведения."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3199,7 +3199,7 @@ msgstr ""
 "голосовом канале при запуске бота."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3208,12 +3208,12 @@ msgstr ""
 "автоплейлиста, когда очередь пуста."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "Перемешает автоплейлист дорожек перед их воспроизведением."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3222,7 +3222,7 @@ msgstr ""
 "Это применимо только к текущей песне, если она была добавлена автоматическим плейлистом."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3274,7 +3274,7 @@ msgstr ""
 "В настоящее время эта опция не применяется к автоматическому плейлисту или трекам, добавленным в пустую очередь."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3291,7 +3291,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 "Если включено, сообщения о состоянии будут сообщать о приостановленных "
@@ -3300,7 +3300,7 @@ msgstr ""
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3338,7 +3338,7 @@ msgstr ""
 "списке очереди."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3347,7 +3347,7 @@ msgstr ""
 "автоплейлиста."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr "Отображать настройки MusicBot в журналах при запуске."
 
@@ -3362,7 +3362,7 @@ msgstr ""
 "пропускать пропуска."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3392,14 +3392,14 @@ msgid "Completely remove the footer from embeds."
 msgstr "Полностью удалить нижний колонтитул с вставки."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 "Музыкальный робот автоматически отключается при входе в голосовой канал."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3410,7 +3410,7 @@ msgstr ""
 "Слушатели являются участниками каналов, за исключением ботов, которые не являются глухими."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3419,7 +3419,7 @@ msgstr ""
 "Вы можете установить это количество секунд или фразы: 4 часа"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3427,7 +3427,7 @@ msgstr ""
 "Если включено, MusicBot сразу же покинет канал, когда очередь песен пуста."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3475,7 +3475,7 @@ msgstr ""
 "воспроизведение для одной песни на одного участника."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3488,7 +3488,7 @@ msgstr ""
 "По умолчанию это отключено."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3500,7 +3500,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3528,7 +3528,7 @@ msgstr ""
 "воспроизведения команд."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3539,7 +3539,7 @@ msgstr ""
 "Оставьте пустым для отключения."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3556,12 +3556,12 @@ msgstr ""
 "Оставьте пустым для использования по умолчанию, динамически сгенерированных UA строк."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "Вкл/Выкл функцию блокировки списка, не очищая список блоков."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3569,12 +3569,12 @@ msgstr ""
 "пользователя Discord по одному в строке."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "Включить функцию списка блоков песни, не очищая список блоков."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3583,7 +3583,7 @@ msgstr ""
 "Название или URL песни, содержащие любую строку в списке, будут заблокированы."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3592,7 +3592,7 @@ msgstr ""
 "Каждый файл должен содержать список доступных для воспроизведения URL или терминов, по одному треку в строке."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3606,7 +3606,7 @@ msgstr ""
 "Maps to:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3615,7 +3615,7 @@ msgstr ""
 "краткосрочный кэш для воспроизведения."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3627,7 +3627,7 @@ msgstr ""
 "Установите значение 0 для отключения. Максимально допустимое значение %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3640,7 +3640,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3658,7 +3658,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3670,7 +3670,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3692,7 +3692,7 @@ msgstr ""
 "  Двойная проверка правильности, доступный путь к каталогу."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3705,7 +3705,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3718,7 +3718,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3730,7 +3730,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3752,7 +3752,7 @@ msgstr ""
 "  Проверьте папку конфигурации и файлы существуют и могут быть прочитаны MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3776,7 +3776,7 @@ msgstr ""
 "  Скопируйте файл примера из репозитория, если все остальное не удалось."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3796,7 +3796,7 @@ msgstr ""
 "  Установите %(option)s на числовой ID или установите его в `auto` или `0` для автоматической привязки владельца."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3816,7 +3816,7 @@ msgstr ""
 "  Проверьте настройки пути и убедитесь, что файл существует и доступен для MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3836,32 +3836,32 @@ msgstr ""
 "  Убедитесь, что все ID числовые и разделены только пробелами или запятыми."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD не имеет заголовков..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Извлечение информации о треке не дало никаких данных."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Невозможно продолжить извлечение. Цикл события закрыт."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "URL-адрес Spotify недействителен или не поддерживается."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Невозможно провести некорректный URL-адрес."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Локальный медиа-файл не найден."
 
@@ -4197,28 +4197,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4246,7 +4246,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4300,7 +4300,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4308,7 +4308,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4318,7 +4318,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4387,7 +4387,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4401,7 +4401,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4410,7 +4410,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4424,7 +4424,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4432,7 +4432,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4441,26 +4441,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4472,28 +4472,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4504,25 +4504,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4531,7 +4531,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/ru_RU/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/ru_RU/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -33,37 +33,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 "Участник не включен голосовым путем и не может использовать эту команду."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Вы не можете использовать эту команду, если не в голосовом канале."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "У Музыкабота нет прав подключаться в канале: `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "У Музыкабота нет прав говорить в канале: `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
@@ -71,29 +71,29 @@ msgstr ""
 "перезапустить?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "У MusicBot нет разрешения на чтение."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot не может просить говорить."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Что-то не так, мы не получили VoiceClient."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -102,32 +102,32 @@ msgstr ""
 "голосе!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr "%(mention)s - ваша песня `%(title)s` теперь играет в %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "Теперь играя в %(channel)s: `%(title)s` добавлен %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 "Теперь проигрыватель автоматически добавил запись `%(title)s` в %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr "Пропускать песни, добавленные %(user)s , так как они не в голосе!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -139,12 +139,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Попытка отправить некорректный объект ответа."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -167,13 +167,13 @@ msgstr ""
 "  Проверка статуса API на официальном сайте: discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr "Запрошенная песня `%(subject)s` заблокирована списком блоков песен."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -182,12 +182,12 @@ msgstr ""
 "Эта команда будет удалена в будущей версии, заменена командами autoplaylist (команды)."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -195,18 +195,18 @@ msgstr ""
 "команд.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Псевдонимы для этой команды:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "` Алиас%(alias)s`%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -217,7 +217,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -229,12 +229,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Нет такой команды"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -244,7 +244,7 @@ msgstr ""
 "Для списка всех команд, запустите: %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -266,68 +266,68 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Заблокировать указанного пользователя."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Разблокировать указанного пользователя."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Показать статус блока упомянутого пользователя."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 "Вы должны указать пользователя или указать его идентификационный номер."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Неверная субкоманда. Для примеров использования используйте `help "
 "blockuser`."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot не может найти указанного пользователя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Владелец не может быть добавлен в заблокированный список."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "Блок списка пользователей в настоящее время включен."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "Блок списка пользователей в настоящее время отключен."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 "Не удается добавить пользователей, которые вы указали, они уже добавлены."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -337,24 +337,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "Никто из этих пользователей не находится в чёрном списке."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "Пользователь: `%(user)s` не заблокирован.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "Пользователь: `%(user)s` заблокирован.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -366,7 +366,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -376,7 +376,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -393,27 +393,27 @@ msgstr ""
 "Это означает, что добавление 'Pie' будет совпадать с 'вишневым пирогом', но не 'piecrust' в проверках.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 "Вы должны предоставить тему песни, если песня в настоящее время не "
 "воспроизводится."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Неверная субкоманда. Используйте `help blocksong` для примеров "
 "использования."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Тема `%(subject)s` уже находится в списке блоков песен."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -423,12 +423,12 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "Тема отсутствует в списке блоков песни и не может быть удалена."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -438,88 +438,88 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Добавляет очередь в плейлист гильдий\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Неверная субкоманда. Используйте `help autoplaylist` для примеров "
 "использования."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Недействительная ссылка на песню"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 "Очередь пуста. Добавьте несколько песен с помощью команды воспроизведения!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "Все песни в очереди уже находятся в списке автоматов."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "%(number)d треков добавлено в список автоматов."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "`%(url)s` добавлен в автомат."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Эта песня уже есть в автомате."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "`%(url)sудалён из автомата."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Эта песня еще не находится в автомате."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Загружена свежая копия плейлиста: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Вы должны указать имя файла плейлиста."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -528,13 +528,13 @@ msgstr ""
 "Этот плейлист новый, вы должны добавить песни, чтобы сохранить его на диске!"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr "Плейлист для этого сервера был обновлен на: `%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
@@ -542,7 +542,7 @@ msgstr ""
 "добавления этого бота на другой сервер."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -552,7 +552,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -561,29 +561,29 @@ msgstr ""
 "Группы с правами доступа BypassKaraokeMode контролируют членов Караоке.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Вам не разрешено запрашивать плейлисты"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 "Плейлист имеет слишком много записей (%(songs)s , но максимум %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -592,12 +592,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "Бот был ранее приостановлен, возобновите воспроизведение сейчас."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -614,7 +614,7 @@ msgstr ""
 "MusicBot также поддерживает Spotify URIs и URL, но звук загружается с YouTube regardless.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -623,13 +623,13 @@ msgstr ""
 " в очередь.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "Элементы плейлиста перемещены в очередь из `%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -638,14 +638,14 @@ msgstr ""
 "Читать справку для команды воспроизведения для информации о поддерживаемых входах.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -658,37 +658,37 @@ msgstr ""
 "Из-за специфики кодеков в ffmpeg это может быть неточным.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Невозможно использовать поиск, если нет проигрывания."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Невозможно использовать поиск по текущему треку, он имеет неизвестную "
 "длительность."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Поиск не поддерживается для потоков."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 "Невозможно использовать переключение без времени для размещения "
 "воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Не удалось преобразовать `%(input)s` в допустимое время в секундах."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -698,7 +698,7 @@ msgstr ""
 "треке длиной `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -706,7 +706,7 @@ msgstr ""
 "Переход к времени `%(input)s` (`%(seconds).2f` секунд) в текущей песне."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -714,66 +714,66 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 "На данный момент треков нет. Воспроизводите что-то с помощью команды "
 "воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Неверная субкоманда. Используйте команду `help repeat` для примеров "
 "использования."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "Повторяется плейлист."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "Плейлист больше не повторяется."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "Игрок теперь повторяет текущую песню."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "Игрок больше не будет повторять текущую песню."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "Игрок уже зацикливает песню!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Игрок в данный момент не зацикливается."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "Песня больше не повторяется."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "Песня повторяется."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -782,24 +782,24 @@ msgstr ""
 "Используйте команду очереди, чтобы найти номера позиции трека.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 "Нет песен в очереди песен. Проигрывайте что-нибудь с помощью команды "
 "воспроизведения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Позиции песни должны быть целыми!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Вы поставили позицию за пределами плейлиста!"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -807,7 +807,7 @@ msgstr ""
 "Песня успешно перемещена с позиции %(from)s в очереди на позицию %(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -817,34 +817,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Воспроизведение локального медиа не включено."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 "URL-адрес Spotify недействителен или в настоящее время не поддерживается."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Обнаружен URL-адрес Spotify, но Spotify не включен."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Вы достигли лимита на добавленные песни (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Караоке-режим включен, попробуйте еще раз, когда он отключен!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -854,17 +854,11 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 "Это видео не может быть воспроизведено. Попробуйте использовать команду "
 "трансляции."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "Поиск YouTube не дал результатов по запросу:  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1042,7 +1036,7 @@ msgid "Show information on what is currently playing."
 msgstr "Показать информацию о том, что сейчас играет."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr ""
 
@@ -1079,7 +1073,7 @@ msgstr "Прогресс:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 "Нет песен в очереди! Очередь что-то с помощью команды воспроизведения."
@@ -1188,38 +1182,25 @@ msgstr "Удаляет все песни, которые сейчас наход
 msgid "Cleared all songs from the queue."
 msgstr "Все песни из очереди очищены."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Удалить трек из очереди, по желанию можно в указанной очереди.\n"
-"Если позиция опущена, песня в конце очереди удаляется.\n"
-"Используйте команду очереди, чтобы найти номер позиции вашего трека.\n"
-"Тем не менее, позиции всех песен меняются после начала воспроизведения новой песни.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Нечего удалять в очереди!"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Удалено `%(track)s` добавил `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "В очереди у пользователя `%(user)s ничего не найдено"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1228,25 +1209,25 @@ msgstr ""
 "Вы должны быть тот, кто поставил его в очередь или имеет мгновенные пропуска."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 "Неверный номер записи. Используйте команду очереди для поиска позиций."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Удалена запись `%(track)s` добавлена `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Удалена запись `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1254,61 +1235,61 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Нельзя пропустить! Игрок не играет!"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "Следующая песня `%(track)s` загружается, пожалуйста, подождите."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 "Следующая песня будет воспроизведена в ближайшее время. Пожалуйста, "
 "подождите."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 "У вас недостаточно прав для принудительного пропуска циклической песни."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "У вас нет разрешения на принудительный пропуск."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "У вас нет разрешения на пропуск зацикливаемой песни."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1318,12 +1299,12 @@ msgstr ""
 "Пропущен голос.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " Следующая песня!"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1331,7 +1312,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1339,25 +1320,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Текущий объем: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` не является допустимым числом"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Изменена громкость с **%(old)d** до **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1367,14 +1348,14 @@ msgstr ""
 "Том может быть установлен только от 1 до 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Неприемлемый объём: %(volume)s. Предоставьте значение от 1 до 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1382,43 +1363,43 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Скорость не может быть применена к потоковым носителям."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Вы должны предоставить скорость для установки."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Предоставленная вами скорость является недопустимой. Используйте число в "
 "диапазоне от 0.5 до 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Установка скорости воспроизведения в `%(speed).3f` для текущего трека."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1427,23 +1408,23 @@ msgstr ""
 "используйте команду помощи."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Недопустимый параметр для команды: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Псевдонимы перезагружены из файла конфигурации."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Псевдонимы сохранены в конфигурационном файле."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1453,12 +1434,12 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Вы должны указать псевдоним и команду для псевдонима"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
@@ -1466,61 +1447,61 @@ msgstr ""
 "`%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Вы должны указать имя псевдонима для удаления."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Псевдоним `%(alias)s` не существует."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Псевдоним `%(alias)s` был удален."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Показывает текст справки для определенного варианта.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Отображение текущего значения параметра.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Сохраняет текущее значение в файл параметров.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1529,34 +1510,34 @@ msgstr ""
 "файла.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Сброс параметра в значение по умолчанию.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Управление конфигурацией options.ini из Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 "Конфигурация не может использовать канал и упоминания пользователя "
 "одновременно."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*Все настройки присутствуют и учтены для!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "Похоже, что настройки конфигурации не были изменены."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1566,7 +1547,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1582,12 +1563,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "Настройки конфигурации успешно перезагружены из файла!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1597,7 +1578,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1606,18 +1587,18 @@ msgstr ""
 " корректный раздел и название опции."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Указанная опция является неоднозначной, укажите название раздела."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 "Вы должны указать название раздела и название параметра для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1627,25 +1608,25 @@ msgstr ""
 "Доступные разделы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Опция `%(option)s` недоступна."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Эта опция может быть задана только редактированием конфигурационного файла."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "По умолчанию эта опция установлена на: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1659,25 +1640,25 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr "Параметр `%(option)s` не редактируется. Невозможно сохранить на диск."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Не удалось сохранить опцию: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Опция `%(config)s` успешно сохранена"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
@@ -1685,7 +1666,7 @@ msgstr ""
 "отображается."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1697,24 +1678,24 @@ msgstr ""
 "INI значение файла: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr "Параметр `%(option)s` не редактируется. Не удается обновить параметр."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "Вы должны указать раздел, параметр и значение для этой подкоманды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Опция `%(option)s` не была обновлена!"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1724,7 +1705,7 @@ msgstr ""
 "Для сохранения изменения используйте `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1732,13 +1713,13 @@ msgstr ""
 "значению по умолчанию."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Параметр `%(option)s` не был сброшен до значения по умолчанию!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1748,17 +1729,17 @@ msgstr ""
 "Чтобы сохранить изменение используйте `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Устаревшая команда, используйте команду config."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Команда опции является устаревшим, используйте команду config."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1767,34 +1748,34 @@ msgstr ""
 "Использование опции обновления будет сканировать кэш для внешних изменений перед отображением деталей."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Указан неверный параметр, используйте информацию: info, update, or clear"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Отключено"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Включено"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Неограниченный"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1810,36 +1791,36 @@ msgstr ""
 "**Cached Now:  %(used)s in %(files)s file(s)."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "Кэш был очищен."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Не удалось** удалить кэш, проверьте журналы для получения дополнительной "
 "информации..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "Не найден кэш для очистки."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Аргумент очереди страницы должен быть целым числом."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1847,12 +1828,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(время неизвестно)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1864,7 +1845,7 @@ msgstr ""
 "Прогресс: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1878,19 +1859,19 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Песни в очереди"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1901,38 +1882,38 @@ msgstr ""
 "Эта команда может быть медленной, если указаны большие диапазоны.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "Неверный параметр. Укажите количество сообщений для поиска."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Нельзя использовать очистку в приватном ЛС канале."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Очищено %(number)s сообщение(ов)."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Бот не имеет разрешения на управление сообщениями."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Сбросить отдельные URL плейлиста в файл."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "Указанный URL не является допустимым URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1942,37 +1923,37 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Похоже, что это не плейлист."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Вот дамп плейлиста для:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Ваш идентификатор пользователя: `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "ID пользователя для `%(username)s`: `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1980,24 +1961,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Допустимые категории: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Ниже приведены идентификаторы ваших запросов:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "Получить список разрешений, или разрешения упомянутого пользователя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2005,12 +1986,12 @@ msgstr ""
 "Неверный ID пользователя или имя сервера, проверьте ID и повторите попытку."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Не удалось определить пользователя discord. Попробуйте еще раз."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2024,7 +2005,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2038,64 +2019,64 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Перезагружает права доступа из файла permissions.ini.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Удалить существующую группу.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Показать текст справки для опции разрешения.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Сохранить группу прав доступа в файл.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Установка значения прав доступа для группы.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Управление конфигурацией permissions.ini из дистрибутива."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 "Права доступа не могут использовать каналы и упоминания пользователей "
 "одновременно."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "Права доступа успешно перезагружены из файла!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2105,7 +2086,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2119,23 +2100,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Вы должны указать название группы или опции для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Вы должны указать группу, опцию и значение для этой команды."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "Субкоманда %(option)s требует имя группы и прав доступа."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2145,25 +2126,25 @@ msgstr ""
 "Доступные группы:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Разрешение `%(option)s` недоступно."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Это право может быть установлено только редактированием файла разрешений."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "По умолчанию это разрешение установлено в: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2177,13 +2158,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Невозможно добавить группу `%(group)s`, она уже существует."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2195,12 +2176,12 @@ msgstr ""
 "Убедитесь, что новая группа сохранена в: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Невозможно удалить встроенную группу."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2210,24 +2191,24 @@ msgstr ""
 "Не забудьте сохранить это изменение с: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Группа владельцев не редактируется."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Не удалось сохранить группу: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Группа успешно сохранена: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2239,13 +2220,13 @@ msgstr ""
 "INI значение файла: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Разрешение `%(option)s` не было обновлено!"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2255,14 +2236,14 @@ msgstr ""
 "Чтобы сохранить изменение, используйте `setperms сохранить %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2271,7 +2252,7 @@ msgstr ""
 "Запомнить, что изменения имени ограничены дважды в час.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2281,23 +2262,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Установить имя бота в `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Изменить псевдоним MusicBot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Невозможно изменить никнейм: нет разрешения."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2307,23 +2288,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Установите ник бота в `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Установите префикс команд для каждого сервера."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Очистить префикс команды для каждого сервера."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2332,25 +2313,25 @@ msgstr ""
 "Сначала должен быть включен параметр EnablePrefixPerGuild"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Пользовательские эмодзи должны быть с этого сервера, чтобы использовать в "
 "качестве префикса."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Префикс команд сервера очищен."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Теперь префикс команд сервера:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2359,39 +2340,39 @@ msgstr ""
 "Используйте команду конфигурации для обновления префикса."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Показать коды языков, доступные для использования.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Сброс языка сервера на язык бота по умолчанию.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "Управление языком, используемым для сообщений на сервере."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Эта команда может быть использована только в гильдиях."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Неверная субкоманда. Используйте команду справки для получения "
 "дополнительной информации."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2405,37 +2386,37 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Не удается установить язык в `%(locale)s`, он недоступен."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Язык для этого сервера теперь установлен в: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Язык для этого сервера был сброшен: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Вы должны указать URL или прикрепить файл."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2445,58 +2426,58 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "Изменил аватар бота."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Принудительно отключиться от сервера discord."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Отключен от сервера`%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Отсоединил голосового клиента без проигрывателя? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Сейчас не подключен к серверу`%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Попытка перезагрузки без перезапуска процесса. Параметр по умолчанию.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr "    Попытка перезапустить весь процесс MusicBot, перезагрузка всего.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Полный перезапуск, но попытаться обновить pip пакеты перед "
 "перезагрузкой.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    Полный перезапуск, но сначала обновите исходный код MusicBot.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2505,7 +2486,7 @@ msgstr ""
 "перезагрузкой.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2518,7 +2499,7 @@ msgstr ""
 "Если у вас есть менеджер служб, мы рекомендуем использовать его вместо этой команды для перезапуска.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2526,19 +2507,19 @@ msgstr ""
 "uppip, или upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s перезапуск текущего экземпляра..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Перезапуск бота..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2546,59 +2527,59 @@ msgstr ""
 "%(emoji)s попытается обновить необходимые pip пакеты и перезапустить бот..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "%(emoji)s попытается обновить бот-код git и перезапустить бот..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s попытается обновить всё и перезапустить бот..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Отсоединитесь от всех голосовых каналов и закройте процесс MusicBot."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Оставить сервер discord, заданный по имени или ID сервера."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Вы должны указать ID или имя."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Не найдено ни одной гильдии с ID или именем `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Неизвестен"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Слева от гильдии: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2607,38 +2588,38 @@ msgstr ""
 "Может использоваться для закрепления событий вручную в файле журнала MusicBot.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Логированная точка останова с ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Просмотр ограниченного вывода objgraph.show_growth().\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Просмотр наиболее распространенных типов утечек объектов.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Оценить заданную функцию и аргументы на обджграфе.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2649,12 +2630,12 @@ msgstr ""
 "Поскольку этот метод вычисляет произвольный код, он считается опасным, как команда отладки.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Не удалось импортировать `objgraph`, он установлен?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2669,7 +2650,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2685,7 +2666,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2694,73 +2675,73 @@ msgstr ""
 "Вывод используется для обновления страниц GitHub и, таким образом, не подходит для нормального использования ссылок."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Подкоманда должна быть одной из %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Делает INI-файлы по умолчанию."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Запрошенный INI-файл сохранен на диск. Проверьте"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Не удалось найти исполняемый файл git."
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "В ветке `%(branch)s` нет обновлений."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Новые коммиты доступны в удаленной ветке `%(branch)s`."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "Ошибка при проверке, смотрите журналы для подробностей."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Обновление для `%(name)s` до версии: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "Обновления для зависимостей не найдены."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "Доступны для скачивания обновления MusicBot."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot полностью актуальен!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2780,20 +2761,20 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 "Отображает время загрузки MusicBot или время с момента последнего "
 "запуска/перезапуска."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s был онлайн для `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
@@ -2801,35 +2782,35 @@ msgstr ""
 "голосовых клиентов."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Отображение задержки API и задержки голоса при подключении MusicBot."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "авто"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**Задержка API:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Отображать номер версии MusicBot в чате."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2839,17 +2820,17 @@ msgstr ""
 "Текущая версия: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Обновите файл cookies.txt, используя файл cookies.txt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Включение или отключение файла cookies.txt без его удаления."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2864,28 +2845,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies уже включены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookies должны быть загружены для включения. (issing cookies файл.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Не удалось включить куки из-за ошибки:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Cookies были включены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2895,12 +2876,12 @@ msgstr ""
 "Cookies временно отключены и будут повторно включены при следующем перезапуске."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Cookies были отключены."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2908,51 +2889,51 @@ msgstr ""
 "cookie."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Ошибка при загрузке файла cookie с дискода:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Не удалось сохранить куки на диске:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies загружены и включены."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "Вы не можете использовать этого бота в личных сообщениях."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Эта команда не разрешена для вашей группы прав:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Эта команда требует, чтобы вы были в голосовом канале."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Команда:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Ошибка исключения"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2962,17 +2943,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "Нет описания.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "Использование не дано."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2986,13 +2967,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Выход голосового канала %(channel)s из-за неактивности."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Левый `%(guild)s` из-за отсутствия владельца бота в нем."
@@ -3575,12 +3556,12 @@ msgstr ""
 "Оставьте пустым для использования по умолчанию, динамически сгенерированных UA строк."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "Вкл/Выкл функцию блокировки списка, не очищая список блоков."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3588,12 +3569,12 @@ msgstr ""
 "пользователя Discord по одному в строке."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "Включить функцию списка блоков песни, не очищая список блоков."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3602,7 +3583,7 @@ msgstr ""
 "Название или URL песни, содержащие любую строку в списке, будут заблокированы."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3611,7 +3592,7 @@ msgstr ""
 "Каждый файл должен содержать список доступных для воспроизведения URL или терминов, по одному треку в строке."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3625,7 +3606,7 @@ msgstr ""
 "Maps to:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3634,7 +3615,7 @@ msgstr ""
 "краткосрочный кэш для воспроизведения."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3646,7 +3627,7 @@ msgstr ""
 "Установите значение 0 для отключения. Максимально допустимое значение %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3659,7 +3640,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3677,7 +3658,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3689,7 +3670,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3711,7 +3692,7 @@ msgstr ""
 "  Двойная проверка правильности, доступный путь к каталогу."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3724,7 +3705,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3737,7 +3718,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3749,7 +3730,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3771,7 +3752,7 @@ msgstr ""
 "  Проверьте папку конфигурации и файлы существуют и могут быть прочитаны MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3795,7 +3776,7 @@ msgstr ""
 "  Скопируйте файл примера из репозитория, если все остальное не удалось."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3815,7 +3796,7 @@ msgstr ""
 "  Установите %(option)s на числовой ID или установите его в `auto` или `0` для автоматической привязки владельца."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3835,7 +3816,7 @@ msgstr ""
 "  Проверьте настройки пути и убедитесь, что файл существует и доступен для MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3855,32 +3836,32 @@ msgstr ""
 "  Убедитесь, что все ID числовые и разделены только пробелами или запятыми."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD не имеет заголовков..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Извлечение информации о треке не дало никаких данных."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Невозможно продолжить извлечение. Цикл события закрыт."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "URL-адрес Spotify недействителен или не поддерживается."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Невозможно провести некорректный URL-адрес."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Локальный медиа-файл не найден."
 
@@ -3903,13 +3884,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Загрузка не удалась из-за ошибки yt-dlp: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "Загрузка не удалась из-за необработанного исключения: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Не удалось извлечь данные для запрошенного носителя."
 
@@ -4079,28 +4060,28 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Не удалось извлечь информацию"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Это плейлист."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Недопустимый тип содержимого `%(type)s` для URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "нет длительности данных"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "нет данных о продолжительности в текущей записи"
 
@@ -4182,21 +4163,21 @@ msgid "Only dev users can use this command."
 msgstr "Только пользователи dev могут использовать эту команду."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4204,13 +4185,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -4222,22 +4203,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4265,61 +4246,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4327,7 +4308,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4337,7 +4318,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4361,40 +4342,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4402,13 +4376,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4427,7 +4401,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4436,7 +4410,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4467,28 +4441,123 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "Поиск YouTube не дал результатов по запросу:  %(url)s"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+#~ "Удалить трек из очереди, по желанию можно в указанной очереди.\n"
+#~ "Если позиция опущена, песня в конце очереди удаляется.\n"
+#~ "Используйте команду очереди, чтобы найти номер позиции вашего трека.\n"
+#~ "Тем не менее, позиции всех песен меняются после начала воспроизведения новой песни.\n"
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr "Управление автоплейлистами и настройками для каждой гильдии."

--- a/i18n/sv_SE/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/sv_SE/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -468,20 +468,20 @@ msgid ""
 msgstr "MusicBot anslutning till röst avbröts. Detta är udda. Kanske omstart?"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot begär att få tala i kanalen: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot har inte behörighet att tala."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot kunde inte begära att få tala."
 
@@ -617,7 +617,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Ställer in URL-historik guild %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Ingen miniatyrbild har angetts för post med URL: %s"
@@ -703,19 +703,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "Loopa över spelare autospellista..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Fel vid bearbetning av låt \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Fel vid extrahering av låt \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot måste stoppa auto spellista utvinning och borgen."
 
@@ -1086,7 +1086,7 @@ msgstr "Lista över gillen:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr " - %s"
@@ -1658,7 +1658,7 @@ msgid "The player is not currently looping."
 msgstr "Spelaren loopar inte för närvarande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Sångpositioner måste vara heltal!"
 
@@ -1681,33 +1681,33 @@ msgid "Local media playback is not enabled."
 msgstr "Lokal medieuppspelning är inte aktiverad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte för närvarande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Upptäckte en Spotify-URL, men Spotify är inte aktiverat."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Du har nått din köade låtgräns (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke-läget är aktiverat, försök igen när det är inaktiverat!"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "Problem med extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1717,12 +1717,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Den videon kan inte spelas. Prova att använda strömkommandot."
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1732,7 +1732,7 @@ msgstr ""
 "%(time_per).2f s/sång"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1741,103 +1741,103 @@ msgstr ""
 "sekunder)"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "Extraherade en post med \"youtube<unk> list\" som utsugningsnyckel"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Sånglängden överskrider gränsen (%(length)s > %(max)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "Lade till låt(ar) på position %s"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "Kan inte uppskatta tid innan du spelar för position: %d"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "Misslyckades att hämta information från strömningsförfrågan: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Streaming av spellistor stöds ännu inte."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Du har nått din gräns för spellistans objekt (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr "Ange en sökfråga. Använd `help search` för mer information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Du kan inte söka efter mer än %(max)s videor"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "Väntar på stämningslås: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "Kallelselås som förvärvats för: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "Du är inte ansluten till röst. Försök att ansluta till en röstkanal!"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "Ansluter till %(guild)s/%(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot kan inte följa en användare som inte är medlem i servern."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Spelaren spelar inte."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Ingenting i kön att ta bort!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Ingenting hittades i kön från användaren `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1846,38 +1846,38 @@ msgstr ""
 "Du måste vara den som köade det eller har omedelbar hoppa över behörigheter."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Ogiltigt postnummer. Använd kökommandot för att hitta köpositioner."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Kan inte hoppa över! Spelaren spelar inte!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "Du har inte behörighet att tvinga hoppa över en loopad låt."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Du har inte behörighet att tvinga hopp."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Du har inte behörighet att hoppa över en loopad låt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` är inte ett giltigt tal"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1887,14 +1887,14 @@ msgstr ""
 "Volymen kan endast ändras från 1 till 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Orimlig volym angiven: %(volume)s. Ange ett värde mellan 1 och 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1903,29 +1903,29 @@ msgstr ""
 "Använd konfigurationskommandot för att ställa in en standard uppspelningshastighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Hastighet kan inte tillämpas på strömmade medier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Du måste ange en hastighet att ställa in."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Hastigheten du angav är ogiltig. Använd ett nummer mellan 0,5 och 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Ogiltigt alternativ för kommandot: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1935,28 +1935,28 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Du måste tillhandahålla ett alias och ett kommando till alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Du måste ange ett alias namn för att ta bort."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` finns inte."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Konfigurationen kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1966,7 +1966,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1975,17 +1975,17 @@ msgstr ""
 "undervisnings- och alternativnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Det alternativ som anges är tvetydigt, ange ett avsnittsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "Du måste ange ett namn och alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1995,32 +1995,32 @@ msgstr ""
 "De tillgängliga sektionerna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Alternativet `%(option)s` är inte tillgängligt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "Alternativet `%(option)s` är inte redigerbart. Kan inte spara till disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Kunde inte spara alternativet: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Alternativ `%(option)s` är inte redigerbar, värde kan inte visas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2028,25 +2028,25 @@ msgstr ""
 "inställningen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Du måste ange ett avsnitt, alternativ och värde för detta underkommando."
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Gör set med på %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Alternativet `%(option)s` uppdaterades inte!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2054,46 +2054,46 @@ msgstr ""
 "standard."
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Återställer %(config)s till standard %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Alternativet `%(option)s` återställdes inte till standard!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Alternativkommandot är föråldrat, använd kommandot config istället."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Ogiltigt alternativ angivet, användning: info, uppdatering eller rensa"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Misslyckades** att ta bort cache, kolla loggar för mer information..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Kö sida argument måste vara ett heltal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Det finns inga låtar köade! Köa något med ett spelkommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2103,24 +2103,24 @@ msgstr ""
 "Det finns **%(total)s** sidor."
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "Hoppade över den aktuella spellistposten."
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "Inte tillräckligt med poster för att paginera kön."
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Kunde inte posta kömeddelande, inget meddelande att lägga till reaktioner "
 "på."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2129,17 +2129,17 @@ msgstr ""
 "Om problemet kvarstår, skicka in en felrapport."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Kan inte använda rensning på privat DM-kanal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "Den angivna URL:en var inte en giltig URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2149,12 +2149,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Detta verkar inte vara en spellista."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2163,17 +2163,17 @@ msgstr ""
 "försök igen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Kunde inte bestämma discord-användaren. Försök igen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Behörigheter kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2183,23 +2183,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Du måste ange ett grupp- eller alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Du måste ange en grupp, alternativ och värde för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s underkommandot kräver ett grupp- och behörighetsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2209,47 +2209,47 @@ msgstr ""
 "De tillgängliga grupperna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Behörigheten `%(option)s` är inte tillgänglig."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Kan inte lägga till grupp `%(group)s` det finns redan."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Kan inte ta bort inbyggd grupp."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Ägargruppen är inte redigerbar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Det gick inte att spara gruppen: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Gör set på %(option)s med värde: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Behörighet `%(option)s` uppdaterades inte!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2258,7 +2258,7 @@ msgstr ""
 "Kom ihåg att namnändringar är begränsade till två gånger per timme.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2268,12 +2268,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Det går inte att ändra smeknamn: ingen behörighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2283,13 +2283,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Anpassad emoji måste vara från den här servern för att använda som prefix."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2298,29 +2298,29 @@ msgstr ""
 "Använd konfigurationskommandot för att uppdatera prefixet istället."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Detta kommando kan endast användas i guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Ogiltigt underkommando ges. Använd hjälpkommandot för mer information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Kan inte ställa in språk till `%(locale)s` det är inte tillgängligt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Du måste ange en URL eller bifoga en fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2330,19 +2330,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot hittade en %s utan guild! Detta kan vara ett problem."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Inte ansluten till servern `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2350,44 +2350,44 @@ msgstr ""
 "eller upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Du måste ange ett ID eller namn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Ingen guild hittades med ID eller namn `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Aktivera debug brytpunkt ID: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Kunde inte importera `objgraph`, är det installerat?"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "Felsökningskoden gick med eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "Felsökningskoden kördes med körning()."
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "Felsökningskoden misslyckades att köra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2403,55 +2403,55 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Underkommando måste vara ett av: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Kunde inte lokalisera git körbar."
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "Det gick inte att söka efter uppdateringar via git-kommandot."
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Paket saknar meta i pip rapport."
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr "Det gick inte att hämta pip-uppdateringsstatus på grund av något fel."
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "Har en konstig röstklient post."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies har redan aktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Cookies måste laddas upp för att kunna aktiveras. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Kunde inte aktivera cookies på grund av fel:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2461,7 +2461,7 @@ msgstr ""
 "Cookies tillfälligt inaktiverade och kommer att aktiveras igen vid nästa omstart."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2469,178 +2469,178 @@ msgstr ""
 "cookie-fil."
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "Kunde inte ta bort gamla, inaktiverade cookiefil:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Fel vid nedladdning av cookie-filen från diskett:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Kunde inte spara kakor till disk:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Har ett meddelande utan kanal, på något sätt:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorerar kommando från mig själv (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignorerar kommando från annan bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignorerar kommando från kanal av typ:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 "Användare i blocklistan: %(id)s/%(name)s  försökte kommando: %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Meddelande från %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Detta kommando är inte tillåtet för din behörighetsgrupp:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Detta kommando kräver att du är i en röstkanal."
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "Ogiltig kommandoanvändning, saknade värden för parametrar: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Fel i %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Undantag vid hantering av kommando: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Kan inte generera hjälp för saknat kommando:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Saknar hjälpdata för kommandot:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Lämnar röstkanal %s i %s på grund av inaktivitet."
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot har blivit ansluten."
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot har blivit frånkopplad."
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Har ett uttag:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "Rösttillstånd uppdaterat innan on_ready finished"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorerar %s i %s eftersom det är en bunden röstkanal."
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s har upptäckts som tom. Hantering av timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "En användare anslöt till %s, avbryter timer."
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "Botten blev flyttad och röstkanalen %s är tom. Hantering av timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Botten blev flyttad och röstkanalen %s är inte tom."
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "Följer inte längre %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Följande användare `%(user)s` till kanal:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "Röststaten kopplar ifrån innan kanalen är ingen."
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2650,98 +2650,98 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 "Kan inte använda auto-join-kanal med typ: %(type)s  i guild:  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 "Kan inte hitta den automatiskt anslöta kanalen, togs den bort? Guild:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Återansluter till auto-anslöt guild i kanalen:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Kan inte ansluta till kanalen:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Bot har lagts till i guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Vänster guild '%s' på grund av bot ägaren hittades inte."
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Skapar datamapp för guild %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Bot har tagits bort från guild: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "Uppdaterad guild-lista:"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Guild \"%s\" har blivit tillgänglig."
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Återupptar spelare i \"%s\" på grund av tillgänglighet."
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Guild \"%s\" har inte blivit tillgänglig."
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausa spelare i \"%s\" på grund av otillgänglighet."
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Guild uppdatering för:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Guild-attribut %(attr)s är nu: %(new)s  -- Var: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Kanaluppdatering för:  %(channel)s  --  %(changes)s"
@@ -2759,7 +2759,7 @@ msgid "Loading config from:  %s"
 msgstr "Laddar konfiguration från:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2789,7 +2789,7 @@ msgstr ""
 "  Använd exempelalternativen som mall eller kopiera den från förrådet."
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2799,7 +2799,7 @@ msgstr ""
 "begränsas istället."
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2808,7 +2808,7 @@ msgstr ""
 " rotation av loggfilen. Använder standard istället."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2827,12 +2827,12 @@ msgstr ""
 "  Kontrollera att sökvägen du har konfigurerat är en sökväg till en mapp / katalog."
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Ett undantag kastades vid validering av AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2854,13 +2854,13 @@ msgstr ""
 "  Dubbelkolla inställningen är giltig, sökväg för tillgänglig katalog."
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Ljudcache kommer att lagras i:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2880,7 +2880,7 @@ msgstr ""
 "  Ställ in konfigurationsalternativet eller ange miljövariabeln %(env_var)s med en app-token."
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2889,7 +2889,7 @@ msgstr ""
 "till 128 tecken."
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2899,17 +2899,17 @@ msgstr ""
 "Alternativvärdet för %.3f kommer att vara begränsat istället."
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "Validerar alternativ med tjänstdata..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "Förvärvad ägar-ID via API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2930,12 +2930,12 @@ msgstr ""
 "  Ställ Manuellt in 'OwnerID' konfigurationsalternativet eller försök igen senare."
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot har ingen användarinstans, kan inte fortsätta."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2954,12 +2954,12 @@ msgstr ""
 "  Använd inte Bot eller App ID i fältet 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "Kan inte hitta konfigurationsalternativ. Kontrollerar alternativ ..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2969,18 +2969,18 @@ msgstr ""
 " filtillägg."
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Kopierar existerande exempelfil:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr "Något gick fel när du försökte hitta en konfigurationsalternativsfil."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3002,7 +3002,7 @@ msgstr ""
 "  Verifiera konfigurationsmappen och filerna finns och kan läsas av MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3026,13 +3026,13 @@ msgstr ""
 "  Kopiera exempelfilen från repo om allt annat misslyckas."
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 "Dev Bug! Konfigurationsalternativet har getter som inte är tillgängligt."
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3041,43 +3041,43 @@ msgstr ""
 "måste vara samma typ."
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "Alternativet saknades tidigare."
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Konfigurationssektion inte i tolkad konfiguration! saknas: %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Sparad konfigurationsalternativ: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Det gick inte att spara konfigurationen:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 "Alternativnamn är inte unika mellan INI-sektioner! Lösaren är inaktiverad."
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Misslyckades att spara standard-INI-filen på:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3097,7 +3097,7 @@ msgstr ""
 "  sätt %(option)s till ett numeriskt ID eller sätt det till `auto` eller `0` för automatisk ägarbindning."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3117,7 +3117,7 @@ msgstr ""
 "  Kontrollera sökvägsinställningen och se till att filen finns och är tillgänglig för MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3137,7 +3137,7 @@ msgstr ""
 "  Se till att alla ID är numeriska, och separeras endast med mellanslag eller kommatecken."
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3147,7 +3147,7 @@ msgstr ""
 "nivå: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3157,7 +3157,7 @@ msgstr ""
 "'%(value)s' som använder standard istället."
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3167,7 +3167,7 @@ msgstr ""
 "(%(value)s) och kommer istället att sättas till %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3175,50 +3175,50 @@ msgstr ""
 "Döper om INI-filpost [%(old_s)s] > %(old_o)s  till [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "Uppgraderar konfigurationsfilen med bytt namn på alternativ..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Det gick inte att uppgradera konfigurationen. Du måste uppgradera den "
 "manuellt."
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Blocklistefil hittades inte:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Kunde inte ladda blocklistan från filen:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Kunde inte uppdatera blocklistefilen:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Laddad lista över användarblock med %s poster."
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Vi hittade en gammal svartlistad fil, den kommer att döpas om till:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Laddade en Låtblockslista med %s poster."
@@ -3279,39 +3279,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Tvinga YTDLP att använda användaragenten:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot kommer att använda cookies för yt-dlp från:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp kommer att använda din konfigurerade proxyserver."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD verkar inte ha några rubriker..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr "Det gick inte att kontrollera mediahuvuden på grund av timeout."
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Misslyckad begäran om HEAD för:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "undantag för HEAD begäran: "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3321,56 +3321,56 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Sanitized YTDL extraktionsinformation (ej JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Song info extrahering returnerade inga data."
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Kallas extrah_info med: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Kan inte köra extraktion, loop är stängd. (Detta är normalt vid "
 "avstängningar.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Kan inte fortsätta extraktionen, händelseslingan är stängd."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte."
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "Fel vid nedladdning med ström-URL"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "Anta att innehållet är en direkt ström"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Kan inte strömma en ogiltig URL."
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3378,23 +3378,23 @@ msgstr ""
 "utrymme."
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Kallas safe_extract_info med:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Den lokala mediefilen kunde inte hittas."
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Saknar __input_subject från YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3402,7 +3402,7 @@ msgstr ""
 "undvika detta."
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Varning, varaktighet fel för: %(url)s"
@@ -4686,13 +4686,13 @@ msgstr ""
 "Sök efter ffmpeg med din systempakethanterare eller bygg från källkod."
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "Mindre än %sMB ledigt utrymme kvar på denna enhet"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4701,12 +4701,12 @@ msgstr ""
 "Söker efter uppdateringar till MusicBot eller beroenden..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "Inga MusicBot uppdateringar tillgängliga via `git`-kommandot."
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -4715,23 +4715,23 @@ msgstr ""
 "manuellt."
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "Följande paket kan uppdateras:\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  till version:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "Inga beroendeuppdateringar tillgängliga via `pip`-kommandot."
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -4740,7 +4740,7 @@ msgstr ""
 "manuellt."
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4750,35 +4750,35 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "Värdet är över den maximala gränsen."
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "Värdet får inte vara negativt."
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "Värdet för Max Loggar Kept måste vara ett tal från 0 till %s"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "Loggnivå '%s' är inte tillgänglig."
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "Loggnivå måste vara en av:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -4787,39 +4787,39 @@ msgstr ""
 "ffmpeg."
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "Tillgänglig via Github:"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr "För mer hjälp och stöd med denna bot, gå med i vår diskotek:"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "Denna programvara tillhandahålls under MIT-licensen."
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "Se 'LICENSE' textfil för fullständiga detaljer."
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr "Åsidosätt standard/systemet upptäckt språk för all text i MusicBot."
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 "Använd detta språk för alla serversidiga loggmeddelanden från MusicBot."
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4828,28 +4828,28 @@ msgstr ""
 "Detta hindrar inte val av språk per guild."
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "Skriv ut information om MusicBot versionen och avsluta."
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 "Hoppa över alla valfria startkontroller, inklusive uppdateringskontrollen."
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "Hoppa över endast diskutrymme kontroll vid start."
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "Hoppa över endast uppdateringskontrollen vid start."
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -4858,7 +4858,7 @@ msgstr ""
 "importera dem."
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4868,7 +4868,7 @@ msgstr ""
 "(Standard: %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
@@ -4876,7 +4876,7 @@ msgstr ""
 "vara en av: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4886,42 +4886,42 @@ msgstr ""
 "bör innehålla värden som är kompatibla med strftime(). (Standard: '%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "Version:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "Öppnade en ny MusicBot instans. Denna terminal kan stängas säkert!"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Laddar MusicBot version:  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Loggen öppnad:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Byter arbetskatalog till:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4931,7 +4931,7 @@ msgstr ""
 "hitta `musicbot` och` . den` mappar för att verifiera en ny katalogplats."
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4940,7 +4940,7 @@ msgstr ""
 "Om du inte använde git för att klona utvecklingskatalogen, är du starkt uppmanad."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4949,12 +4949,12 @@ msgstr ""
 "avslutar."
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "Här är det exakta felet, det kan vara en bugg."
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4963,7 +4963,7 @@ msgstr ""
 "kan du öppna den misslyckade webbplatsen i Microsoft Edge eller IE...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -4972,17 +4972,17 @@ msgstr ""
 "certifi istället."
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Syntaxfel (ändring upptäcktes, har du redigerat koden?)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Syntaxfel (detta är en bugg, inte ditt fel)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5003,12 +5003,12 @@ msgstr ""
 "  eller starta utan `--no-install-deps` och MusicBot kommer att försöka installera dem åt dig."
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "Försöker installera MusicBot beroendepaket automatiskt...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5044,57 +5044,43 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, låt hoppas installera beroenden fungerade!"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"MusicBot fick ett ImportError efter att ha försökt installera paket. "
-"MusicBot måste avslutas..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "Undantaget som orsakade ovanstående fel: "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot gör en mjuk omstart..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot gör en fullständig process omstart..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "Fel vid start av bot"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "Stänger händelseloop."
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Startar om %s sekunder..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "Allt klart."
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "OK, vi stänger!"
 
@@ -5115,31 +5101,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5153,7 +5139,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5213,7 +5199,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5444,24 +5430,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5508,25 +5494,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5534,66 +5520,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5620,7 +5560,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5632,25 +5572,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5663,29 +5603,145 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "MusicBot fick ett ImportError efter att ha försökt installera paket. "
+#~ "MusicBot måste avslutas..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "Undantaget som orsakade ovanstående fel: "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/sv_SE/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/sv_SE/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -156,7 +156,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "Ohanterat undantag för uppgiften:  %(task)r --  %(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify gav oss inte ett token. Inaktivering."
 
@@ -175,63 +175,43 @@ msgstr ""
 "Kunde inte starta Spotify-klienten. Är ditt klient-ID och hemligt korrekt? "
 "Detaljer: %s. Fortsätter ändå om 5 sekunder..."
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-"Konfigurationen hade inte Spotify-app-autentiseringsuppgifter som försökte "
-"använda gästläge."
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "Autentiseras med Spotify framgångsrikt med gästläge."
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr "Kunde inte starta Spotify-klienten med gästläge. Detaljer: %s."
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "Initierades, ansluter nu till disharmoni."
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "Testet för nätverkspolning är inaktiverat via konfiguration."
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "Testet för nätverkspolning stängs ner."
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "Kunde inte lösa ping mål."
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "Test av nätverkspolning avbruten."
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "Nätverkstestning via HTTP har ingen session att låna."
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "Kunde inte hitta `ping` körbar i din omgivning."
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -245,7 +225,7 @@ msgstr ""
 "Alternativt inaktivera nätverkskontroll via config."
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -259,7 +239,7 @@ msgstr ""
 "Alternativt inaktivera nätverkskontroll via config."
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -273,28 +253,28 @@ msgstr ""
 "Alternativt inaktivera nätverkskontroll via config."
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "MusicBot upptäckt nätverk är tillgängligt igen."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "VoiceClient är inte ansluten, väntar på att återuppta MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "Återuppspelning av spelare: (%(guild_id)s) %(player)r"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot upptäckte ett nätverksavbrott."
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -303,7 +283,7 @@ msgstr ""
 "%(player)r"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -313,12 +293,12 @@ msgstr ""
 "%(owner)s"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "Söker efter kanaler för att automatiskt gå med eller återuppta..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
@@ -326,13 +306,13 @@ msgstr ""
 "%(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Hittade återupptagbar röstkanal:  %(channel)s  i guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
@@ -340,120 +320,120 @@ msgstr ""
 "kanalen:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "Hittade ägare i röstkanalen:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr "Ignorerar återupptagbar kanal, AutoSummon till ägare i kanalen:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr "Ignorerar Auto-Join kanal, AutoSummon till ägare i kanalen:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Redan ansluten till kanalen:  %(channel)s  i guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "Försöker gå med i kanalen:  %(channel)s  i guild:  %(guild)s"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "Kasta MusicPlayer och göra en ny..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot kommer att göra en ny MusicPlayer nu..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr "Inte anslöt till %(guild)s/%(channel)s, det stöds inte röstkanalen."
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "Avslutade anslutningar konfigurerade kanaler."
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Medlemmen är inte röstaktiverad och kan inte använda detta kommando."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Du kan inte använda detta kommando när du inte är i röstkanalen."
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "Få bot Application Info."
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "MusicBot har inte behörighet att ansluta i kanalen:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot har inte behörighet att ansluta i kanalen: `%(name)s`"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "MusicBot har inte behörighet att tala i kanalen:  %s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot har inte behörighet att tala i kanalen: `%(name)s`"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "Återanvänder robotar VoiceClient från guild:  %s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "Tvingar frånkoppling på inaktuell röstklient i guild:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "Kopplingen misslyckades eller avbröts?"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "MusicBot kan inte ansluta till kanalen just nu:  %(channel)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -462,12 +442,12 @@ msgstr ""
 "Försök igen senare, eller starta om boten om detta fortsätter."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot har en röstklient nu..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -477,53 +457,53 @@ msgstr ""
 "ansluta till:  %(channel)s"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr "MusicBot VoiceClient anslutningsförsök avbröts. Inget försök."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr "MusicBot anslutning till röst avbröts. Detta är udda. Kanske omstart?"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot begär att få tala i kanalen: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot har inte behörighet att tala."
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot kunde inte begära att få tala."
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "Kopplar från en musikspelare i guild:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "Koppla från VoiceClient innan vi dödar musikspelaren."
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "Kopplingen misslyckades eller avbröts."
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -532,18 +512,18 @@ msgstr ""
 "ändå..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "Kopplar från en oseriös röstklient i guild:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "Kopplar bort en icke-guild röstklient..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -553,20 +533,20 @@ msgstr ""
 "Objektet är faktiskt av typ:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 "Vi har fortfarande en MusicPlayer ref i guild (%(guild_id)s):  %(player)r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "Guild (%(guild)s) vill ha en spelare, frivillig:  %(player)r"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -575,24 +555,24 @@ msgstr ""
 "om boten."
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer har en röstklient som inte är ansluten."
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "Musikspelarobjekt:  %r"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "VoiceClient obj:  %r"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -602,7 +582,7 @@ msgstr ""
 " %(create)s  Deserialize:  %(serial)s"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -612,7 +592,7 @@ msgstr ""
 "poster"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -621,85 +601,85 @@ msgstr ""
 "Använd kommandot för att föra botten till din röstkanal."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Något är fel, vi fick inte röstklienten."
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "Körs på"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "Ställer in URL-historik guild %(guild_id)s == %(url)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "Ingen miniatyrbild har angetts för post med URL: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "ingen kanal att lägga nu spela upp meddelandet i"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "ignorerade nu-spela meddelande som det redan var publicerat."
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "Kör på_player_fortsätt"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "Körs på"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "Kör på_player_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "Körs på"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "Händelseslingan är stängd, inget annat att göra här."
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "Logga ut på gång, ignorera denna händelse."
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 "VoiceClient säger att det inte är anslutet, inget annat vi kan göra här."
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "Spelaren är klar och kön är tom, lämnar röstkanalen..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr "Loopa över kön för att expunge låtar med saknad författare..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -708,291 +688,291 @@ msgstr ""
 "%(song)s"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr "Inga spelbara låtar i Guilds autospelslista inaktiveras."
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "Inget innehåll i aktuell autospellista. Fyller med ny musik..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "Loopa över spelare autospellista..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "Fel vid bearbetning av låt \"%(url)s\":  %(raw_error)s"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "Fel vid extrahering av låt \"%(url)s\": %(raw_error)s"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot måste stoppa auto spellista utvinning och borgen."
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr "MusicBot fick ett ohanterat undantag i spelarens färdiga händelse."
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr "Expanderar automatisk spellista med poster extraherade från:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "Det gick inte att lägga till låt från autospellista: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "Undantag data för ovanstående fel:"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "Inga spelbara låtar i autospelarlistan inaktiveras."
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "Kör på_player_entry_added"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr "Hoppar över automatisk spellista automatiskt för köad post."
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "Musikspelare undantag för post: %r"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "Musikspelare undantag."
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "Det gick inte att spela upp låten automatiskt spellista:  %r"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "Logga ut pågår, ignorerar statusuppdateringshändelsen."
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "Uppdatera botstatus:  %(status)s -- %(activity)r"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "Serialiserar kö för %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "Deserialiserar kö för %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "Skriver aktuell låt för %s"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "Kan inte skicka icke-svarsobjekt:  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Försökte skicka ett ogiltigt svarsobjekt."
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "skickar inbäddad till: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "skicka text till: %s"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "Kan inte skicka meddelande till \"%s\", ingen behörighet"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "Kan inte skicka meddelande till \"%s\", ogiltig eller raderad kanal"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr "Meddelandet är över meddelandets storleksgräns (%s)"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr "Kunde inte skicka privat meddelande, skicka i reservkanal istället."
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr "Betygsätt begränsat skicka meddelande, försöker igen om %s sekunder."
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "Avbrutet meddelande försök igen för:  %s"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "Betygsätt begränsat skicka meddelande, men kan inte försöka igen!"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "Det gick inte att skicka meddelande i reservkanal."
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "Det gick inte att skicka på grund av ett HTTP-fel."
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "Kan inte ta bort meddelandet \"%s\", ingen behörighet"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "Kan inte ta bort meddelandet \"%s\", meddelandet hittades inte"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr "Betygsätt begränsat meddelande ta bort, försöker igen om %s sekunder."
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "Betygsätt begränsat meddelande ta bort, men kan inte försöka igen!"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "Det gick inte att ta bort meddelandet"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "Fick HTTPException försöker ta bort meddelandet: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "Kan inte redigera meddelandet \"%s\", meddelandet hittades inte"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "Skickar meddelande istället"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 "Betygsätt begränsat redigeringsmeddelande, försöker igen om %s sekunder."
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "Avbröt meddelanderedigering för:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "Det gick inte att redigera meddelandet"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "Fick HTTPException försöker redigera meddelandet %s till: %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "Avbruten borttagning av meddelande (ID: %(id)s):  %(content)s"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "Fångade en signal från OS: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "Koppla bort och stänga MusicBot..."
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "Undantag kastas medan hanteringen avbryter signalen!"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot gör nu avstängningssteg..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1015,44 +995,44 @@ msgstr ""
 "  Kontrollera API-status på den officiella webbplatsen: discordstatus.com"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "Väntar på nedladdningstrådar för att slutföra..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr "Väntar på uppgift:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr "Kommer att försöka avbryta uppgiften:  %(name)s  (%(func)s)"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "Väntar på väntande uppgifter..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "Stänger HTTP Connector."
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "Stänger aiohttp session."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "Utloggning har kallats."
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1062,81 +1042,81 @@ msgstr ""
 "%(error)s"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "Undantag i %s"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot återupptog en session med oenighet."
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "Slutför"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "Inloggad, nu blir MusicBot klar..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "KlientAnvändaren är på något sätt ingen, vi måste borgen..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "MusicBot:  %(id)s/%(name)s#%(desc)s"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr "Ägare:     %(id)s/%(name)s#%(desc)s\n"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "Lista över gillen:"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr " - %s"
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "Vänster %s på grund av bot ägaren hittades inte"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 "Fortsätter inte med kontroller på %s servrar på grund av otillgänglighet"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr "Ägare kunde inte hittas på någon guild (id: %s)\n"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "Ägare okänd, bot är inte på några guilds."
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1150,250 +1130,250 @@ msgstr ""
 "  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "Har ingen för bunden kanal med ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "Kan inte binda till icke meddelandebar kanal med ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "Bundna till textkanaler:"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr " - %(guild)s/%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "Inte bunden till någon textkanal"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "Har ingen för automatisk anslutning kanal med ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 "Kan inte automatiskt ansluta till en Privat/Icke-Guild kanal med ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 "Kan inte automatiskt ansluta till icke-anslutningsbar kanal med ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "Automatisk anslutning av röstkanaler:"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "Inte automatiskt gå med i några röstkanaler"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "Händelse på _ready har avfyrat %s gånger"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "Hämtar applikationsinformation."
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "Det finns säkra datamappar"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "Validerar konfiguration"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "Validerar behörighetskonfiguration"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "Inaktiverad"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "Aktiverad"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "Alternativ:"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "  Kommando prefix: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "  Standardvolym: %d%%"
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "  Hoppa över tröskel: %(num)d röster eller %(percent).0f%%"
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "  Nu spelas @mentions: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr "  Auto-spellista: %(status)s (ordning: %(order)s)"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "slumpmässigt"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "sekventiell"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "  Automatisk paus: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "  Ta bort meddelanden: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "    Ta bort inbjudan: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    Ta bort nu spela: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "  Felsökningsläge: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "  Nedladdade låtar kommer att vara %s"
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "    Radera om oanvänd för %d dagar"
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "  Statusmeddelande: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "  Spotify-integrering: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "    Tidsåtgång: %s sekunder"
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "    Timeout: %d sekunder"
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "  Självdöv: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "  Prefix för kommandon per server: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "  Runda Robin Kö: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 "Den efterfrågade låten `%(subject)s` blockeras av listan över låtblock."
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 "Försök att hantera röstkanalens inaktivitet, men Bot är inte i röst..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "Kanalaktivitet väntar redan i guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1401,31 +1381,31 @@ msgstr ""
 "Kanalaktivitet väntar %(time)d sekunder för att lämna kanalen: %(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr "Kanalaktivitet timer för %s har löpt ut. Kopplar från."
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "Timer för kanalaktivitet avbryts för: %(channel)s i %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "Ignorerar spelarinaktivitet i auto-anslöt kanal:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "Spelarens aktivitets timer väntar redan i guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1434,137 +1414,137 @@ msgstr ""
 "%(channel)s"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr "Spelarens aktivitets timer för %s har löpt ut. Kopplar från."
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 "Tidtagaren för spelarens aktivitet avbryts för: %(channel)s i %(guild)s"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "Spelarens aktivitet timer återställs."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Inget sådant kommando"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "Du måste ange en användare eller ange deras ID-nummer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Ogiltigt underkommando angivet. Använd `help blockuser` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot kunde inte hitta de användare du angav."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Ägaren kan inte läggas till i blocklistan."
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 "Lägger inte till användare i blocklistan, redan blockerad:  %(id)s/%(name)s"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 "Tar inte bort användare från blocklistan, inte listad:  %(id)s/%(name)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Kan inte lägga till de användare du listade, de är redan tillagda."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "Du måste ange ett låtämne om ingen låt spelas just nu."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Ogiltigt underkommando angivet. Använd `help blocksong` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Ämne `%(subject)s` finns redan i listan över låtblock."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "Ämnet finns inte i listan över låtblock och kan inte tas bort."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Ogiltigt underkommando angivet. Använd `help autoplaylist` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Länk till medföljande låt är ogiltig"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "Kön är tom. Lägg till några låtar med ett låtkommando!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Den här låten finns redan i autospellistan."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Den här låten finns ännu inte med i autospellistan."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Du måste ange ett filnamn för spellistan."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Du har inte behörighet att begära spellistor"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "Spellistan har för många poster (%(songs)s men max är %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1576,12 +1556,12 @@ msgstr ""
 "Gränsen är %(max)s för din grupp."
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "Ignorerar automatisk paus på grund av nätverksavbrott."
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1590,12 +1570,12 @@ msgstr ""
 "bearbeta automatisk paus."
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "Behandlar redan automatisk paus, ignorerar denna händelse."
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1605,58 +1585,58 @@ msgstr ""
 "guild:  %s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "Auto-paus väntar avbröts."
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 "En ny MusicPlayer håller på att anslutas och ignorerar gamla auto-paus-"
 "händelser."
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr "Spelar i en tom röstkanal, kör automatisk paus för guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "Tidigare automatisk pausad spelare avpausar för guild: %s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Kan inte använda söka om det inte finns något att spela."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Kan inte använda sökningen på nuvarande spår, den har en okänd varaktighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Sökandet stöds inte för strömmar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "Kan inte använda söka utan tid för att placera uppspelning."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Kunde inte konvertera `%(input)s` till en giltig tid i sekunder."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1666,29 +1646,29 @@ msgstr ""
 "spåret med en längd av `%(progress)s / %(total)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Ogiltigt underkommando. Använd kommandot `help repeat` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Spelaren loopar inte för närvarande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Sångpositioner måste vara heltal!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Du gav en position utanför spellistan storlek!"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
@@ -1696,38 +1676,38 @@ msgstr ""
 " till reaktioner på."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Lokal medieuppspelning är inte aktiverad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte för närvarande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Upptäckte en Spotify-URL, men Spotify är inte aktiverat."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Du har nått din köade låtgräns (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke-läget är aktiverat, försök igen när det är inaktiverat!"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "Problem med extract_info(): "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1737,15 +1717,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Den videon kan inte spelas. Prova att använda strömkommandot."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "YouTube-sökning gav inga resultat för:  %(url)s"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1852,18 +1826,18 @@ msgid "Player is not playing."
 msgstr "Spelaren spelar inte."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Ingenting i kön att ta bort!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Ingenting hittades i kön från användaren `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1872,38 +1846,38 @@ msgstr ""
 "Du måste vara den som köade det eller har omedelbar hoppa över behörigheter."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Ogiltigt postnummer. Använd kökommandot för att hitta köpositioner."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Kan inte hoppa över! Spelaren spelar inte!"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "Du har inte behörighet att tvinga hoppa över en loopad låt."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Du har inte behörighet att tvinga hopp."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Du har inte behörighet att hoppa över en loopad låt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` är inte ett giltigt tal"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1913,14 +1887,14 @@ msgstr ""
 "Volymen kan endast ändras från 1 till 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Orimlig volym angiven: %(volume)s. Ange ett värde mellan 1 och 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1929,29 +1903,29 @@ msgstr ""
 "Använd konfigurationskommandot för att ställa in en standard uppspelningshastighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Hastighet kan inte tillämpas på strömmade medier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Du måste ange en hastighet att ställa in."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Hastigheten du angav är ogiltig. Använd ett nummer mellan 0,5 och 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Ogiltigt alternativ för kommandot: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1961,28 +1935,28 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Du måste tillhandahålla ett alias och ett kommando till alias"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Du måste ange ett alias namn för att ta bort."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` finns inte."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Konfigurationen kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1992,7 +1966,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2001,17 +1975,17 @@ msgstr ""
 "undervisnings- och alternativnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Det alternativ som anges är tvetydigt, ange ett avsnittsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "Du måste ange ett namn och alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2021,32 +1995,32 @@ msgstr ""
 "De tillgängliga sektionerna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Alternativet `%(option)s` är inte tillgängligt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "Alternativet `%(option)s` är inte redigerbart. Kan inte spara till disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Kunde inte spara alternativet: `%(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Alternativ `%(option)s` är inte redigerbar, värde kan inte visas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -2054,25 +2028,25 @@ msgstr ""
 "inställningen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Du måste ange ett avsnitt, alternativ och värde för detta underkommando."
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "Gör set med på %(config)s == %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Alternativet `%(option)s` uppdaterades inte!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -2080,46 +2054,46 @@ msgstr ""
 "standard."
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "Återställer %(config)s till standard %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Alternativet `%(option)s` återställdes inte till standard!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Alternativkommandot är föråldrat, använd kommandot config istället."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Ogiltigt alternativ angivet, användning: info, uppdatering eller rensa"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Misslyckades** att ta bort cache, kolla loggar för mer information..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Kö sida argument måste vara ett heltal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Det finns inga låtar köade! Köa något med ett spelkommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2129,24 +2103,24 @@ msgstr ""
 "Det finns **%(total)s** sidor."
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "Hoppade över den aktuella spellistposten."
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "Inte tillräckligt med poster för att paginera kön."
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 "Kunde inte posta kömeddelande, inget meddelande att lägga till reaktioner "
 "på."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2155,17 +2129,17 @@ msgstr ""
 "Om problemet kvarstår, skicka in en felrapport."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Kan inte använda rensning på privat DM-kanal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "Den angivna URL:en var inte en giltig URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2175,12 +2149,12 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Detta verkar inte vara en spellista."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2189,17 +2163,17 @@ msgstr ""
 "försök igen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Kunde inte bestämma discord-användaren. Försök igen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Behörigheter kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2209,23 +2183,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Du måste ange ett grupp- eller alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Du måste ange en grupp, alternativ och värde för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s underkommandot kräver ett grupp- och behörighetsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2235,47 +2209,47 @@ msgstr ""
 "De tillgängliga grupperna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Behörigheten `%(option)s` är inte tillgänglig."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Kan inte lägga till grupp `%(group)s` det finns redan."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Kan inte ta bort inbyggd grupp."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Ägargruppen är inte redigerbar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Det gick inte att spara gruppen: `%(group)s`"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "Gör set på %(option)s med värde: %(value)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Behörighet `%(option)s` uppdaterades inte!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2284,7 +2258,7 @@ msgstr ""
 "Kom ihåg att namnändringar är begränsade till två gånger per timme.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2294,12 +2268,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Det går inte att ändra smeknamn: ingen behörighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2309,13 +2283,13 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Anpassad emoji måste vara från den här servern för att använda som prefix."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2324,29 +2298,29 @@ msgstr ""
 "Använd konfigurationskommandot för att uppdatera prefixet istället."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Detta kommando kan endast användas i guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Ogiltigt underkommando ges. Använd hjälpkommandot för mer information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Kan inte ställa in språk till `%(locale)s` det är inte tillgängligt."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Du måste ange en URL eller bifoga en fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2356,19 +2330,19 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot hittade en %s utan guild! Detta kan vara ett problem."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Inte ansluten till servern `%(guild)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2376,44 +2350,44 @@ msgstr ""
 "eller upgit"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Du måste ange ett ID eller namn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Ingen guild hittades med ID eller namn `%(input)s`"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "Aktivera debug brytpunkt ID: %(uuid)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Kunde inte importera `objgraph`, är det installerat?"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "Felsökningskoden gick med eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "Felsökningskoden kördes med körning()."
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "Felsökningskoden misslyckades att köra."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2429,55 +2403,55 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Underkommando måste vara ett av: %(options)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Kunde inte lokalisera git körbar."
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "Det gick inte att söka efter uppdateringar via git-kommandot."
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Paket saknar meta i pip rapport."
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr "Det gick inte att hämta pip-uppdateringsstatus på grund av något fel."
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "Har en konstig röstklient post."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies har redan aktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Cookies måste laddas upp för att kunna aktiveras. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Kunde inte aktivera cookies på grund av fel:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2487,7 +2461,7 @@ msgstr ""
 "Cookies tillfälligt inaktiverade och kommer att aktiveras igen vid nästa omstart."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2495,178 +2469,178 @@ msgstr ""
 "cookie-fil."
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "Kunde inte ta bort gamla, inaktiverade cookiefil:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Fel vid nedladdning av cookie-filen från diskett:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Kunde inte spara kakor till disk:  %(raw_error)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "Har ett meddelande utan kanal, på något sätt:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "Ignorerar kommando från mig själv (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "Ignorerar kommando från annan bot (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "Ignorerar kommando från kanal av typ:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 "Användare i blocklistan: %(id)s/%(name)s  försökte kommando: %(command)s"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "Meddelande från %(id)s/%(name)s: %(message)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Detta kommando är inte tillåtet för din behörighetsgrupp:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Detta kommando kräver att du är i en röstkanal."
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "Ogiltig kommandoanvändning, saknade värden för parametrar: %(params)r"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "Fel i %(command)s: %(err_name)s: %(err_text)s"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "Undantag vid hantering av kommando: %(command)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "Kan inte generera hjälp för saknat kommando:  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "Saknar hjälpdata för kommandot:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr "Lämnar röstkanal %s i %s på grund av inaktivitet."
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot har blivit ansluten."
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot har blivit frånkopplad."
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "Har ett uttag:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "Rösttillstånd uppdaterat innan on_ready finished"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "Ignorerar %s i %s eftersom det är en bunden röstkanal."
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s har upptäckts som tom. Hantering av timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "En användare anslöt till %s, avbryter timer."
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "Botten blev flyttad och röstkanalen %s är tom. Hantering av timeouts."
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "Botten blev flyttad och röstkanalen %s är inte tom."
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "Följer inte längre %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "Följande användare `%(user)s` till kanal:  %(channel)s"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "Röststaten kopplar ifrån innan kanalen är ingen."
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2676,98 +2650,98 @@ msgstr ""
 "%(code)s) [S:%(state)s]"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 "Kan inte använda auto-join-kanal med typ: %(type)s  i guild:  %(guild)s"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 "Kan inte hitta den automatiskt anslöta kanalen, togs den bort? Guild:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "Återansluter till auto-anslöt guild i kanalen:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "Kan inte ansluta till kanalen:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "Bot har lagts till i guild: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "Vänster guild '%s' på grund av bot ägaren hittades inte."
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "Skapar datamapp för guild %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "Bot har tagits bort från guild: %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "Uppdaterad guild-lista:"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "Guild \"%s\" har blivit tillgänglig."
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "Återupptar spelare i \"%s\" på grund av tillgänglighet."
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "Guild \"%s\" har inte blivit tillgänglig."
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "Pausa spelare i \"%s\" på grund av otillgänglighet."
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "Guild uppdatering för:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "Guild-attribut %(attr)s är nu: %(new)s  -- Var: %(old)s"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "Kanaluppdatering för:  %(channel)s  --  %(changes)s"
@@ -2785,7 +2759,7 @@ msgid "Loading config from:  %s"
 msgstr "Laddar konfiguration från:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2815,7 +2789,7 @@ msgstr ""
 "  Använd exempelalternativen som mall eller kopiera den från förrådet."
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2825,7 +2799,7 @@ msgstr ""
 "begränsas istället."
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -2834,7 +2808,7 @@ msgstr ""
 " rotation av loggfilen. Använder standard istället."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2853,12 +2827,12 @@ msgstr ""
 "  Kontrollera att sökvägen du har konfigurerat är en sökväg till en mapp / katalog."
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "Ett undantag kastades vid validering av AudioCachePath."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2880,13 +2854,13 @@ msgstr ""
 "  Dubbelkolla inställningen är giltig, sökväg för tillgänglig katalog."
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "Ljudcache kommer att lagras i:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2906,7 +2880,7 @@ msgstr ""
 "  Ställ in konfigurationsalternativet eller ange miljövariabeln %(env_var)s med en app-token."
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -2915,7 +2889,7 @@ msgstr ""
 "till 128 tecken."
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2925,17 +2899,17 @@ msgstr ""
 "Alternativvärdet för %.3f kommer att vara begränsat istället."
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "Validerar alternativ med tjänstdata..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "Förvärvad ägar-ID via API"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2956,12 +2930,12 @@ msgstr ""
 "  Ställ Manuellt in 'OwnerID' konfigurationsalternativet eller försök igen senare."
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot har ingen användarinstans, kan inte fortsätta."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2980,12 +2954,12 @@ msgstr ""
 "  Använd inte Bot eller App ID i fältet 'OwnerID'."
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "Kan inte hitta konfigurationsalternativ. Kontrollerar alternativ ..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2995,18 +2969,18 @@ msgstr ""
 " filtillägg."
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "Kopierar existerande exempelfil:  %(example_file)s"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr "Något gick fel när du försökte hitta en konfigurationsalternativsfil."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3028,7 +3002,7 @@ msgstr ""
 "  Verifiera konfigurationsmappen och filerna finns och kan läsas av MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3052,13 +3026,13 @@ msgstr ""
 "  Kopiera exempelfilen från repo om allt annat misslyckas."
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 "Dev Bug! Konfigurationsalternativet har getter som inte är tillgängligt."
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3067,43 +3041,43 @@ msgstr ""
 "måste vara samma typ."
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "Alternativet saknades tidigare."
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "Konfigurationssektion inte i tolkad konfiguration! saknas: %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "Sparad konfigurationsalternativ: %(config)s  =  %(value)s"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "Det gick inte att spara konfigurationen:  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 "Alternativnamn är inte unika mellan INI-sektioner! Lösaren är inaktiverad."
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "Misslyckades att spara standard-INI-filen på:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3123,7 +3097,7 @@ msgstr ""
 "  sätt %(option)s till ett numeriskt ID eller sätt det till `auto` eller `0` för automatisk ägarbindning."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3143,7 +3117,7 @@ msgstr ""
 "  Kontrollera sökvägsinställningen och se till att filen finns och är tillgänglig för MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3163,7 +3137,7 @@ msgstr ""
 "  Se till att alla ID är numeriska, och separeras endast med mellanslag eller kommatecken."
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3173,7 +3147,7 @@ msgstr ""
 "nivå: %(fallback)s"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3183,7 +3157,7 @@ msgstr ""
 "'%(value)s' som använder standard istället."
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3193,7 +3167,7 @@ msgstr ""
 "(%(value)s) och kommer istället att sättas till %(fallback)s."
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3201,143 +3175,143 @@ msgstr ""
 "Döper om INI-filpost [%(old_s)s] > %(old_o)s  till [%(new_s)s] > %(new_o)s"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "Uppgraderar konfigurationsfilen med bytt namn på alternativ..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 "Det gick inte att uppgradera konfigurationen. Du måste uppgradera den "
 "manuellt."
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "Blocklistefil hittades inte:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "Kunde inte ladda blocklistan från filen:  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "Kunde inte uppdatera blocklistefilen:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "Laddad lista över användarblock med %s poster."
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 "Vi hittade en gammal svartlistad fil, den kommer att döpas om till:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "Laddade en Låtblockslista med %s poster."
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "Kan inte ladda data för guild med ID 0. Detta är sannolikt ett fel i koden!"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "Ingen fil för guild %(id)s/%(name)s"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "Laddar guild-data för guild med ID:  %(id)s/%(name)s"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "Ett OS-fel förhindrat läsning av guild datafil:  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr "Guild %(id)s/%(name)s har anpassat kommandoprefix: %(prefix)s"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "Kan inte spara data för guild med ID 0. Detta är sannolikt ett fel i koden!"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr "Kunde inte spara guild-specifika data på grund av OS-fel."
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 "Det gick inte att serialisera guild specifik data på grund av ogiltiga data."
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "Tvinga YTDLP att använda användaragenten:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot kommer att använda cookies för yt-dlp från:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp kommer att använda din konfigurerade proxyserver."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD verkar inte ha några rubriker..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr "Det gick inte att kontrollera mediahuvuden på grund av timeout."
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "Misslyckad begäran om HEAD för:  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "undantag för HEAD begäran: "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3347,56 +3321,56 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "Sanitized YTDL extraktionsinformation (ej JSON):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Song info extrahering returnerade inga data."
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "Kallas extrah_info med: '%(subject)s', %(args)s, %(kws)s"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 "Kan inte köra extraktion, loop är stängd. (Detta är normalt vid "
 "avstängningar.)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Kan inte fortsätta extraktionen, händelseslingan är stängd."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte."
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "Fel vid nedladdning med ström-URL"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "Anta att innehållet är en direkt ström"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Kan inte strömma en ogiltig URL."
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
@@ -3404,23 +3378,23 @@ msgstr ""
 "utrymme."
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "Kallas safe_extract_info med:  %(args)s, %(kws)s"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Den lokala mediefilen kunde inte hittas."
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "Saknar __input_subject från YtdlpResponseDict"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
@@ -3428,7 +3402,7 @@ msgstr ""
 "undvika detta."
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "Varning, varaktighet fel för: %(url)s"
@@ -3475,12 +3449,12 @@ msgstr ""
 "Postnamn:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr "Inmatningsdata saknar versionsnummer, kan inte deserialisera."
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr "Inmatningsdata har fel versionsnummer, kan inte deserialiseras."
 
@@ -3511,7 +3485,7 @@ msgstr ""
 "uppslag!"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "Kunde inte ladda %s"
@@ -3523,7 +3497,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr "Kan inte ladda ner Spotify-länkar, bearbetningsfel med typ: %(type)s"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "Gör dig redo för inmatning:  %r"
@@ -3545,7 +3519,7 @@ msgid "Download already cached at:  %s"
 msgstr "Nedladdningen är redan cachad på:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3563,7 +3537,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "Fick en varaktighet på %(time)s sekunder för filen:  %(file)s"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3574,75 +3548,75 @@ msgstr ""
 "fungera, men kommer att innebära att dina spår inte kommer att utjämnas."
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "Undantag vid kontroll av postdata."
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "Försöker få varaktighet via pymediainfo för:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "Det gick inte att få varaktighet via pymediainfo."
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "Försöker få varaktighet via ffprobe för:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "Kunde inte hitta ffprobe i din sökväg!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe returnerade något som inte kunde användas."
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "ffprobe kunde inte utföras av någon anledning."
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "Beräknar medelvolym av:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "Kunde inte hitta ffmpeg på din sökväg!"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "Kunde inte tolka 'jag' i normalisera json."
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "Kunde inte tolka 'LRA' i normalisera json."
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "Kunde inte tolka \"TP\" i normalisera json."
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "Kunde inte tolka 'thresh' i normalisera json."
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "Kunde inte tolka 'offset' i normalisera json."
 
@@ -3686,55 +3660,55 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Nedladdning misslyckades på grund av ett yt-dlp fel: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "Extraktion stötte på ett ohanterat undantag."
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 "Nedladdning misslyckades på grund av ett ohanterat undantag: %(raw_error)s"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "Hämtning misslyckades:  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Det gick inte att extrahera data för de begärda medierna."
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "Nedladdning slutförd:  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserialized StreamPlaylistEntry kan inte hitta kanal med ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized StreamPlaylistEntry har fel kanaltyp:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "Deserialized StreamPlaylistEntry kan inte hitta författare med ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
@@ -3742,26 +3716,26 @@ msgstr ""
 "uppslag!"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry kan inte hitta kanal med ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr "Deserialized LocalFilePlaylistEntry har fel kanaltyp:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 "Deserialized LocalFilePlaylistEntry kan inte hitta författare med ID:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -3770,7 +3744,7 @@ msgstr ""
 " uppslag!"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "Fick en varaktighet på %(seconds)s sekunder för filen:  %(file)s"
@@ -3880,20 +3854,20 @@ msgstr ""
 "Ny: %(new)s"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Lang Argument fel:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
 "Det gick inte att läsa in loggöversättningar för någon av:  [%s]  i:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4224,63 +4198,63 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "Avkodad data från ffmpeg: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "Lägger till strömpost för URL:  %(url)s"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Kunde inte extrahera information"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Detta är en spellista."
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr "Inmatningsinformation verkar vara en ström, lägger till ström post..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Ogiltig innehållstyp `%(type)s` för URL: %(url)s"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "Fick text/html för innehållstyp, detta kan vara en ström."
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "Otvivelaktig innehållstyp \"%(type)s\" för url:  %(url)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "Lägger till URLPlaylistEntry för: %(subject)s"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "Lägger till LocalFilePlaylistEntry för: %(subject)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "Ignorerade video från sammansatt spellista länk med ID:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4289,7 +4263,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4297,7 +4271,7 @@ msgstr ""
 "Ignorerar låt i poster av '%s', varaktighet längre än tillåtet maximalt."
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4305,40 +4279,40 @@ msgstr ""
 "raderad:  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "Kunde inte lägga till objekt"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "Föremål: %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "Hoppade över %s dåliga poster"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "Ordna om looping över poster."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "Ladda ner nästa låt:  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "ingen varaktighet data"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "ingen varaktighet i aktuell post"
 
@@ -4912,42 +4886,42 @@ msgstr ""
 "bör innehålla värden som är kompatibla med strftime(). (Standard: '%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "Version:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "Öppnade en ny MusicBot instans. Denna terminal kan stängas säkert!"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "Laddar MusicBot version:  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "Loggen öppnad:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "Byter arbetskatalog till:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4957,7 +4931,7 @@ msgstr ""
 "hitta `musicbot` och` . den` mappar för att verifiera en ny katalogplats."
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4966,7 +4940,7 @@ msgstr ""
 "Om du inte använde git för att klona utvecklingskatalogen, är du starkt uppmanad."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -4975,12 +4949,12 @@ msgstr ""
 "avslutar."
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "Här är det exakta felet, det kan vara en bugg."
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4989,7 +4963,7 @@ msgstr ""
 "kan du öppna den misslyckade webbplatsen i Microsoft Edge eller IE...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -4998,17 +4972,17 @@ msgstr ""
 "certifi istället."
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "Syntaxfel (ändring upptäcktes, har du redigerat koden?)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "Syntaxfel (detta är en bugg, inte ditt fel)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5029,12 +5003,12 @@ msgstr ""
 "  eller starta utan `--no-install-deps` och MusicBot kommer att försöka installera dem åt dig."
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "Försöker installera MusicBot beroendepaket automatiskt...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5070,12 +5044,12 @@ msgstr ""
 "  https://discord.gg/bots"
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "OK, låt hoppas installera beroenden fungerade!"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5084,58 +5058,58 @@ msgstr ""
 "MusicBot måste avslutas..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "Undantaget som orsakade ovanstående fel: "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot gör en mjuk omstart..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot gör en fullständig process omstart..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "Fel vid start av bot"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "Stänger händelseloop."
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "Startar om %s sekunder..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "Allt klart."
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "OK, vi stänger!"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -5160,12 +5134,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -5179,7 +5153,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -5247,45 +5221,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -5297,220 +5271,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5529,30 +5503,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5560,18 +5534,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5646,9 +5620,90 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+#~ "Konfigurationen hade inte Spotify-app-autentiseringsuppgifter som försökte "
+#~ "använda gästläge."
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "Autentiseras med Spotify framgångsrikt med gästläge."
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr "Kunde inte starta Spotify-klienten med gästläge. Detaljer: %s."
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "YouTube-sökning gav inga resultat för:  %(url)s"
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/sv_SE/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/sv_SE/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -799,7 +799,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr "Det finns inga låtar köade. Spela något med ett play-kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "Sångpositioner måste vara heltal!"
 
@@ -837,28 +837,28 @@ msgid "Local media playback is not enabled."
 msgstr "Lokal medieuppspelning är inte aktiverad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte för närvarande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Upptäckte en Spotify-URL, men Spotify är inte aktiverat."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Du har nått din köade låtgräns (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke-läget är aktiverat, försök igen när det är inaktiverat!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -868,12 +868,12 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Den videon kan inte spelas. Prova att använda strömkommandot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -882,7 +882,7 @@ msgstr ""
 "sekunder)"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -892,13 +892,13 @@ msgstr ""
 "Position i kö: %(position)s"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr "Sånglängden överskrider gränsen (%(length)s > %(max)s)"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -908,24 +908,24 @@ msgstr ""
 "Position i kön: %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "Spelar nästa!"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "%(position)s - uppskattad tid till att spela: `%(eta)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr "%(position)s - kan inte uppskatta tiden innan du spelar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -938,23 +938,23 @@ msgstr ""
 "Obs: FFmpeg kan släppa strömmen slumpmässigt eller om anslutning hicka händer.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "Streaming av spellistor stöds ännu inte."
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "Nu strömmande spår `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr "    Sök med tjänst för ett antal resultat med sökfrågan.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -963,58 +963,58 @@ msgstr ""
 "    Obs: dubbelcitat krävs i detta fall.\n"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr "Du har nått din gräns för spellistans objekt (%(max)s)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr "Ange en sökfråga. Använd `help search` för mer information."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "Du kan inte söka efter mer än %(max)s videor"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "Söker efter videor..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "Sökning misslyckades på grund av ett fel: %(error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "Inga videor hittades."
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "För att välja en låt, skriv in motsvarande nummer."
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr "Sökresultat från %(service)s:"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "**%(index)s**. **%(track)s** <unk> %(length)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -1023,194 +1023,194 @@ msgstr ""
 "**0**. Avbryt"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "Välj en låt"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr "Lade till låt [%(track)s](%(url)s) till kön."
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "Resultat %(number)s i %(total)s: %(url)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "Okej, kommer rakt upp!"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "Visa information om vad som spelas just nu."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "Nu spelas"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "Strömmar just nu:"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "Spelar just nu:"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "Tillagd av:"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "Förlopp:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Det finns inga låtar köade! Köa något med ett spelkommando."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "Säg till MusicBot att gå med i kanalen du är i."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "Du är inte ansluten till röst. Försök att ansluta till en röstkanal!"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "Ansluten till `%(channel)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr "Gör MusicBot att följa en användare när de byter kanal på en server.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "Följer inte längre användaren `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr "Nu följer användaren `%(user)s` mellan röstkanaler."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot kan inte följa en användare som inte är medlem i servern."
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr "Följer användaren `%(user)s` mellan röstkanaler."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "Pausa uppspelning om en låt spelas upp."
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "Pausad musik i `%(channel)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "Spelaren spelar inte."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "Återuppspelning om spelaren tidigare var pausad."
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "Återupptagen musik i `%(channel)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "Återupptagen musikkö"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "Spelaren är inte pausad."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "Blanda alla aktuella spår i kön."
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "Blandade alla låtar i kön."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "Tar bort alla låtar i kön."
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "Rensade alla låtar från kön."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "Ingenting i kön att ta bort!"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Tog bort `%(track)s` tillagd av `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Ingenting hittades i kön från användaren `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1219,24 +1219,24 @@ msgstr ""
 "Du måste vara den som köade det eller har omedelbar hoppa över behörigheter."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Ogiltigt postnummer. Använd kökommandot för att hitta köpositioner."
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Tog bort post `%(track)s` tillagd av `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Tog bort post `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1247,23 +1247,23 @@ msgstr ""
 "Om LegacySkip -alternativet är aktiverat kan kraftparametern ignoreras.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "Kan inte hoppa över! Spelaren spelar inte!"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "Nästa låt `%(track)s` laddas ner, vänligen vänta."
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "Nästa låt kommer att spelas inom kort. Vänligen vänta."
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1272,7 +1272,7 @@ msgstr ""
 "Du kanske vill starta om boten om den inte börjar fungera."
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1281,28 +1281,28 @@ msgstr ""
 "Du kanske vill starta om boten om den inte börjar fungera."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "Du har inte behörighet att tvinga hoppa över en loopad låt."
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Tvinga hoppad `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "Du har inte behörighet att tvinga hopp."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "Du har inte behörighet att hoppa över en loopad låt."
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1312,12 +1312,12 @@ msgstr ""
 "Omröstningen att hoppa över har passerats.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " Nästa låt kommer!"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1327,7 +1327,7 @@ msgstr ""
 "Behöver **%(votes)s** fler röster för att hoppa över denna låt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1338,25 +1338,25 @@ msgstr ""
 "Volyminställningen behålls tills MusicBot startas om.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Nuvarande volym: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` är inte ett giltigt tal"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Uppdaterad volym från **%(old)d** till **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1366,14 +1366,14 @@ msgstr ""
 "Volymen kan endast ändras från 1 till 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Orimlig volym angiven: %(volume)s. Ange ett värde mellan 1 och 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1384,7 +1384,7 @@ msgstr ""
 "Uppspelning av strömning stöder inte hastighetsjusteringar.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1393,35 +1393,35 @@ msgstr ""
 "Använd konfigurationskommandot för att ställa in en standard uppspelningshastighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "Hastighet kan inte tillämpas på strömmade medier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "Du måste ange en hastighet att ställa in."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Hastigheten du angav är ogiltig. Använd ett nummer mellan 0,5 och 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Ställer in uppspelningshastighet till `%(speed).3f` för nuvarande spår."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Lägg till ett nytt alias med valfria argument.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1430,23 +1430,23 @@ msgstr ""
 "hjälpkommandot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Ogiltigt alternativ för kommandot: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "Alias laddade om från konfigurationsfilen."
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "Alias sparade i konfigurationsfilen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1456,40 +1456,40 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "Du måste tillhandahålla ett alias och ett kommando till alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nytt alias tillagt. `%(alias)s` är nu ett alias av `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "Du måste ange ett alias namn för att ta bort."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` finns inte."
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` togs bort."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    Visar hjälptext om eventuella saknade konfigurationsalternativ.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1498,32 +1498,32 @@ msgstr ""
 "konfigurationsfilen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr "    Lista tillgängliga konfigurationsalternativ och deras sektioner.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Ladda om filen options.ini från disk.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Visar hjälptext för ett specifikt alternativ.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    Visa det aktuella värdet av alternativet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Sparar det aktuella värdet till alternativfilen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1532,32 +1532,32 @@ msgstr ""
 " inte filen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    Återställ alternativet till dess standardvärde.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Hantera options.ini konfiguration inifrån Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Konfigurationen kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*Alla konfigurationsalternativ är närvarande och redovisas för!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "Inga konfigurationsalternativ verkar ändras."
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1567,7 +1567,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1583,12 +1583,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "Konfigurationsalternativ laddades om från filen framgångsrikt!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1598,7 +1598,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1607,17 +1607,17 @@ msgstr ""
 "undervisnings- och alternativnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Det alternativ som anges är tvetydigt, ange ett avsnittsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "Du måste ange ett namn och alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1627,26 +1627,26 @@ msgstr ""
 "De tillgängliga sektionerna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Alternativet `%(option)s` är inte tillgängligt."
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Det här alternativet kan bara ställas in genom att redigera "
 "konfigurationsfilen."
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Som standard är detta alternativ inställt på: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1660,32 +1660,32 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "Alternativet `%(option)s` är inte redigerbart. Kan inte spara till disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Kunde inte spara alternativet: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Alternativet sparades framgångsrikt: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Alternativ `%(option)s` är inte redigerbar, värde kan inte visas."
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1697,7 +1697,7 @@ msgstr ""
 "INI filvärde: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1705,19 +1705,19 @@ msgstr ""
 "inställningen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Du måste ange ett avsnitt, alternativ och värde för detta underkommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Alternativet `%(option)s` uppdaterades inte!"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1727,7 +1727,7 @@ msgstr ""
 "För att spara ändringen använd `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1735,13 +1735,13 @@ msgstr ""
 "standard."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Alternativet `%(option)s` återställdes inte till standard!"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1751,17 +1751,17 @@ msgstr ""
 "För att spara ändringen använd `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "Föråldrat kommando, använd kommandot config istället."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Alternativkommandot är föråldrat, använd kommandot config istället."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1770,34 +1770,34 @@ msgstr ""
 "Genom att använda uppdateringsalternativet kommer att skanna cachen efter externa ändringar innan detaljer visas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Ogiltigt alternativ angivet, användning: info, uppdatering eller rensa"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "Inaktiverad"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "Aktiverad"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s dagar"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "Obegränsad"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1813,23 +1813,23 @@ msgstr ""
 "**Cached nu:  %(used)s i %(files)s fil(er)."
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "Cachen har rensats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Misslyckades** att ta bort cache, kolla loggar för mer information..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "Ingen cache hittades att rensa."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1838,12 +1838,12 @@ msgstr ""
 "Valfritt sidnummer visar senare poster i kön.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "Kö sida argument måste vara ett heltal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1853,12 +1853,12 @@ msgstr ""
 "Det finns **%(total)s** sidor."
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(okänd tid)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1870,7 +1870,7 @@ msgstr ""
 "Framsteg: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1884,12 +1884,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "Låtar i kö"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1898,7 +1898,7 @@ msgstr ""
 "Om problemet kvarstår, skicka in en felrapport."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1909,38 +1909,38 @@ msgstr ""
 "Detta kommando kan vara långsamt om större intervall anges.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "Ogiltig parameter. Ange ett antal meddelanden att söka."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "Kan inte använda rensning på privat DM-kanal."
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Rensade upp %(number)s meddelande(er)."
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "Bot har inte behörighet att hantera meddelanden."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Dumpa de enskilda webbadresserna i en spellista till en fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "Den angivna URL:en var inte en giltig URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1950,18 +1950,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "Detta verkar inte vara en spellista."
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Här är spellistan dumpa för:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1970,19 +1970,19 @@ msgstr ""
 "Detta kommando är föråldrat till förmån för utvecklarläge i Discord-klienter.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Ditt användar-ID är `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "Användar-ID för `%(username)s` är `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1993,18 +1993,18 @@ msgstr ""
 "Detta kommando är föråldrat till förmån för att använda Utvecklarläge i Discord-klienter.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Giltiga kategorier: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "Här är de ID du begärt:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
@@ -2012,7 +2012,7 @@ msgstr ""
 "användaren."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2021,12 +2021,12 @@ msgstr ""
 "försök igen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "Kunde inte bestämma discord-användaren. Försök igen."
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2040,7 +2040,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2054,62 +2054,62 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Visa laddade grupper och listbehörighetsalternativ.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Laddar om behörigheter från permissions.ini filen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    Lägg till ny grupp med standardinställningar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    Ta bort befintlig grupp.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    Visa hjälptext för behörighetsalternativet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Visa behörighetsvärde för given grupp och behörighet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    Spara behörighetsgrupp till fil.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    Ange behörighetsvärde för gruppen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Hantera behörighet.ini konfiguration inifrån diskord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Behörigheter kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "Behörigheter laddades om från filen framgångsrikt!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2119,7 +2119,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2133,23 +2133,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "Du måste ange ett grupp- eller alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Du måste ange en grupp, alternativ och värde för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s underkommandot kräver ett grupp- och behörighetsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2159,25 +2159,25 @@ msgstr ""
 "De tillgängliga grupperna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Behörigheten `%(option)s` är inte tillgänglig."
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Denna behörighet kan bara ställas in genom att redigera behörighetsfilen."
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Som standard är den här behörigheten satt till: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2191,13 +2191,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Kan inte lägga till grupp `%(group)s` det finns redan."
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2209,12 +2209,12 @@ msgstr ""
 "Se till att spara den nya gruppen med: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "Kan inte ta bort inbyggd grupp."
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2224,24 +2224,24 @@ msgstr ""
 "Se till att spara denna ändring med: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "Ägargruppen är inte redigerbar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Det gick inte att spara gruppen: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Gruppen sparades framgångsrikt: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2253,13 +2253,13 @@ msgstr ""
 "INI filvärde: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Behörighet `%(option)s` uppdaterades inte!"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2269,7 +2269,7 @@ msgstr ""
 "För att spara ändringen använd `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2278,7 +2278,7 @@ msgstr ""
 "Obs: API:et kan begränsa namnändringar till två gånger per timme."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2287,7 +2287,7 @@ msgstr ""
 "Kom ihåg att namnändringar är begränsade till två gånger per timme.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2297,23 +2297,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Ange botens användarnamn till `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "Ändra MusicBots smeknamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "Det går inte att ändra smeknamn: ingen behörighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2323,23 +2323,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Sätt botens smeknamn till `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    Ange ett prefix för kommandot per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    Rensa kommandoprefixet per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2348,24 +2348,24 @@ msgstr ""
 "Alternativet EnablePrefixPerGuild måste aktiveras först."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Anpassad emoji måste vara från den här servern för att använda som prefix."
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "Server-kommandoprefixet är rensat."
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Serverkommandoprefix är nu:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2374,38 +2374,38 @@ msgstr ""
 "Använd konfigurationskommandot för att uppdatera prefixet istället."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    Visa språkkoder tillgängliga att använda.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    Ange önskat språk för den här servern.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Återställ serverspråket till botens standardspråk.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "Hantera språket som används för meddelanden i samtalsservern."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "Detta kommando kan endast användas i guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Ogiltigt underkommando ges. Använd hjälpkommandot för mer information."
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2419,25 +2419,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Kan inte ställa in språk till `%(locale)s` det är inte tillgängligt."
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Språk för denna server nu satt till: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Språk för den här servern har återställts till: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2446,12 +2446,12 @@ msgstr ""
 "Att koppla en fil och utelämna url-parametern fungerar.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "Du måste ange en URL eller bifoga en fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2461,58 +2461,58 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "Ändrade botens avatar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Tvinga MusicBot att koppla från discord-servern."
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Frånkopplad från servern `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Kopplade från en spellös röstklient? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Inte ansluten till servern `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Försök att ladda om utan processens omstart. Standardalternativet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr "    Försök att starta om hela MusicBot processen, ladda om allt.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Fullständig omstart, men försök att uppdatera pip-paket innan omstart.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Fullständig omstart, men uppdatera MusicBot källkod med git först.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2520,7 +2520,7 @@ msgstr ""
 "    Försök att uppdatera alla beroenden och källkod innan den startas om.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2533,7 +2533,7 @@ msgstr ""
 "Om du har en servicehanterare, rekommenderar vi att du använder den istället för detta kommando för omstart.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2541,19 +2541,19 @@ msgstr ""
 "eller upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Startar om aktuell instans..."
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Startar om botprocessen..."
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2561,7 +2561,7 @@ msgstr ""
 "%(emoji)s Försöker uppgradera nödvändiga pip-paket och starta om boten..."
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
@@ -2569,23 +2569,23 @@ msgstr ""
 "boten..."
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Kommer att försöka uppgradera allt och starta om boten..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Koppla från alla röstkanaler och avsluta MusicBot-processen."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Lämna discord-servern med namn eller server-ID."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2594,12 +2594,12 @@ msgstr ""
 "Namnen är skiftlägeskänsliga, så att använda ett ID-nummer är mer tillförlitligt.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "Du måste ange ett ID eller namn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Ingen guild hittades med ID eller namn `%(input)s`"
@@ -2611,13 +2611,13 @@ msgid "Unknown"
 msgstr "Okänd"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Lämnade guilden: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2626,38 +2626,38 @@ msgstr ""
 "Kan användas för att manuellt identifiera händelser i MusicBot loggfilen.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Loggad brytpunkt med ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Visa de vanligaste typerna som rapporterats av objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Visa begränsad objgraph.show_growth() utgång.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Visa de vanligaste typerna av läckande objekt.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Visa typvärden för läckande objekt.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Utvärdera den givna funktionen och argumenten på objektgrafen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2668,12 +2668,12 @@ msgstr ""
 "Eftersom denna metod utvärderar godtycklig kod anses den vara farlig som debug kommandot.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Kunde inte importera `objgraph`, är det installerat?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2698,7 +2698,7 @@ msgstr ""
 "Faran med detta kommando kan inte underskattas. Använd den inte eller ge tillgång till den om du inte förstår riskerna!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2714,7 +2714,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2723,23 +2723,23 @@ msgstr ""
 "Utgången används för att uppdatera GitHub sidor och är därmed olämplig för normal referensanvändning."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Underkommando måste vara ett av: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "Gör standard INI-filer."
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Sparade den begärda INI-filen till disk. Gå och kontrollera den"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2748,50 +2748,50 @@ msgstr ""
 "eller beroenden.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "Kunde inte lokalisera git körbar."
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Inga uppdateringar i grenen `%(branch)s` fjärrkontroll."
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nya commits finns i `%(branch)s` branch remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "Fel vid kontroll, se loggar för detaljer."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Uppdatering för `%(name)s` till version: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "Inga uppdateringar för beroenden hittades."
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "Det finns uppdateringar för MusicBot tillgängliga för nedladdning."
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot är helt uppdaterad!"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2811,53 +2811,53 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "Visar MusicBot upptid, eller tid sedan senaste start / omstart."
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s har varit online för `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 "Visa latensinformation för Discord API och alla anslutna röstklienter."
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "Inga röstklienter anslutna.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Visa API-latens och röstfördröjning om MusicBot är ansluten."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "automatiskt"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "Visa MusicBot versionsnummer i chatten."
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2867,17 +2867,17 @@ msgstr ""
 "Aktuell version: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Uppdatera cookies.txt-filen med hjälp av en cookies.txt-bilaga."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Aktivera eller inaktivera cookies.txt-fil utan att ta bort den."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2902,29 +2902,29 @@ msgstr ""
 "  funktion om du inte förstår hur man undviker riskerna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookies har redan aktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Cookies måste laddas upp för att kunna aktiveras. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Kunde inte aktivera cookies på grund av fel:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Cookies har aktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2934,12 +2934,12 @@ msgstr ""
 "Cookies tillfälligt inaktiverade och kommer att aktiveras igen vid nästa omstart."
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Cookies har inaktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2947,51 +2947,51 @@ msgstr ""
 "cookie-fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Fel vid nedladdning av cookie-filen från diskett:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Kunde inte spara kakor till disk:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies uppladdade och aktiverade."
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "Du kan inte använda denna bot i privata meddelanden."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Detta kommando är inte tillåtet för din behörighetsgrupp:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "Detta kommando kräver att du är i en röstkanal."
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Kommando:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "Fel vid undantag"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3001,17 +3001,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "Ingen beskrivning angiven.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "Ingen användning angiven."
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3025,13 +3025,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Lämnar röstkanal %(channel)s på grund av inaktivitet."
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Vänster `%(guild)s` på grund av att bot ägaren inte hittas i den."
@@ -3154,7 +3154,7 @@ msgstr ""
 "Används endast när BindToChannels saknar ett ID för en server."
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3235,14 +3235,14 @@ msgstr ""
 "Du kan ställa in detta från 0 till 1, eller 0% till 100%."
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 "Tillåt MusicBot att hålla nedladdade medier, eller ta bort det direkt."
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3252,7 +3252,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3260,7 +3260,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3274,7 +3274,7 @@ msgid "Mention the user who added the song when it is played."
 msgstr "Nämn användaren som lagt till låten när den spelas."
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3283,7 +3283,7 @@ msgstr ""
 "startar."
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3292,12 +3292,12 @@ msgstr ""
 "när kön är tom."
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "Blanda automatiskt spellista spår innan du spelar dem."
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3306,7 +3306,7 @@ msgstr ""
 "Detta gäller endast för den aktuella låten om den lades till av auto spellista."
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3363,7 +3363,7 @@ msgstr ""
 "För närvarande gäller inte detta alternativ för automatisk spellista eller låtar som lagts till i en tom kön."
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3392,7 +3392,7 @@ msgstr ""
 " {p0_url}      = Spår-URL för den nuvarande uppspelningslåten."
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 "Om aktiverad, kommer statusmeddelanden att rapportera information om pausade"
@@ -3401,7 +3401,7 @@ msgstr ""
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3439,7 +3439,7 @@ msgstr ""
 "kön."
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3448,7 +3448,7 @@ msgstr ""
 "spellistan."
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr "Visa konfigurationsinställningar för MusicBot i loggarna vid start."
 
@@ -3463,7 +3463,7 @@ msgstr ""
 "hoppar över."
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3495,14 +3495,14 @@ msgid "Completely remove the footer from embeds."
 msgstr "Ta helt bort sidfoten från bäddar."
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 "MusicBot kommer automatiskt att döva sig själv när du går in i en röstkanal."
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3513,7 +3513,7 @@ msgstr ""
 "Lyssnare är kanalmedlemmar, exklusive botar, som inte är döva."
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3522,7 +3522,7 @@ msgstr ""
 "Du kan ställa in detta till ett antal sekunder eller fras som: 4 timmar"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3531,7 +3531,7 @@ msgstr ""
 "tom."
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3579,7 +3579,7 @@ msgstr ""
 "organisera uppspelning för en låt per medlem."
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3592,7 +3592,7 @@ msgstr ""
 "Som standard är detta inaktiverat."
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3604,7 +3604,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3630,7 +3630,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr "Tillåt MusicBot att automatiskt avpausa när spelkommandon används."
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3641,7 +3641,7 @@ msgstr ""
 "Lämna tomt för att inaktivera."
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3658,12 +3658,12 @@ msgstr ""
 "Lämna tomt för att använda standardsträngar, dynamiskt genererade UA-strängar."
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "Växla funktionen för användarblocklistan, utan att tömma blocklistan."
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3671,13 +3671,13 @@ msgstr ""
 "rad."
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Aktivera funktionen för blockering av låtar, utan att tömma blocklistan."
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3686,7 +3686,7 @@ msgstr ""
 "Varje låttitel eller URL som innehåller någon rad i listan kommer att blockeras."
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3695,7 +3695,7 @@ msgstr ""
 "Varje fil ska innehålla en lista över spelbara webbadresser eller termer, ett spår per rad."
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3709,7 +3709,7 @@ msgstr ""
 "Kartor till:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3718,7 +3718,7 @@ msgstr ""
 "uppspelning."
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3730,7 +3730,7 @@ msgstr ""
 "Sätt till 0 för att inaktivera. Maximalt tillåtet tal är %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3743,7 +3743,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3773,7 +3773,7 @@ msgstr ""
 "  Använd exempelalternativen som mall eller kopiera den från förrådet."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3792,7 +3792,7 @@ msgstr ""
 "  Kontrollera att sökvägen du har konfigurerat är en sökväg till en mapp / katalog."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3814,7 +3814,7 @@ msgstr ""
 "  Dubbelkolla inställningen är giltig, sökväg för tillgänglig katalog."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3834,7 +3834,7 @@ msgstr ""
 "  Ställ in konfigurationsalternativet eller ange miljövariabeln %(env_var)s med en app-token."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3855,7 +3855,7 @@ msgstr ""
 "  Ställ Manuellt in 'OwnerID' konfigurationsalternativet eller försök igen senare."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3874,7 +3874,7 @@ msgstr ""
 "  Använd inte Bot eller App ID i fältet 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3896,7 +3896,7 @@ msgstr ""
 "  Verifiera konfigurationsmappen och filerna finns och kan läsas av MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3920,7 +3920,7 @@ msgstr ""
 "  Kopiera exempelfilen från repo om allt annat misslyckas."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3940,7 +3940,7 @@ msgstr ""
 "  sätt %(option)s till ett numeriskt ID eller sätt det till `auto` eller `0` för automatisk ägarbindning."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3960,7 +3960,7 @@ msgstr ""
 "  Kontrollera sökvägsinställningen och se till att filen finns och är tillgänglig för MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3980,32 +3980,32 @@ msgstr ""
 "  Se till att alla ID är numeriska, och separeras endast med mellanslag eller kommatecken."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD verkar inte ha några rubriker..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "Song info extrahering returnerade inga data."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Kan inte fortsätta extraktionen, händelseslingan är stängd."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "Kan inte strömma en ogiltig URL."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "Den lokala mediefilen kunde inte hittas."
 
@@ -4355,28 +4355,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4404,7 +4404,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -4458,7 +4458,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4466,7 +4466,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4476,7 +4476,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4545,7 +4545,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4559,7 +4559,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4568,7 +4568,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4582,7 +4582,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4599,26 +4599,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4630,28 +4630,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4662,25 +4662,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4689,7 +4689,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/sv_SE/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/sv_SE/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -41,29 +41,29 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "Medlemmen är inte röstaktiverad och kan inte använda detta kommando."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "Du kan inte använda detta kommando när du inte är i röstkanalen."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "MusicBot har inte behörighet att ansluta i kanalen: `%(name)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "MusicBot har inte behörighet att tala i kanalen: `%(name)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -72,23 +72,23 @@ msgstr ""
 "Försök igen senare, eller starta om boten om detta fortsätter."
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr "MusicBot anslutning till röst avbröts. Detta är udda. Kanske omstart?"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot har inte behörighet att tala."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot kunde inte begära att få tala."
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -97,12 +97,12 @@ msgstr ""
 "Använd kommandot för att föra botten till din röstkanal."
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "Något är fel, vi fick inte röstklienten."
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -110,32 +110,32 @@ msgstr ""
 "Hoppar över nästa låt `%(title)s` som begärare `%(user)s` är inte i röst!"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr "%(mention)s - din låt `%(title)s` spelar nu i %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "Spelar nu i %(channel)s: `%(title)s` tillagd av %(author)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr "Nu spelas automatiskt tillagd post `%(title)s` i %(channel)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 "Hoppar över låtar som lagts till av %(user)s eftersom de inte är i röst!"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -147,12 +147,12 @@ msgstr ""
 "%(error)s```"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug] Försökte skicka ett ogiltigt svarsobjekt."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -175,14 +175,14 @@ msgstr ""
 "  Kontrollera API-status på den officiella webbplatsen: discordstatus.com"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 "Den efterfrågade låten `%(subject)s` blockeras av listan över låtblock."
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -191,12 +191,12 @@ msgstr ""
 "Detta kommando kommer att tas bort i en framtida version, ersätts av kommandot autoplaylist (autoplaylist)."
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -204,18 +204,18 @@ msgstr ""
 "tillgängliga kommandon.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**Alias för detta kommando:**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr "`%(alias)s` alias av `%(command)s %(args)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -226,7 +226,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -238,12 +238,12 @@ msgstr ""
 "%(alias_list)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "Inget sådant kommando"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -253,7 +253,7 @@ msgstr ""
 "För en lista över alla kommandon, kör: %(example_all)s\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -275,22 +275,22 @@ msgstr ""
 "%(all_note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    Blockera en nämnd användare."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    Avblockera en nämnd användare."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    Visa blockstatus för en nämnd användare."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -299,44 +299,44 @@ msgstr ""
 "Blockerade användare är förbjudna att använda alla bot kommandon.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "Du måste ange en användare eller ange deras ID-nummer."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 "Ogiltigt underkommando angivet. Använd `help blockuser` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot kunde inte hitta de användare du angav."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "Ägaren kan inte läggas till i blocklistan."
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "Användarblockslista är för närvarande aktiverad."
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "Användarblockslista är för närvarande inaktiverad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "Kan inte lägga till de användare du listade, de är redan tillagda."
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -346,24 +346,24 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "Ingen av dessa användare finns i den svarta listan."
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr "Användare: `%(user)s` är inte blockerad.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr "Användare: `%(user)s` är blockerad.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -375,7 +375,7 @@ msgstr ""
 "%(users)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -385,7 +385,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -402,25 +402,25 @@ msgstr ""
 "Detta innebär att lägga till 'Pie' matchar 'cherry Pie' men inte 'piecrust' i schack.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "Du måste ange ett låtämne om ingen låt spelas just nu."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 "Ogiltigt underkommando angivet. Använd `help blocksong` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr "Ämne `%(subject)s` finns redan i listan över låtblock."
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -430,12 +430,12 @@ msgstr ""
 "%(status)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "Ämnet finns inte i listan över låtblock och kan inte tas bort."
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -445,7 +445,7 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -454,12 +454,12 @@ msgstr ""
 "till/från den aktuella spellistan.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    Lägger till hela kön i guilds spellista.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -468,68 +468,68 @@ msgstr ""
 "spellista.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 "Ogiltigt underkommando angivet. Använd `help autoplaylist` för "
 "användningsexempel."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "Länk till medföljande låt är ogiltig"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "Kön är tom. Lägg till några låtar med ett låtkommando!"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "Alla låtar i kön finns redan i autospellistan."
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "Lade till %(number)d låtar till autospellistan."
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr "Lade till `%(url)s` till autospellistan."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "Den här låten finns redan i autospellistan."
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr "Tog bort `%(url)s` från autospellistan."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "Den här låten finns ännu inte med i autospellistan."
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "Laddade en ny kopia av spellistan: `%(file)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "Du måste ange ett filnamn för spellistan."
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -538,13 +538,13 @@ msgstr ""
 "Den här spellistan är ny, du måste lägga till låtar för att spara den på disken!"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr "Spellistan för denna server har uppdaterats till: `%(name)s`%(note)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
@@ -552,7 +552,7 @@ msgstr ""
 "till en annan server."
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -562,7 +562,7 @@ msgstr ""
 "%(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -571,28 +571,28 @@ msgstr ""
 "Grupper med BypassKaraokeMode behörighetsstyr vilka medlemmar som är Karaokemedlemmar.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\N{OK HAND SIGN} Karaokeläget är nu aktiverat."
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\N{OK HAND SIGN} Karaokeläget är nu inaktiverat."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "Du har inte behörighet att begära spellistor"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr "Spellistan har för många poster (%(songs)s men max är %(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -604,12 +604,12 @@ msgstr ""
 "Gränsen är %(max)s för din grupp."
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "Bot har tidigare pausats, återupptar uppspelningen nu."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -626,7 +626,7 @@ msgstr ""
 "MusicBot stöder också Spotify-URI:er och webbadresser, men ljudet hämtas från YouTube oavsett.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -635,13 +635,13 @@ msgstr ""
 "kön.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "Blandade spellistobjekt i kön från `%(request)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -650,7 +650,7 @@ msgstr ""
 "Läsa hjälp för play-kommandot för information om stödda ingångar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -659,7 +659,7 @@ msgstr ""
 "Läs hjälp för play-kommandot för information om stödda ingångar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -672,34 +672,34 @@ msgstr ""
 "På grund av codec specifika i ffmpeg, detta kanske inte är korrekt.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "Kan inte använda söka om det inte finns något att spela."
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 "Kan inte använda sökningen på nuvarande spår, den har en okänd varaktighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "Sökandet stöds inte för strömmar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "Kan inte använda söka utan tid för att placera uppspelning."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr "Kunde inte konvertera `%(input)s` till en giltig tid i sekunder."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -709,7 +709,7 @@ msgstr ""
 "spåret med en längd av `%(progress)s / %(total)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -717,7 +717,7 @@ msgstr ""
 "Söker efter tid `%(input)s` (`%(seconds).2f` sekunder) i den aktuella låten."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -728,64 +728,64 @@ msgstr ""
 "Om inget alternativ finns och låten redan upprepas, kommer upprepningen att stängas av.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr "Inga låtar spelas just nu. Spela något med ett låtkommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 "Ogiltigt underkommando. Använd kommandot `help repeat` för "
 "användningsexempel."
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "Spellistan repeterar nu."
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "Spellistan repeterar inte längre."
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "Spelaren kommer nu att loopa den aktuella låten."
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "Spelaren kommer inte längre att loopa den aktuella låten."
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "Spelaren har redan loopat en låt!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "Spelaren loopar inte för närvarande."
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "Sången repeterar inte längre."
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "Sången repeterar nu."
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    Flytta låten på plats FRÅN till plats TO.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -794,22 +794,22 @@ msgstr ""
 "Använd kökommandot för att hitta låtpositionsnummer.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr "Det finns inga låtar köade. Spela något med ett play-kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "Sångpositioner måste vara heltal!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "Du gav en position utanför spellistan storlek!"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -818,7 +818,7 @@ msgstr ""
 "%(to)s!"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -832,33 +832,33 @@ msgstr ""
 "Vill du köa spellistan också?"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "Lokal medieuppspelning är inte aktiverad."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte för närvarande."
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "Upptäckte en Spotify-URL, men Spotify är inte aktiverat."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr "Du har nått din köade låtgräns (%(max)s)"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke-läget är aktiverat, försök igen när det är inaktiverat!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -868,15 +868,9 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "Den videon kan inte spelas. Prova att använda strömkommandot."
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "YouTube-sökning gav inga resultat för:  %(url)s"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1056,7 +1050,7 @@ msgid "Show information on what is currently playing."
 msgstr "Visa information om vad som spelas just nu."
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -1093,7 +1087,7 @@ msgstr "Förlopp:"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "Det finns inga låtar köade! Köa något med ett spelkommando."
 
@@ -1198,38 +1192,25 @@ msgstr "Tar bort alla låtar i kön."
 msgid "Cleared all songs from the queue."
 msgstr "Rensade alla låtar från kön."
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-"Ta bort en låt från kön, eventuellt på den givna köpositionen.\n"
-"Om positionen utelämnas tas låten i slutet av kön bort.\n"
-"Använd kökommandot för att hitta positionsnumret på din spår.\n"
-"Dock ändras positioner för alla låtar när en ny låt börjar spela.\n"
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "Ingenting i kön att ta bort!"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "Tog bort `%(track)s` tillagd av `%(user)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "Ingenting hittades i kön från användaren `%(user)s`"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1238,24 +1219,24 @@ msgstr ""
 "Du måste vara den som köade det eller har omedelbar hoppa över behörigheter."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "Ogiltigt postnummer. Använd kökommandot för att hitta köpositioner."
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "Tog bort post `%(track)s` tillagd av `%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "Tog bort post `%(track)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1266,23 +1247,23 @@ msgstr ""
 "Om LegacySkip -alternativet är aktiverat kan kraftparametern ignoreras.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "Kan inte hoppa över! Spelaren spelar inte!"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr "Nästa låt `%(track)s` laddas ner, vänligen vänta."
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "Nästa låt kommer att spelas inom kort. Vänligen vänta."
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1291,7 +1272,7 @@ msgstr ""
 "Du kanske vill starta om boten om den inte börjar fungera."
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1300,28 +1281,28 @@ msgstr ""
 "Du kanske vill starta om boten om den inte börjar fungera."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "Du har inte behörighet att tvinga hoppa över en loopad låt."
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr "Tvinga hoppad `%(track)s`."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "Du har inte behörighet att tvinga hopp."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "Du har inte behörighet att hoppa över en loopad låt."
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1331,12 +1312,12 @@ msgstr ""
 "Omröstningen att hoppa över har passerats.%(next_up)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " Nästa låt kommer!"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1346,7 +1327,7 @@ msgstr ""
 "Behöver **%(votes)s** fler röster för att hoppa över denna låt."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1357,25 +1338,25 @@ msgstr ""
 "Volyminställningen behålls tills MusicBot startas om.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "Nuvarande volym: `%(volume)s%%`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "`%(new_volume)s` är inte ett giltigt tal"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "Uppdaterad volym från **%(old)d** till **%(new)d**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1385,14 +1366,14 @@ msgstr ""
 "Volymen kan endast ändras från 1 till 100."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr "Orimlig volym angiven: %(volume)s. Ange ett värde mellan 1 och 100."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1403,7 +1384,7 @@ msgstr ""
 "Uppspelning av strömning stöder inte hastighetsjusteringar.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1412,35 +1393,35 @@ msgstr ""
 "Använd konfigurationskommandot för att ställa in en standard uppspelningshastighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "Hastighet kan inte tillämpas på strömmade medier."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "Du måste ange en hastighet att ställa in."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 "Hastigheten du angav är ogiltig. Använd ett nummer mellan 0,5 och 100."
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 "Ställer in uppspelningshastighet till `%(speed).3f` för nuvarande spår."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    Lägg till ett nytt alias med valfria argument.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1449,23 +1430,23 @@ msgstr ""
 "hjälpkommandot."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "Ogiltigt alternativ för kommandot: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "Alias laddade om från konfigurationsfilen."
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "Alias sparade i konfigurationsfilen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1475,40 +1456,40 @@ msgstr ""
 "`%(raw_error)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "Du måste tillhandahålla ett alias och ett kommando till alias"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "Nytt alias tillagt. `%(alias)s` är nu ett alias av `%(command)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "Du måste ange ett alias namn för att ta bort."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr "Alias `%(alias)s` finns inte."
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr "Alias `%(alias)s` togs bort."
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    Visar hjälptext om eventuella saknade konfigurationsalternativ.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1517,32 +1498,32 @@ msgstr ""
 "konfigurationsfilen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr "    Lista tillgängliga konfigurationsalternativ och deras sektioner.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    Ladda om filen options.ini från disk.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    Visar hjälptext för ett specifikt alternativ.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    Visa det aktuella värdet av alternativet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    Sparar det aktuella värdet till alternativfilen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1551,32 +1532,32 @@ msgstr ""
 " inte filen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    Återställ alternativet till dess standardvärde.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "Hantera options.ini konfiguration inifrån Discord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "Konfigurationen kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*Alla konfigurationsalternativ är närvarande och redovisas för!*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "Inga konfigurationsalternativ verkar ändras."
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1586,7 +1567,7 @@ msgstr ""
 "%(changed)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1602,12 +1583,12 @@ msgstr ""
 "%(manual)s"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "Konfigurationsalternativ laddades om från filen framgångsrikt!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1617,7 +1598,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1626,17 +1607,17 @@ msgstr ""
 "undervisnings- och alternativnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "Det alternativ som anges är tvetydigt, ange ett avsnittsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "Du måste ange ett namn och alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1646,26 +1627,26 @@ msgstr ""
 "De tillgängliga sektionerna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr "Alternativet `%(option)s` är inte tillgängligt."
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 "Det här alternativet kan bara ställas in genom att redigera "
 "konfigurationsfilen."
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "Som standard är detta alternativ inställt på: %(default)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1679,32 +1660,32 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 "Alternativet `%(option)s` är inte redigerbart. Kan inte spara till disk."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "Kunde inte spara alternativet: `%(option)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "Alternativet sparades framgångsrikt: `%(config)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr "Alternativ `%(option)s` är inte redigerbar, värde kan inte visas."
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1716,7 +1697,7 @@ msgstr ""
 "INI filvärde: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
@@ -1724,19 +1705,19 @@ msgstr ""
 "inställningen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 "Du måste ange ett avsnitt, alternativ och värde för detta underkommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "Alternativet `%(option)s` uppdaterades inte!"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1746,7 +1727,7 @@ msgstr ""
 "För att spara ändringen använd `config save %(section)s %(option)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
@@ -1754,13 +1735,13 @@ msgstr ""
 "standard."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "Alternativet `%(option)s` återställdes inte till standard!"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1770,17 +1751,17 @@ msgstr ""
 "För att spara ändringen använd `config save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "Föråldrat kommando, använd kommandot config istället."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "Alternativkommandot är föråldrat, använd kommandot config istället."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1789,34 +1770,34 @@ msgstr ""
 "Genom att använda uppdateringsalternativet kommer att skanna cachen efter externa ändringar innan detaljer visas."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 "Ogiltigt alternativ angivet, användning: info, uppdatering eller rensa"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "Inaktiverad"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "Aktiverad"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "%(time)s dagar"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "Obegränsad"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1832,23 +1813,23 @@ msgstr ""
 "**Cached nu:  %(used)s i %(files)s fil(er)."
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "Cachen har rensats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 "**Misslyckades** att ta bort cache, kolla loggar för mer information..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "Ingen cache hittades att rensa."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -1857,12 +1838,12 @@ msgstr ""
 "Valfritt sidnummer visar senare poster i kön.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "Kö sida argument måste vara ett heltal."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1872,12 +1853,12 @@ msgstr ""
 "Det finns **%(total)s** sidor."
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(okänd tid)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1889,7 +1870,7 @@ msgstr ""
 "Framsteg: `[%(progress)s/%(total)s]`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1903,12 +1884,12 @@ msgstr ""
 "%(tracks)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "Låtar i kö"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -1917,7 +1898,7 @@ msgstr ""
 "Om problemet kvarstår, skicka in en felrapport."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1928,38 +1909,38 @@ msgstr ""
 "Detta kommando kan vara långsamt om större intervall anges.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "Ogiltig parameter. Ange ett antal meddelanden att söka."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "Kan inte använda rensning på privat DM-kanal."
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr "Rensade upp %(number)s meddelande(er)."
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "Bot har inte behörighet att hantera meddelanden."
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "Dumpa de enskilda webbadresserna i en spellista till en fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "Den angivna URL:en var inte en giltig URL."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1969,18 +1950,18 @@ msgstr ""
 "%(raw_error)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "Detta verkar inte vara en spellista."
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "Här är spellistan dumpa för:  %(url)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -1989,19 +1970,19 @@ msgstr ""
 "Detta kommando är föråldrat till förmån för utvecklarläge i Discord-klienter.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "Ditt användar-ID är `%(id)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "Användar-ID för `%(username)s` är `%(id)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2012,18 +1993,18 @@ msgstr ""
 "Detta kommando är föråldrat till förmån för att använda Utvecklarläge i Discord-klienter.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "Giltiga kategorier: %(cats)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "Här är de ID du begärt:"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
@@ -2031,7 +2012,7 @@ msgstr ""
 "användaren."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2040,12 +2021,12 @@ msgstr ""
 "försök igen."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "Kunde inte bestämma discord-användaren. Försök igen."
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2059,7 +2040,7 @@ msgstr ""
 "```"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2073,62 +2054,62 @@ msgstr ""
 "```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    Visa laddade grupper och listbehörighetsalternativ.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    Laddar om behörigheter från permissions.ini filen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    Lägg till ny grupp med standardinställningar.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    Ta bort befintlig grupp.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    Visa hjälptext för behörighetsalternativet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    Visa behörighetsvärde för given grupp och behörighet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    Spara behörighetsgrupp till fil.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    Ange behörighetsvärde för gruppen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "Hantera behörighet.ini konfiguration inifrån diskord."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "Behörigheter kan inte använda kanal och användarnamn samtidigt."
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "Behörigheter laddades om från filen framgångsrikt!"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2138,7 +2119,7 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2152,23 +2133,23 @@ msgstr ""
 "%(options)s\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "Du måste ange ett grupp- eller alternativnamn för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "Du måste ange en grupp, alternativ och värde för detta kommando."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr "%(option)s underkommandot kräver ett grupp- och behörighetsnamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2178,25 +2159,25 @@ msgstr ""
 "De tillgängliga grupperna är:  %(sections)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr "Behörigheten `%(option)s` är inte tillgänglig."
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 "Denna behörighet kan bara ställas in genom att redigera behörighetsfilen."
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "Som standard är den här behörigheten satt till: `%(value)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2210,13 +2191,13 @@ msgstr ""
 "%(default)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr "Kan inte lägga till grupp `%(group)s` det finns redan."
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2228,12 +2209,12 @@ msgstr ""
 "Se till att spara den nya gruppen med: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "Kan inte ta bort inbyggd grupp."
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2243,24 +2224,24 @@ msgstr ""
 "Se till att spara denna ändring med: `setperms save %(group)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "Ägargruppen är inte redigerbar."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "Det gick inte att spara gruppen: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "Gruppen sparades framgångsrikt: `%(group)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2272,13 +2253,13 @@ msgstr ""
 "INI filvärde: `%(ini)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "Behörighet `%(option)s` uppdaterades inte!"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2288,7 +2269,7 @@ msgstr ""
 "För att spara ändringen använd `setperms save %(section)s %(option)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2297,7 +2278,7 @@ msgstr ""
 "Obs: API:et kan begränsa namnändringar till två gånger per timme."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2306,7 +2287,7 @@ msgstr ""
 "Kom ihåg att namnändringar är begränsade till två gånger per timme.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2316,23 +2297,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "Ange botens användarnamn till `%(name)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "Ändra MusicBots smeknamn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "Det går inte att ändra smeknamn: ingen behörighet."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2342,23 +2323,23 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "Sätt botens smeknamn till `%(nick)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    Ange ett prefix för kommandot per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    Rensa kommandoprefixet per server."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2367,24 +2348,24 @@ msgstr ""
 "Alternativet EnablePrefixPerGuild måste aktiveras först."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 "Anpassad emoji måste vara från den här servern för att använda som prefix."
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "Server-kommandoprefixet är rensat."
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "Serverkommandoprefix är nu:  %(prefix)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2393,38 +2374,38 @@ msgstr ""
 "Använd konfigurationskommandot för att uppdatera prefixet istället."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    Visa språkkoder tillgängliga att använda.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    Ange önskat språk för den här servern.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    Återställ serverspråket till botens standardspråk.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "Hantera språket som används för meddelanden i samtalsservern."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "Detta kommando kan endast användas i guilds."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 "Ogiltigt underkommando ges. Använd hjälpkommandot för mer information."
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2438,25 +2419,25 @@ msgstr ""
 "%(languages)s```"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr "Kan inte ställa in språk till `%(locale)s` det är inte tillgängligt."
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "Språk för denna server nu satt till: `%(locale)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "Språk för den här servern har återställts till: `%(locale)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2465,12 +2446,12 @@ msgstr ""
 "Att koppla en fil och utelämna url-parametern fungerar.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "Du måste ange en URL eller bifoga en fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2480,58 +2461,58 @@ msgstr ""
 "%(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "Ändrade botens avatar."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "Tvinga MusicBot att koppla från discord-servern."
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "Frånkopplad från servern `%(guild)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "Kopplade från en spellös röstklient? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "Inte ansluten till servern `%(guild)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "    Försök att ladda om utan processens omstart. Standardalternativet.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr "    Försök att starta om hela MusicBot processen, ladda om allt.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "    Fullständig omstart, men försök att uppdatera pip-paket innan omstart.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "    Fullständig omstart, men uppdatera MusicBot källkod med git först.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2539,7 +2520,7 @@ msgstr ""
 "    Försök att uppdatera alla beroenden och källkod innan den startas om.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2552,7 +2533,7 @@ msgstr ""
 "Om du har en servicehanterare, rekommenderar vi att du använder den istället för detta kommando för omstart.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
@@ -2560,19 +2541,19 @@ msgstr ""
 "eller upgit"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "%(emoji)s Startar om aktuell instans..."
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "%(emoji)s Startar om botprocessen..."
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2580,7 +2561,7 @@ msgstr ""
 "%(emoji)s Försöker uppgradera nödvändiga pip-paket och starta om boten..."
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
@@ -2588,23 +2569,23 @@ msgstr ""
 "boten..."
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "%(emoji)s Kommer att försöka uppgradera allt och starta om boten..."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "Koppla från alla röstkanaler och avsluta MusicBot-processen."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   Lämna discord-servern med namn eller server-ID."
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2613,30 +2594,30 @@ msgstr ""
 "Namnen är skiftlägeskänsliga, så att använda ett ID-nummer är mer tillförlitligt.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "Du måste ange ett ID eller namn."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "Ingen guild hittades med ID eller namn `%(input)s`"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "Okänd"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr "Lämnade guilden: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2645,38 +2626,38 @@ msgstr ""
 "Kan användas för att manuellt identifiera händelser i MusicBot loggfilen.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "Loggad brytpunkt med ID:  %(uuid)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    Visa de vanligaste typerna som rapporterats av objgraph.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    Visa begränsad objgraph.show_growth() utgång.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    Visa de vanligaste typerna av läckande objekt.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    Visa typvärden för läckande objekt.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    Utvärdera den givna funktionen och argumenten på objektgrafen.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2687,12 +2668,12 @@ msgstr ""
 "Eftersom denna metod utvärderar godtycklig kod anses den vara farlig som debug kommandot.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "Kunde inte importera `objgraph`, är det installerat?"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2717,7 +2698,7 @@ msgstr ""
 "Faran med detta kommando kan inte underskattas. Använd den inte eller ge tillgång till den om du inte förstår riskerna!\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2733,7 +2714,7 @@ msgstr ""
 "%(ex_text)s```"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2742,23 +2723,23 @@ msgstr ""
 "Utgången används för att uppdatera GitHub sidor och är därmed olämplig för normal referensanvändning."
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "Underkommando måste vara ett av: %(options)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "Gör standard INI-filer."
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "Sparade den begärda INI-filen till disk. Gå och kontrollera den"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -2767,50 +2748,50 @@ msgstr ""
 "eller beroenden.\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "Kunde inte lokalisera git körbar."
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr "Inga uppdateringar i grenen `%(branch)s` fjärrkontroll."
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr "Nya commits finns i `%(branch)s` branch remote."
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "Fel vid kontroll, se loggar för detaljer."
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr "Uppdatering för `%(name)s` till version: `%(version)s`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "Inga uppdateringar för beroenden hittades."
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "Det finns uppdateringar för MusicBot tillgängliga för nedladdning."
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot är helt uppdaterad!"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2830,53 +2811,53 @@ msgstr ""
 "%(pip_status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "Visar MusicBot upptid, eller tid sedan senaste start / omstart."
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "%(name)s har varit online för `%(time)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 "Visa latensinformation för Discord API och alla anslutna röstklienter."
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "Inga röstklienter anslutna.\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "Visa API-latens och röstfördröjning om MusicBot är ansluten."
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "automatiskt"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "**API Latency:** `%(delay).0f ms`%(voice)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "Visa MusicBot versionsnummer i chatten."
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2886,17 +2867,17 @@ msgstr ""
 "Aktuell version: `%(version)s`"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    Uppdatera cookies.txt-filen med hjälp av en cookies.txt-bilaga."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    Aktivera eller inaktivera cookies.txt-fil utan att ta bort den."
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2921,29 +2902,29 @@ msgstr ""
 "  funktion om du inte förstår hur man undviker riskerna."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookies har redan aktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 "Cookies måste laddas upp för att kunna aktiveras. (Missing cookies file.)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "Kunde inte aktivera cookies på grund av fel:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Cookies har aktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2953,12 +2934,12 @@ msgstr ""
 "Cookies tillfälligt inaktiverade och kommer att aktiveras igen vid nästa omstart."
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Cookies har inaktiverats."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
@@ -2966,51 +2947,51 @@ msgstr ""
 "cookie-fil."
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "Fel vid nedladdning av cookie-filen från diskett:  %(raw_error)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "Kunde inte spara kakor till disk:  %(raw_error)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookies uppladdade och aktiverade."
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "Du kan inte använda denna bot i privata meddelanden."
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "Detta kommando är inte tillåtet för din behörighetsgrupp:  %(group)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "Detta kommando kräver att du är i en röstkanal."
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "**Kommando:** %(name)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "Fel vid undantag"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3020,17 +3001,17 @@ msgstr ""
 "%(prefix)s`%(command)s ...`\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "Ingen beskrivning angiven.\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "Ingen användning angiven."
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3044,13 +3025,13 @@ msgstr ""
 "%(desc)s"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr "Lämnar röstkanal %(channel)s på grund av inaktivitet."
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr "Vänster `%(guild)s` på grund av att bot ägaren inte hittas i den."
@@ -3677,12 +3658,12 @@ msgstr ""
 "Lämna tomt för att använda standardsträngar, dynamiskt genererade UA-strängar."
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "Växla funktionen för användarblocklistan, utan att tömma blocklistan."
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
@@ -3690,13 +3671,13 @@ msgstr ""
 "rad."
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 "Aktivera funktionen för blockering av låtar, utan att tömma blocklistan."
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3705,7 +3686,7 @@ msgstr ""
 "Varje låttitel eller URL som innehåller någon rad i listan kommer att blockeras."
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3714,7 +3695,7 @@ msgstr ""
 "Varje fil ska innehålla en lista över spelbara webbadresser eller termer, ett spår per rad."
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3728,7 +3709,7 @@ msgstr ""
 "Kartor till:  %(path)s/some/folder/name/file.ext"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -3737,7 +3718,7 @@ msgstr ""
 "uppspelning."
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3749,7 +3730,7 @@ msgstr ""
 "Sätt till 0 för att inaktivera. Maximalt tillåtet tal är %(max)s."
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3762,7 +3743,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3792,7 +3773,7 @@ msgstr ""
 "  Använd exempelalternativen som mall eller kopiera den från förrådet."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3811,7 +3792,7 @@ msgstr ""
 "  Kontrollera att sökvägen du har konfigurerat är en sökväg till en mapp / katalog."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3833,7 +3814,7 @@ msgstr ""
 "  Dubbelkolla inställningen är giltig, sökväg för tillgänglig katalog."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3853,7 +3834,7 @@ msgstr ""
 "  Ställ in konfigurationsalternativet eller ange miljövariabeln %(env_var)s med en app-token."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3874,7 +3855,7 @@ msgstr ""
 "  Ställ Manuellt in 'OwnerID' konfigurationsalternativet eller försök igen senare."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3893,7 +3874,7 @@ msgstr ""
 "  Använd inte Bot eller App ID i fältet 'OwnerID'."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3915,7 +3896,7 @@ msgstr ""
 "  Verifiera konfigurationsmappen och filerna finns och kan läsas av MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3939,7 +3920,7 @@ msgstr ""
 "  Kopiera exempelfilen från repo om allt annat misslyckas."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3959,7 +3940,7 @@ msgstr ""
 "  sätt %(option)s till ett numeriskt ID eller sätt det till `auto` eller `0` för automatisk ägarbindning."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3979,7 +3960,7 @@ msgstr ""
 "  Kontrollera sökvägsinställningen och se till att filen finns och är tillgänglig för MusicBot."
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3999,32 +3980,32 @@ msgstr ""
 "  Se till att alla ID är numeriska, och separeras endast med mellanslag eller kommatecken."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD verkar inte ha några rubriker..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "Song info extrahering returnerade inga data."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "Kan inte fortsätta extraktionen, händelseslingan är stängd."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify-URL är ogiltig eller stöds inte."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "Kan inte strömma en ogiltig URL."
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "Den lokala mediefilen kunde inte hittas."
 
@@ -4047,14 +4028,14 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "Nedladdning misslyckades på grund av ett yt-dlp fel: %(raw_error)s"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 "Nedladdning misslyckades på grund av ett ohanterat undantag: %(raw_error)s"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "Det gick inte att extrahera data för de begärda medierna."
 
@@ -4237,28 +4218,28 @@ msgstr ""
 "yt-dlp extractor `%(extractor)s` är inte tillåtet i din grupp."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "Kunde inte extrahera information"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "Detta är en spellista."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "Ogiltig innehållstyp `%(type)s` för URL: %(url)s"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "ingen varaktighet data"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "ingen varaktighet i aktuell post"
 
@@ -4340,21 +4321,21 @@ msgid "Only dev users can use this command."
 msgstr "Endast utvecklaranvändare kan använda detta kommando."
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -4362,13 +4343,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -4380,22 +4361,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4423,61 +4404,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -4485,7 +4466,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -4495,7 +4476,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -4519,40 +4500,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4560,13 +4534,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4585,7 +4559,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4594,7 +4568,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4625,28 +4599,123 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr "YouTube-sökning gav inga resultat för:  %(url)s"
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+#~ "Ta bort en låt från kön, eventuellt på den givna köpositionen.\n"
+#~ "Om positionen utelämnas tas låten i slutet av kön bort.\n"
+#~ "Använd kökommandot för att hitta positionsnumret på din spår.\n"
+#~ "Dock ändras positioner för alla låtar när en ny låt börjar spela.\n"
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr "Hantera automatiskt spellista filer och per-guild inställningar."

--- a/i18n/th_TH/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/th_TH/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -129,7 +129,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr ""
 
@@ -146,61 +146,43 @@ msgid ""
 "Details: %s. Continuing anyway in 5 seconds..."
 msgstr ""
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr ""
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -210,7 +192,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -220,7 +202,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -230,35 +212,35 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -266,155 +248,155 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -422,65 +404,65 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -488,36 +470,36 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -525,7 +507,7 @@ msgid ""
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -533,364 +515,364 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -904,44 +886,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -949,80 +931,80 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1032,348 +1014,348 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1382,24 +1364,24 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1407,55 +1389,55 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1463,59 +1445,59 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1523,7 +1505,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -1623,56 +1605,56 @@ msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1680,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1718,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1747,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1772,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1870,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1910,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1949,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2004,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2017,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2042,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2108,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2163,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2347,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2448,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2456,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2475,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2494,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2513,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2528,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2551,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2576,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2591,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2651,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2664,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2677,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2685,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2693,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2701,120 +2683,120 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2822,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -2934,12 +2916,12 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 
@@ -2956,13 +2938,13 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr ""
@@ -2984,7 +2966,7 @@ msgid "Download already cached at:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -2999,50 +2981,50 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr ""
 
@@ -3084,60 +3066,60 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr ""
@@ -3206,7 +3188,7 @@ msgid "Cache level requires cleanup. %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -3482,104 +3464,104 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -4088,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4131,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4187,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4213,55 +4195,55 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr ""
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4279,117 +4261,111 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: noise
@@ -4417,19 +4393,19 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4437,34 +4413,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4478,7 +4454,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4496,12 +4472,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4514,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4526,7 +4502,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4535,31 +4511,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4583,7 +4559,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -4591,50 +4567,50 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
@@ -4680,13 +4656,13 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4764,13 +4740,13 @@ msgid "Deserialize returned an object that is not a MusicPlayer:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4826,45 +4802,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -4876,220 +4852,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5108,30 +5084,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5139,18 +5115,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5225,9 +5201,88 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/th_TH/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/th_TH/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -416,13 +416,13 @@ msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr ""
 
@@ -615,13 +615,13 @@ msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr ""
@@ -1455,7 +1455,7 @@ msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -1476,28 +1476,28 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1505,12 +1505,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1518,143 +1518,143 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1662,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1700,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1729,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1754,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1852,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1892,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1931,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1986,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1999,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2024,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2090,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2145,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2329,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2438,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2457,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2476,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2495,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2510,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2533,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2558,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2573,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2633,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2646,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2659,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2667,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2675,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2683,30 +2683,30 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
@@ -2764,39 +2764,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2804,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -3892,55 +3892,55 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr ""
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
 msgstr ""
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr ""
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr ""
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -3948,107 +3948,107 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr ""
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr ""
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
 msgstr ""
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr ""
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr ""
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
 msgstr ""
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
 msgstr ""
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4056,13 +4056,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4070,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4113,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4169,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4195,55 +4195,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr ""
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4261,7 +4249,7 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
@@ -4274,13 +4262,13 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
@@ -4364,48 +4352,48 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4413,34 +4401,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4454,7 +4442,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4472,12 +4460,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4490,7 +4478,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4502,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4511,31 +4499,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4794,7 +4782,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5025,24 +5013,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5089,25 +5077,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5115,66 +5103,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5201,7 +5143,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5213,25 +5155,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5244,29 +5186,143 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr ""
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/th_TH/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/th_TH/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -19,95 +19,95 @@ msgstr ""
 "X-Crowdin-Project-ID: 734017\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -116,12 +116,12 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -135,36 +135,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -173,7 +173,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -182,12 +182,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -195,7 +195,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -209,64 +209,64 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -274,24 +274,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -300,7 +300,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -319,18 +319,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -338,12 +338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -351,104 +351,104 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -456,35 +456,35 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -493,39 +493,39 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -534,33 +534,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -568,14 +568,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -583,84 +583,84 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -670,28 +670,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -860,7 +860,7 @@ msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
@@ -1002,58 +1002,49 @@ msgstr ""
 msgid "Cleared all songs from the queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1061,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1120,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1133,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1141,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1167,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1182,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1241,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1336,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1347,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1360,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1385,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1412,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1445,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1470,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1490,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1544,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1579,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1593,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1603,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1623,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1657,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1695,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1721,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1731,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1796,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1820,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1847,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1866,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1892,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1906,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1921,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1945,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2011,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2075,110 +2066,110 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2186,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2206,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2217,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2296,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2349,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2374,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2403,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2466,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2486,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2941,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2981,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2997,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3006,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3018,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3032,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3045,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3059,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3074,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3087,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3100,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3113,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3155,13 +3146,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
@@ -3287,22 +3278,22 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -3385,32 +3376,32 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -3418,19 +3409,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -3441,21 +3432,15 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
@@ -3472,50 +3457,50 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3523,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3532,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3579,42 +3564,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -3657,7 +3642,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3671,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3689,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3702,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3749,7 +3734,7 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
@@ -3762,61 +3747,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3824,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3834,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -3858,40 +3843,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -3899,13 +3877,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -3924,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3933,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3964,28 +3942,119 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/th_TH/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/th_TH/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -650,7 +650,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -675,23 +675,23 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,19 +699,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -719,13 +719,13 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -733,24 +733,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -759,292 +759,292 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1052,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1111,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1124,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1132,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1158,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1173,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1232,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1327,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1338,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1351,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1376,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1403,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1436,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1461,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1481,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1535,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1570,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1584,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1594,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1614,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1648,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1686,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1712,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1722,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1787,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1811,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1838,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1857,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1883,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1897,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1912,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1936,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2002,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2066,66 +2066,66 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
@@ -2137,39 +2137,39 @@ msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2177,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2197,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2208,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2287,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2340,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2365,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2394,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2457,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2477,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2575,7 +2575,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -2637,13 +2637,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -2651,14 +2651,14 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -2670,26 +2670,26 @@ msgid "Mention the user who added the song when it is played."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -2736,14 +2736,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -2769,7 +2769,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 
@@ -2782,7 +2782,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -2808,13 +2808,13 @@ msgid "Completely remove the footer from embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -2822,21 +2822,21 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -2873,7 +2873,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -2882,7 +2882,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -2892,7 +2892,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -2913,7 +2913,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -2921,7 +2921,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -2932,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2972,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2988,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -2997,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3009,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3023,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3036,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3050,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3065,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3078,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3091,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3104,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3439,68 +3439,68 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3508,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3517,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3564,56 +3564,56 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3635,14 +3635,14 @@ msgid "Allow MusicBot to format its messages as embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3656,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3674,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3687,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3747,7 +3747,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -3801,7 +3801,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3809,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3819,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -3888,7 +3888,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -3902,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3911,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3925,7 +3925,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -3933,7 +3933,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -3942,26 +3942,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -3973,28 +3973,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4005,25 +4005,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4032,7 +4032,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/xx/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/xx/LC_MESSAGES/musicbot_logs.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Just-Some-Bots/MusicBot release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-13 10:11-0700\n"
+"POT-Creation-Date: 2025-05-02 07:00-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -154,7 +154,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr "%(raw_error)s  --  %(task)r  :ksat rof noitpecxe deldnahnU"
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr ".gnilbasiD .nekot a htiw su edivorp ton did yfitopS"
 
@@ -174,62 +174,51 @@ msgstr ""
 " ruoy sI .tneilc yfitopS trats ton dluoC"
 
 #. Used by: warning
-#: musicbot/bot.py:336
+#: musicbot/bot.py:335
 msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
 msgstr ""
-".edom tseug esu ot gnitpmetta ,slaitnederc ppa yfitopS evah ton did gifnoc "
-"ehT"
+".elbaliava eb ton lliw troppus yfitopS .slaitnederc ppa yfitopS evah ton "
+"seod gifnoc ruoY"
 
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr ".edom tseug gnisu yllufsseccus yfitopS htiw detacitnehtuA"
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ".%s :sliateD .edom tseug gnisu tneilc yfitopS trats ton dluoC"
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr ".drocsid ot gnitcennoc won ,dezilaitinI"
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr ".gifnoc aiv delbasid si tset gnip krowteN"
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr ".nwod gnisolc si tset gnip krowteN"
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr ".tegrat gnip evloser ton dluoC"
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr ".dellecnac tset gnip krowteN"
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr ".worrob ot noisses a evah ton seod PTTH aiv gnitset krowteN"
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr ".tnemnorivne ruoy ni elbatucexe `gnip` etacol ton dluoC"
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -243,7 +232,7 @@ msgstr ""
 ".daetsni gnip PTTH esu ot tpmetta lliW  .htap dnammoc `gnip` a etacol ton dluoc toBcisuM"
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -257,7 +246,7 @@ msgstr ""
 ".daetsni gnip PTTH esu ot tpmetta lliW  .dnammoc `gnip` eht etucexe ot noissimrep deined saw toBcisuM"
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -271,28 +260,28 @@ msgstr ""
 ".daetsni gnip PTTH esu ot tpmetta lliW  .dnammoc metsys `gnip` eht wolla ton yam tnemnorivne ruoY"
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr ".niaga elbaliava si krowten detceted toBcisuM"
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "...reyalPcisuM emuser ot gnitiaw ,detcennoc ton si tneilCecioV"
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr "%(player)r )%(guild_id)s(  :reyalp fo kcabyalp gnimuseR"
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr ".egatuo krowten a detceted toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
@@ -300,7 +289,7 @@ msgstr ""
 "%(player)r )%(guild_id)s(  :ytilibaliava krowten ot eud reyalPcisuM gnisuaP"
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -310,150 +299,150 @@ msgstr ""
 " rof gnikooL"
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "...emuser ro nioj-otua ot slennahc rof gnikcehC"
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr "%(name)s/%(id)s  :nioj otua tonnac ,elbaliava ton dliuG"
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "%(guild)s  :dliug ni  %(channel)s  :lennahc eciov elbamuser dnuoF"
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr "%s  :lennahc gninioJ-otuA fo daetsni noisses eciov gnimuser yrt lliW"
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr "%s  :lennahc eciov ni renwo dnuoF"
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr "%s  :lennahc ni renwo ot nommuSotuA ,lennahc elbamuser gnirongI"
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr "%s  :lennahc ni renwo ot nommuSotuA ,lennahc nioJ-otuA gnirongI"
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "%(guild)s  :dliug ni  %(channel)s  :lennahc ot detcennoc ydaerlA"
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr "%(guild)s  :dliug ni  %(channel)s  :lennahc nioj ot gnitpmettA"
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "...eno wen a gnikam dna reyalPcisuM gnidracsiD"
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "...won reyalPcisuM wen a ekam lliw toBcisuM"
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 ".lennahc eciov detroppus a t'nsi ti ,%(channel)s/%(guild)s gninioj toN"
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr ".slennahc derugifnoc gninioj dehsiniF"
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ".htdiwdnab fo %(suffix)s %(rate).2f ot pu esu yam toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ".dnammoc siht esu tonnac dna delbane-eciov ton si rebmeM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ".lennahc eciov eht ni ton nehw dnammoc siht esu tonnac uoY"
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr ".ofnI noitacilppA tob gnitteG"
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr "%s  :lennahc ni tcennoC ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "`%(name)s`  :lennahc ni tcennoC ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr "%s  :lennahc ni kaepS ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "`%(name)s`  :lennahc ni kaepS ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr "%s  :dliug morf tneilCecioV stob gnisueR"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr "%s  :dliug ni tneilCecioV elats no tcennocsid gnicroF"
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "?dellecnac saw ro deliaf tcennocsiD"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr "%(channel)s  :won thgir lennahc eht ot tcennoc ot elbanu si toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -462,12 +451,12 @@ msgstr ""
 ".lennahc eht ot tcennoc ton dluoc toBcisuM"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "...won tneilCecioV a sah toBcisuM"
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -477,54 +466,54 @@ msgstr ""
 " noitcennoc gniyrteR"
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ".yrter oN .dellecnac saw tpmetta noitcennoc tneilCecioV toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 "?tratser ebyaM .ddo si sihT .dellecnac saw eciov ot noitcennoc toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "%s :lennahc ni kaeps ot gnitseuqer si toBcisuM"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr ".kaeps ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr ".kaeps ot tseuqer ton dluoc toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr "%s  :dliug ni reyalPcisuM a gnitcennocsiD"
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr ".reyalPcisuM eht llik ew erofeb tneilCecioV gnitcennocsiD"
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr ".dellecnac saw ro deliaf tcennocsid ehT"
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
@@ -533,18 +522,18 @@ msgstr ""
 "toBcisuM"
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr "%s  :dliug ni tneilCecioV eugor a gnitcennocsiD"
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "...tneilCecioV dliug-non a gnitcennocsiD"
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -554,19 +543,19 @@ msgstr ""
 "?tcejbo tneilCecioV-non a sniatnoc tsil stneilc_eciov.toBcisuM"
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr "%(player)r  :)%(guild_id)s( dliug ni fer reyalPcisuM a evah llits eW"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr "%(player)r  :lanoitpo ,reyalp a stnaw )%(guild)s( dliuG"
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
@@ -575,24 +564,24 @@ msgstr ""
 "reyalPcisuM ]GUB["
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr ".detcennoc ton si taht tneilCecioV a sah reyalPcisuM"
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr "%r  :jbo reyalPcisuM"
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr "%r  :jbo tneilCecioV"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -602,7 +591,7 @@ msgstr ""
 "%(guild)s  :dliug rof reyalPcisuM a gnitteG"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -612,7 +601,7 @@ msgstr ""
 "detaerC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -621,84 +610,84 @@ msgstr ""
 ".lennahc eciov a ni ton si tob ehT"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ".tneilCecioV eht teg t'ndid ew ,gnorw si gnihtemoS"
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "yalp_reyalp_no gninnuR"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "%(url)s == %(guild_id)s dliug yrotsih LRU gnitteS"
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "%s :LRU htiw yrtne rof tes lianbmuht oN"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "otni egassem gniyalp won tup ot lennahc on"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ".detsop ydaerla saw ti sa egassem gniyalp-won derongi"
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "emuser_reyalp_no gninnuR"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "esuap_reyalp_no gninnuR"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "pots_reyalp_no gninnuR"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "gniyalp_dehsinif_reyalp_no gninnuR"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr ".ereh od ot esle gnihton ,desolc si pool tnevE"
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr ".tneve siht gnirongi ,yaw rednu tuogoL"
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ".ereh od nac ew esle gnihton ,detcennoc ton si ti syas tneilCecioV"
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "...lennahc eciov gnivael ,ytpme si eueuq dna dehsinif reyalP"
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr "...rohtua gnissim htiw sgnos egnupxe ot eueuq revo gnipooL"
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
@@ -706,300 +695,300 @@ msgstr ""
 "%(song)s  :eueuq morf yrtne )deteled( deppiks ,tnesba `%(user)s` rohtuA"
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ".gnilbasid ,tsilyalpotua dliuG eht ni sgnos elbayalp oN"
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "...cisum wen htiw gnilliF .tsilyalpotua tnerruc ni tnetnoc oN"
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "...tsilyalpotua reyalp revo gnipooL"
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "%(raw_error)s  :\"%(url)s\" gnos gnissecorp elihw rorrE"
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "%(raw_error)s :\"%(url)s\" gnos gnitcartxe rorrE"
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ".liab dna noitcartxe tsilyalp otua eht pots ot sdeen toBcisuM"
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ".tneve dehsinif reyalp ni noitpecxe deldnahnu na tog toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr "%s  :morf detcartxe seirtne htiw tsilyalp otua gnidnapxE"
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr "%s :tsilyalpotua morf gnos gnidda rorrE"
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr ":rorre evoba rof atad noitpecxE"
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ".gnilbasid ,tsilyalpotua eht ni sgnos elbayalp oN"
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "dedda_yrtne_reyalp_no gninnuR"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ".yrtne deueuq rof yrtne tsilyalp-otua gnippiks yllacitamotuA"
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr "%r :yrtne rof noitpecxe reyalPcisuM"
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr ".noitpecxe reyalPcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr "%r  :deyalp eb ton dluoc kcart tsilyalp otuA"
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ".tneve etadpu sutats gnirongi ,yaw rednu tuogoL"
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr "%(activity)r -- %(status)s  :sutats tob etadpU"
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr "%s rof eueuq gnizilaireS"
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr "%s rof eueuq gnizilaireseD"
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr "%s rof gnos tnerruc gnitirW"
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "%r  :tcejbo esnopser-non dnes tonnaC"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ".tcejbo esnopser dilavni na gnidnes deirT ]guB veD["
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr "%s :ot debme gnidnes"
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr "%s :ot txet gnidnes"
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr "noissimrep on ,\"%s\" ot egassem dnes tonnaC"
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr "lennahc deteled ro dilavni ,\"%s\" ot egassem dnes tonnaC"
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ")%s( timil ezis egassem eht revo si egasseM"
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ".daetsni lennahc kcabllaf ni gnidnes ,egassem etavirp dnes ton dluoC"
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ".sdnoces %s ni gniyrter ,egassem dnes detimil etaR"
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr "%s  :rof yrter egassem dellecnaC"
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "!yrter tonnac tub ,egassem dnes detimil etaR"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr ".lennahc kcabllaf ni egassem dnes ot deliaF"
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr ".rorre PTTH na ot eud dnes ot deliaF"
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr "noissimrep on ,\"%s\" egassem eteled tonnaC"
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr "dnuof ton egassem ,\"%s\" egassem eteled tonnaC"
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ".sdnoces %s ni gniyrter ,eteled egassem detimil etaR"
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "!yrter tonnac tub ,eteled egassem detimil etaR"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "egassem eteled ot deliaF"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr "%s :egassem eteled ot gniyrt noitpecxEPTTH toG"
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr "dnuof ton egassem ,\"%s\" egassem tide tonnaC"
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "daetsni egassem gnidneS"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ".sdnoces %s ni gniyrter ,egassem tide detimil etaR"
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr "%s  :rof tide egassem dellecnaC"
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "egassem tide ot deliaF"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr "%s :ot %s egassem tide ot gniyrt noitpecxEPTTH toG"
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr "%(content)s  :)%(id)s :DI( egassem rof eteled dellecnaC"
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr "%s :SO eht morf langis a thguaC"
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "...toBcisuM nwod gnisolc dna gnitcennocsiD"
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "!langis tpurretni gnildnah elihw nworht noitpecxE"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr "...spets pu trats gniod won si toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "...spets nwodtuhs gniod won si toBcisuM"
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ".nigol ta deliaf pu tratS"
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -1022,44 +1011,44 @@ msgstr ""
 "!nigoL IPA drocsiD deliaF"
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "...pu hsinif ot sdaerht daolnwod rof gnitiaW"
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ")%(func)s(  %(name)s  :ksat rof tiaw lliW"
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ")%(func)s(  %(name)s  :ksat lecnac ot yrt lliW"
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "...sksat gnidnep gnitiawA"
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr ".rotcennoC PTTH gnisolC"
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr ".noisses ptthoia gnisolC"
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr ".dellac neeb sah tuogoL"
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -1069,39 +1058,39 @@ msgstr ""
 ":%(event)s ni noitpecxE"
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr "%s ni noitpecxE"
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr ".drocsid htiw noisses a demuser toBcisuM"
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "ydaer_no hsiniF"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "...ydaer toBcisuM gnitteg won ,ni deggoL"
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "...liab attog ew ,enon wohemos si resUtneilC"
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr "%(desc)s#%(name)s/%(id)s  :toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
@@ -1109,31 +1098,31 @@ msgstr ""
 "%(desc)s#%(name)s/%(id)s     :renwO"
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr ":tsiL dliuG"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr "%s - "
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr "dnuof ton renwo tob ot eud %s tfeL"
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr "ytilibaliavanu ot eud srevres %s ni skcehc htiw gnideecorp toN"
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
@@ -1141,12 +1130,12 @@ msgstr ""
 ")%s :di( dliug yna no dnuof eb ton dluoc renwO"
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr ".sdliug yna no ton si tob ,nwonknu renwO"
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1160,90 +1149,90 @@ msgstr ""
 " .resworb ruoy ni knil siht etsap ,dliug a nioj tob eht ekam oT"
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr "%d  :DI htiw lennahc dnuob rof enoN toG"
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "%d  :DI htiw lennahc elbaegasseM non ot dnib tonnaC"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr ":slennahc txet ot dnuoB"
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr "lennahC etavirP"
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr "MD resU nwonknU"
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr "%(name)s :MD resU"
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ")laitraP( lennahC nwonknU"
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr "%(id)s :lennahC demannU"
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr "%(channel)s/%(guild)s - "
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "slennahc txet yna ot dnuob toN"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "%d  :DI htiw lennahc nioj otua rof enoN toG"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr "%d  :DI htiw lennahc dliuG-noN/etavirP a nioj otua tonnaC"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr "%d  :DI htiw lennahc elbatcennoc-non ot nioj otua tonnaC"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr ":slennahc eciov gninioj otuA"
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "slennahc eciov yna gninioj otua toN"
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -1276,369 +1265,369 @@ msgstr ""
 "!snoitpo gifnoc gnissim detceteD"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr "semit %s derif sah ydaer_no tnevE"
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr ".ofni noitacilppa gnitteG"
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "tsixe sredlof atad gnirusnE"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "gifnoc gnitadilaV"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "gifnoc snoissimrep gnitadilaV"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "delbasiD"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "delbanE"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr ":snoitpO"
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr "%s :xiferp dnammoC  "
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr "%s :noitnem@ yb dnammoC  "
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr "%s :sesaila dnammoC  "
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr "%%%d :emulov tluafeD  "
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr "%%%(percent).0f ro setov %(num)d :dlohserht pikS  "
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr "%s :piks ycageL    "
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr "%s :piks-atsni rohtuA    "
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr "%s :snoitnem@ gniyalP woN  "
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr "%s :lennahc eciov s'renwO nioj-otuA  "
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ")%(order)s :redro( %(status)s :tsilyalP-otuA  "
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "modnar"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "laitneuqes"
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr "%s :yrotsih eueuq revres-rep evaS    "
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr "%s :yrotsih eueuq labolg evaS    "
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr "%s :rorre noitcartxe no sLRU evomeR    "
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr "%s :stseuqer resu rof tsilyalp pikS    "
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr "%s :esuaP-otuA  "
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr "%s :segasseM eteleD  "
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr "%s :gnikovnI eteleD    "
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "%s :gniyalP woN eteleD    "
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr "%s :edoM gubeD  "
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr "%s :tsilkcolb sgnoS  "
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr "%s :tsilkcolb sresU  "
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr "%s eb lliw sgnos dedaolnwoD  "
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr "syad %d rof desunu fi eteleD    "
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr "%s sdeecxe ehcac fi eteleD    "
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr "%s :kcart txen daolnwod-erP  "
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr "%s :egassem sutatS  "
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr "%s :elif ot eltit gnos tnerruc etirW  "
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr "%s :sdebmE htiw dnopseR  "
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr "delbasiD txeT retooF    "
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr "%s  :txeT retooF    "
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr "%s :noitargetni yfitopS  "
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr "%s :rebmem a ton si renwO erehw srevres evaeL  "
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr "%s :lennahc evitcani morf tcennocsiD  "
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr "sdnoces %s :tuoemiT    "
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr "%s :eueuq fo dne ta tcennocsiD  "
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr "%s :seldi reyalp nehw tcennocsiD  "
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr "sdnoces %d :tuoemiT    "
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr "%s :nefaeD fleS  "
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr "%s :xiferp dnammoc revres-reP  "
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr "%s :snoitcaer gnisu hcraeS  "
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr "%d :hcraes rep stluseR    "
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr "%s :eueuQ niboR dnuoR  "
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr "%s :selif aidem lacoL  "
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr "%s :stset gnip gnikcehc krowteN  "
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr "%s :htiw dessecorp oiduA  "
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr "%s :kcart-rep level oidua ezilauqE  "
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr "%s  :ot tes yxorP PTTH  "
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr "%s  :ot tes tnegA resU  "
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ".tsil kcolb gnos eht yb dekcolb si `%(subject)s` gnos detseuqer ehT"
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 "...eciov ni ton si toB tub ,ytivitcani lennahC ecioV eldnah ot detpmettA"
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr "%s :dliug ni gnitiaw ydaerla ytivitca lennahC"
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr "lennahC nwonknU"
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1646,31 +1635,31 @@ msgstr ""
 "%(channel)s :lennahc evael ot sdnoces %(time)d gnitiaw ytivitca lennahC"
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ".gnitcennocsiD .deripxe sah %s rof remit ytivitca lennahC"
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "%(guild)s ni %(channel)s :rof delecnac remit ytivitca lennahC"
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr "%s  :lennahc denioj-otua ni ytivitcani reyalp gnirongI"
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr "%s :dliug ni gnitiaw ydaerla remit ytivitca reyalP"
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
@@ -1678,134 +1667,134 @@ msgstr ""
 "%(channel)s :lennahc evael ot sdnoces %(time)d gnitiaw remit ytivitca reyalP"
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ".gnitcennocsiD .deripxe sah %s rof remit ytivitca reyalP"
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr "%(guild)s ni %(channel)s :rof delecnac remit ytivitca reyalP"
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr ".teser gnieb si remit ytivitca reyalP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "dnammoc hcus oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ".rebmun DI rieht edivorp ro resu a noitnem tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ".selpmaxe egasu rof `resukcolb pleh` esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ".deificeps uoy )s(resu eht dnif ton dluoc toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ".tsil kcolb eht ot dedda eb tonnac renwo ehT"
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr "%(name)s/%(id)s  :dekcolb ydaerla ,tsil kcolb ot resu gnidda toN"
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr "%(name)s/%(id)s  :detsil ton ,tsil kcolb morf resu gnivomer toN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ".dedda ydaerla era yeht ,detsil uoy sresu eht dda tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ".gniyalp yltnerruc si gnos on fi tcejbus gnos a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ".selpmaxe egasu rof `gnoskcolb pleh` esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ".tsil kcolb gnos eht ni ydaerla si `%(subject)s` tcejbuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ".devomer eb tonnac dna tsil kcolb gnos eht ni ton si tcejbus ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 ".selpmaxe egasu rof `tsilyalpotua pleh` esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "dilavni si knil gnos deilppus ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "!dnammoc yalp a htiw sgnos emos ddA .ytpme si eueuq ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ".tsilyalpotua eht ni ydaerla si gnos sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ".tsilyalpotua eht ni tey ton si gnos sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ".emanelif tsilyalp a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr "`%(playlist)s` :eman eht htiw stsixe elif tsilyalp oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ".dnammoc siht esu ot lennahc eciov a ni eb tsum uoY"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr " :)(ofni_tcartxe htiw eussI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1815,18 +1804,18 @@ msgstr ""
 ":rorre ot eud ofni tcartxe ot deliaF"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "stsilyalp tseuqer ot dewolla ton era uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ")%(max)s si xam tub %(songs)s( seirtne ynam oot sah tsilyalP"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1838,12 +1827,12 @@ msgstr ""
 ".timil eueuq ruoy deecxe lliw seirtne tsilyalp ehT"
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr ".egatuo krowten ot eud esuap-otua gnirongI"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
@@ -1852,12 +1841,12 @@ msgstr ""
 "reyalPcisuM"
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr ".tneve siht gnirongi ,esuap-otua gnissecorp ydaerlA"
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1867,55 +1856,55 @@ msgstr ""
 "tneilCecioV%s"
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr ".dellecnac saw gnitiaw esuap-otuA"
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ".tneve esuap-otua dlo gnirongi ,detcennoc gnieb si reyalPcisuM wen A"
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr "%s :dliug rof esuap otua gninnur ,lennahc eciov ytpme na ni gniyalP"
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr "%s :dliug rof gnisuapnu si reyalp desuap otua ylsuoiverP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ".gniyalp gnihton si ereht fi kees esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ".noitarud nwonknu na sah ti ,kcart tnerruc no kees esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ".smaerts rof detroppus ton si gnikeeS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ".kcabyalp noitisop ot emit a tuohtiw kees esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ".sdnoces ni emit dilav a ot `%(input)s` trevnoc ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1925,69 +1914,69 @@ msgstr ""
 "`%(seconds)s`( `%(input)s` ot kees tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 ".selpmaxe egasu rof `taeper pleh` dnammoc eht esU .dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ".gnipool yltnerruc ton si reyalp ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "!sregetni eb tsum snoitisop gnoS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "!ezis tsilyalp eht edistuo noitisop a evag uoY"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 ".ot snoitcaer dda ot egassem on ,kcabyalp tsilyalp rof tpmorp ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ".delbane ton si kcabyalp aidem lacoL"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ".detroppus yltnerruc ton ro dilavni si LRU yfitopS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ".delbane ton si yfitopS tub ,LRU yfitopS a detceteD"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ")%(max)s( timil gnos deueuqne ruoy dehcaer evah uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "!delbasid sti nehw niaga yrt esaelp ,delbane si edom ekoaraK"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ".dnammoc maerts eht gnisu yrT .deyalp eb tonnac oediv tahT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4437
+#: musicbot/bot.py:4436
 #, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "%(url)s  :rof stluser on denruter hcraes ebuTuoY"
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr "%(url)s  :rof %(extractor)s htiw stluser on denruter hcraeS"
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -2115,18 +2104,32 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr "%(path)s :elif eueuq eteled ot gniyrt elihw rorre level SO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "!evomer ot eueuq eht ni gnihtoN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .snoitisop dilavnI"
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+"\n"
+".eueuq eht morf egnar nevig eht ni sgnos eht lla evomer ot noissimrep eht evah ton od uoY"
+
+#. Used by: CommandError
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s` resu morf eueuq eht ni dnuof gnihtoN"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -2135,38 +2138,38 @@ msgstr ""
 ".eueuq eht morf yrtne taht evomer ot noissimrep eht evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .rebmun yrtne dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "!gniyalp ton si reyalp ehT !piks t'naC"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ".gnos depool a piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ".piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ".gnos depool a piks ot noissimrep evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "rebmun dilav a ton si `%(new_volume)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -2176,7 +2179,7 @@ msgstr ""
 ".%(new_volume)s si %(adjustment)s%(old_volume)s :dedivorp egnahc emulov elbanosaernU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -2184,7 +2187,7 @@ msgstr ""
 ".001 dna 1 neewteb eulav a edivorP .%(volume)s :dedivorp emulov elbanosaernU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -2193,28 +2196,28 @@ msgstr ""
 ".deeps tes tonnac ,gniyalp si kcart oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ".aidem demaerts ot deilppa eb tonnac deepS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ".tes ot deeps a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ".001 dna 5.0 neewteb rebmun a esU .dilavni si dedivorp uoy deeps ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "`%(option)s` :dnammoc rof noitpo dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2224,28 +2227,28 @@ msgstr ""
 ":rorre ot eud sesaila evas ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "saila ot dnammoc a dna saila na ylppus tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ".evomer ot eman saila na ylppus tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ".tsixe ton seod `%(alias)s` saila ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac gifnoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2255,7 +2258,7 @@ msgstr ""
 ":rorre gniwollof eht ot eud gifnoC daoler ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2264,17 +2267,17 @@ msgstr ""
 "noitces evloser ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ".eman noitces a edivorp esaelp ,suougibma si nevig noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ".dnammoc siht rof eman noitpo dna eman noitces a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2284,97 +2287,97 @@ msgstr ""
 ".elbaliava ton si `%(section)s` noitces ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ".ksid ot evas tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "`%(option)s`  :noitpo eht evas ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ".deyalpsid eb tonnac eulav ,elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ".gnittes etadpu tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ".dnammoc bus siht rof eulav dna ,noitpo ,noitces a edivorp tsum uoY"
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "%(value)s == %(config)s no htiw tes gnioD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ".tluafed ot teser tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "%(value)s tluafed ot %(config)s gnitteseR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "!tluafed ot teser ton saw `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ".daetsni dnammoc gifnoc eht esu ,detacerped si dnammoc noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "raelc ro ,etadpu ,ofni :esu ,deificeps noitpo dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "...ofni erom rof sgol kcehc ,ehcac eteled ot **deliaF**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ".rebmun elohw a eb tsum tnemugra egap eueuQ"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos eueuQ !deueuq sgnos on era erehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2384,22 +2387,32 @@ msgstr ""
 ".sdnuob fo tuo si rebmun egap detseuqeR"
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr ".yrtne tsilyalp tnerruc eht deppikS"
 
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+".skcart %(count)d tsil ylno dluoc ew tub %(option)d si gnittes ehT !hgih oot"
+" tes htgneLeueuQ evah yam uoY"
+
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr ".eueuq eht etanigap ot seirtne hguone toN"
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ".ot snoitcaer dda ot egassem on ,egassem eueuq tsop ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2408,17 +2421,17 @@ msgstr ""
 ".egassem eueuq eht ot ecnerefer a teg ro ekam t'ndluoc toBcisuM .niaga taht yrT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ".lennahc MD etavirp no egrup esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ".LRU dilav a ton saw LRU nevig ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2429,12 +2442,12 @@ msgstr ""
 "lru tupni morf ofni tcartxe ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ".tsilyalp a eb ot mees ton seod sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2443,17 +2456,17 @@ msgstr ""
 "dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ".niaga yrT  .resU drocsid eht enimreted ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac snoissimreP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2463,23 +2476,23 @@ msgstr ""
 ":rorre na ot eud snoissimreP daoler ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ".dnammoc siht rof eman noitpo ro puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ".dnammoc siht rof tes ot eulav dna ,noitpo ,puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ".eman noissimrep dna puorg a seriuqer dnammoc-bus %(option)s ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2489,47 +2502,47 @@ msgstr ""
 ".elbaliava ton si `%(group)s` puorg ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noissimrep ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ".stsixe ydaerla ti `%(group)s` puorg dda tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ".puorg ni-tliub evomer tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ".elbatide ton si puorg renwo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "`%(group)s`  :puorg eht evas ot deliaF"
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "%(value)s :eulav htiw %(option)s no tes gnioD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noissimreP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2539,7 +2552,7 @@ msgstr ""
 "?semit ynam oot seman egnahc uoy diD .emanresu egnahc ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2549,12 +2562,12 @@ msgstr ""
 "  :rorre ot eud emanresu egnahc ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ".noissimrep on :emankcin egnahc ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2564,12 +2577,12 @@ msgstr ""
 "  :rorre ot eud emankcin tes ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ".xiferp a sa esu ot revres siht morf eb tsum ijome motsuC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2578,28 +2591,28 @@ msgstr ""
 "!delbane ton si revres rep xiferP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ".sdliug ni desu eb ylno nac dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ".noitamrofni erom rof dnammoc pleh eht esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ".elbaliava ton si ti `%(locale)s` ot egaugnal tes tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ".elif a hcatta ro LRU a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2609,63 +2622,63 @@ msgstr ""
 "  :rorre ot eud ratava egnahc ot elbanU"
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ".melborp a eb dluoc sihT  !dliug on htiw %s a dnuof toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "`%(guild)s` revres ot detcennoc yltnerruc toN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "tigpu ro ,pippu ,edargpu ,lluf ,tfos  :fo eno esu ,nevig noitpo dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ".eman ro DI na edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "`%(input)s` eman ro DI eht htiw dnuof saw dliug oN"
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "%(uuid)s :DI tniopkaerb gubed gnitavitcA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "?dellatsni ti si ,`hpargjbo` tropmi ton dluoC"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr ".)(lave htiw nar edoc gubeD"
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr ".)(cexe htiw nar edoc gubeD"
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr ".etucexe ot deliaf edoc gubeD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2681,54 +2694,54 @@ msgstr ""
 ":edoc gubed etucexe ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "%(options)s :fo eno eb tsum dnammoc-buS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ".elbatucexe tig etacol ton dluoC"
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ".dnammoc tig aiv setadpu rof gnikcehc elihw deliaF"
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr ".troper pip ni atem gnissim egakcaP"
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ".rorre emos ot eud sutats etadpu pip teg ot deliaF"
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr ".yrtne tneilc eciov egnarts a toG"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ".delbane ydaerla seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ").elif seikooc gnissiM( .delbane eb ot dedaolpu eb tsum seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "%(raw_error)s  :rorre ot eud seikooc elbane ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2738,56 +2751,56 @@ msgstr ""
 "%(raw_error)s  :rorre ot eud elif seikooc emaner ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 ".elif eikooc a gnidaolpu elihw niaga yrt ,dnuof erew sdaolpu dehcatta oN"
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "%(raw_error)s  :elif seikooc delbasid ,dlo evomer ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "%(raw_error)s  :drocsid morf elif seikooc eht gnidaolnwod rorrE"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "%(raw_error)s  :ksid ot seikooc evas ton dluoC"
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "%s  :wohemos ,lennahc on htiw egassem a toG"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ")%s( flesym morf dnammoc gnirongI"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ")%s( tob rehto morf dnammoc gnirongI"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "%s  :epyt fo lennahc morf dnammoc gnirongI"
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
@@ -2796,121 +2809,121 @@ msgstr ""
 "toBcisuM"
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ".derongi lennahc rellac ,lennahc dnuob a sah revres rellaC"
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ".dewolla rellac ,lennahc dnuob on sah revres rellaC"
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr "%s  :revres ni )%s( lennahc dnuobnU"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr "%(command)s :dnammoc deirt  %(name)s/%(id)s :tsil kcolb ni resU"
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "%(message)s :%(name)s/%(id)s morf egasseM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "%(group)s  :puorg snoissimrep ruoy rof dewolla ton si dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ".lennahc ecioV a ni eb ot uoy seriuqer dnammoc sihT"
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "%(params)r :smarap rof seulav gnissim ,egasu dnammoc dilavnI"
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "%(err_text)s :%(err_name)s :%(command)s ni rorrE"
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "%(command)s :dnammoc gnildnah elihw noitpecxE"
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "%s  :dnammoc gnissim rof pleh etareneg tonnaC"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "%s  :dnammoc rof atad pleh gnissiM"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ".ytivitcani ot eud %s ni %s lennahc eciov gnivaeL"
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr ".detcennoc emoceb sah toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr ".detcennocsid emoceb sah toBcisuM"
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "%s  :tnevE tekcoS a toG"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "dehsinif ydaer_no erofeb detadpu etatSecioV"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ".lennahc eciov dnuob a si ti sa %s ni %s gnirongI"
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ".stuoemit gnildnaH .ytpme sa detceted neeb sah %s"
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ".remit gnillecnac ,%s denioj resu A"
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2918,30 +2931,30 @@ msgstr ""
 ".stuoemit gnildnaH .ytpme si %s lennahc eciov eht dna devom tog tob ehT"
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ".ytpme ton si %s lennahc eciov eht dna devom tog tob ehT"
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "%s resu gniwollof regnol oN"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "%(channel)s  :lennahc ot `%(user)s` resu gniwolloF"
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr ".enoN si lennahc.erofeb tcennocsid etatSecioV"
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2951,97 +2964,97 @@ msgstr ""
 "eciov morf detcennocsiD"
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 "%(guild)s  :dliug ni  %(type)s :epyt htiw lennahc nioj-otua esu tonnaC"
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "%s  :dliuG  ?deteled ti saw ,lennahc denioj-otua eht dnif tonnaC"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "%s  :lennahc no dliug denioj-otua ot gnitcennoceR"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "%s  :lennahc nioj otua tonnaC"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "%s :dliug ot dedda neeb sah toB"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ".dnuof ton renwo tob ot eud '%s' dliug tfeL"
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "%s dliug rof redlof atad gnitaerC"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "%s :dliug morf devomer neeb sah toB"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr ":tsil dliug detadpU"
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ".elbaliava emoceb sah \"%s\" dliuG"
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ".ytilibaliava ot eud \"%s\" ni reyalp gnimuseR"
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ".elbaliavanu emoceb sah \"%s\" dliuG"
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ".ytilibaliavanu ot eud \"%s\" ni reyalp gnisuaP"
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "%s  :rof etadpu dliuG"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "%(old)s :saW --  %(new)s :won si %(attr)s etubirtta dliuG"
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "%(changes)s  --  %(channel)s  :rof etadpu lennahC"
@@ -3059,12 +3072,12 @@ msgid "Loading config from:  %s"
 msgstr "%s  :morf gifnoc gnidaoL"
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr "...selif snoitpo gifnoc wen gnitareneG"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3087,7 +3100,7 @@ msgstr ""
 ".elif snoitpo gifnoc tluafed gnitaerc rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3117,7 +3130,7 @@ msgstr ""
 ".gifnoc gnidaer elihw rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -3127,7 +3140,7 @@ msgstr ""
 "tonnaC"
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -3136,7 +3149,7 @@ msgstr ""
 "tamroFetaDsgoL noitpo gifnoC"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3155,12 +3168,12 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ".htaPehcaCoiduA gnitadilav elihw nworht saw noitpecxe nA"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3182,13 +3195,13 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "%s  :ni derots eb lliw ehcaC oiduA"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3208,7 +3221,7 @@ msgstr ""
 ".snoitpo gifnoc gnidaer elihw rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -3217,7 +3230,7 @@ msgstr ""
 "egasseMsutatS"
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -3227,17 +3240,17 @@ msgstr ""
 "tsum deeps kcabyalp tluafed ehT"
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "...atad ecivres htiw snoitpo gnitadilaV"
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "IPA aiv DI renwo deriuqcA"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3258,12 +3271,12 @@ msgstr ""
 ".yllacitamotua 'DIrenwO' gnihctef elihw rorrE"
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ".deecorp tonnac ,ecnatsni resu a evah ton seod toBcisuM"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3282,12 +3295,12 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "...sevitanretla rof gnikcehC .dnuof ton elif snoitpo gifnoC"
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3297,13 +3310,13 @@ msgstr ""
 "%(ini_file)s gnimaneR"
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "%(example_file)s  :elif snoitpo elpmaxe gnitsixe gniypoC"
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -3315,12 +3328,12 @@ msgstr ""
 ".selif snoitpo elpmaxe ro snoitpo gifnoc etacol ton dluoC"
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ".elif noitpo gifnoc a dnif ot gniyrt elihw gnorw tnew gnihtemoS"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3342,7 +3355,7 @@ msgstr ""
 ".gifnoc gnitacol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3366,12 +3379,12 @@ msgstr ""
 ".gifnoc gnidaol rorrE"
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ".elbaliava ton si taht retteg sah noitpo gifnoC !guB veD"
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3380,43 +3393,43 @@ msgstr ""
 "!guB veD"
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr ".ylsuoiverp gnissim saw noitpO"
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "%s :gnissiM !gifnoc desrap ni ton noitces gifnoC"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "%(value)s  =  %(config)s :noitpo gifnoc devaS"
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "%s  :gifnoc evas ot deliaF"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 ".delbasid si revloseR  !snoitces INI neewteb euqinu ton era seman noitpO"
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "%s  :ta elif INI tluafed evas ot deliaF"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3436,7 +3449,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3456,7 +3469,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3476,7 +3489,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3486,7 +3499,7 @@ msgstr ""
 "dilavnI"
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3496,7 +3509,7 @@ msgstr ""
 "]%(section)s[ noitpO"
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3506,7 +3519,7 @@ msgstr ""
 "eulav a sah %(option)s > ]%(section)s[ noitpO"
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3514,139 +3527,144 @@ msgstr ""
 "%(new_o)s > ]%(new_s)s[  ot  %(old_o)s > ]%(old_s)s[ yrtne elif INI gnimaneR"
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "...snoitpo demaner htiw elif gifnoc gnidargpU"
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ".yllaunam ti edargpu ot deen ll'uoY  .gifnoc edargpu ot deliaF"
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "%s  :dnuof ton elif tsil kcolB"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "%s  :elif morf tsil kcolb daol ton dluoC"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "%s  :elif tsil kcolb eht etadpu ton dluoC"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ".seirtne %s htiw tsil kcolB resU dedaoL"
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "%s  :ot demaner eb lliw ti ,elif tsilkcalb ycagel a dnuof eW"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ".seirtne %s htiw tsil kcolB gnoS a dedaoL"
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "!edoc eht ni gub a ylekil si sihT .0 DI htiw dliug rof atad daol tonnaC"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr "%(name)s/%(id)s dliug rof elif oN"
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr "%(name)s/%(id)s  :DI htiw dliug rof atad dliug gnidaoL"
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "%s  :elif atad dliug gnidaer detneverp rorre SO nA"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr "%(prefix)s :xiferp dnammoc motsuc sah %(name)s/%(id)s dliuG"
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 "!edoc eht ni gub a ylekil si sihT .0 DI htiw dliug rof atad evas tonnaC"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ".rorrE SO ot eud atad cificeps dliug evas ton dluoC"
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ".atad dilavni ot eud atad cificeps dliug ezilaires ot deliaF"
 
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ".gnissecorp ni gub a eb yam ereht skniht PLDTY"
+
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "%s  :tnegA resU esu ot PLDTY gnicroF"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "%s  :morf pld-ty rof seikooc esu lliw toBcisuM"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ".revres yxorp derugifnoc ruoy esu lliw pld-tY"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "...sredaeh on evah ot smees DAEH"
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ".tuoemit ot eud deliaf sredaeh aidem gnikcehC"
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "%s  :rof tseuqer DAEH deliaF"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr " :noitpecxe tseuqeR DAEH"
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3656,79 +3674,79 @@ msgstr ""
 ":)NOSJ ton( ofnI noitcartxE LDTY dezitinaS"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "%s  :)NOSJ ton( ofnI noitcartxE LDTY dezitinaS"
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr "%s  :detseuqer tsilyalPotuA"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ".atad on denruter noitcartxe ofni gnoS"
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "%(kws)s ,%(args)s ,'%(subject)s'  :htiw ofni_tcartxe dellaC"
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ").snwodtuhs no lamron si sihT( .desolc si pool ,noitcartxe nur tonnaC"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ".desolc si pool tneve ,noitcartxe eunitnoc tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ".detroppus ton ro dilavni si LRU yfitopS"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "%(raw_error)s :atad aidem gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "LRU maerts htiw rorrE daolnwoD"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "maerts tcerid a si tnetnoc gnimussA"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ".LRU dilavni na maerts tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "%(raw_error)s :atad maerts gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 ".ecaps htiw noloc gnicalper retfa niaga gniyrt ,sreldnaHgnitroppuSoN thguaC"
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -3738,48 +3756,48 @@ msgstr ""
 "%(extractor)s rotcartxE"
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "%(kws)s ,%(args)s  :htiw ofni_tcartxe_efas dellaC"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ".dnuof eb ton dluoc elif aidem lacol ehT"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ".tsixe ton seod tsilyalp ehT"
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr "%(raw_error)s :ot eud '%(track)s' kcart ssecorp ton dluoC"
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
 ".eueuq eht ot tsilyalp otua gnidda elihw noitpecxe deldnahnu na tog toBcisuM"
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "tciDesnopseRpldtY morf tcejbus_tupni__ gnissiM"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 ".siht diova ot eurT=ssecorp tes ,tciDesnopseRpldtY ni tsil a ton si seirtnE"
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "%(url)s :rof rorre noitarud ,gninraW"
@@ -3826,17 +3844,17 @@ msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "nwonknU"
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ".ezilairesed tonnac ,rebmun noisrev gnissim si atad yrtnE"
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ".ezilairesed tonnac ,rebmun noisrev gnorw eht sah atad yrtnE"
 
@@ -3866,7 +3884,7 @@ msgstr ""
 "!pukool rof lennahc on tub DI rohtua na sah yrtnEtsilyalPLRU dezilaireseD"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "%s daol ton dluoC"
@@ -3878,7 +3896,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr "%(type)s :epyt htiw rorre gnissecorp ,sknil yfitopS daolnwod tonnaC"
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "%r  :yrtne rof ydaer gnitteG"
@@ -3900,7 +3918,7 @@ msgid "Download already cached at:  %s"
 msgstr "%s  :ta dehcac ydaerla daolnwoD"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3918,7 +3936,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr "%(file)s  :elif rof sdnoces %(time)s fo noitarud toG"
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3929,75 +3947,75 @@ msgstr ""
 "desuac ylekil ,QE tuo gnikrow htiw melborp a sa erehT"
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr ".atad yrtne gnikcehc elihw noitpecxE"
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "%s  :rof ofniaidemyp aiv noitarud teg ot gniyrT"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr ".ofniaidemyp aiv noitarud teg ot deliaF"
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "%s  :rof eborpff aiv noitarud teg ot gniyrT"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "!htap ruoy ni eborpff etacol ton dluoC"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr ".desu eb ton dluoc taht gnihtemos denruter eborpff"
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr ".nosaer emos rof detucexe eb ton dluoc eborpff"
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "%s  :fo emulov naem gnitaluclaC"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "!htap ruoy no gepmff etacol ton dluoC"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr ".nosj ezilamron ni 'I' esrap ton dluoC"
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr ".nosj ezilamron ni 'ARL' esrap ton dluoC"
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr ".nosj ezilamron ni 'PT' esrap ton dluoC"
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr ".nosj ezilamron ni 'hserht' esrap ton dluoC"
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr ".nosj ezilamron ni 'tesffo' esrap ton dluoC"
 
@@ -4040,78 +4058,78 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "%(raw_error)s :rorre pld-ty a ot eud deliaf daolnwoD"
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr ".noitpecxe deldnahnu na deretnuocne noitcartxE"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "%(raw_error)s :noitpecxe deldnahnu na ot eud deliaf daolnwoD"
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "%r  :deliaf daolnwoD"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ".aidem detseuqer eht rof atad tcartxe ot deliaF"
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "%r  :etelpmoc daolnwoD"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "%s  :DI htiw lennahc dnif tonnac yrtnEtsilyalPmaertS dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "%s  :epyt lennahc gnorw eht sah yrtnEtsilyalPmaertS dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr "%s  :DI htiw rohtua dnif tonnac yrtnEtsilyalPmaertS dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 "!pukool rof lennahc on tub DI rohtua na sah yrtnEtsilyalPmaertS dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr "%s  :DI htiw lennahc dnif tonnac yrtnEtsilyalPeliFlacoL dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr "%s  :epyt lennahc gnorw eht sah yrtnEtsilyalPeliFlacoL dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr "%s  :DI htiw rohtua dnif tonnac yrtnEtsilyalPeliFlacoL dezilaireseD"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
@@ -4120,7 +4138,7 @@ msgstr ""
 "dezilaireseD"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr "%(file)s  :elif rof sdnoces %(seconds)s fo noitarud toG"
@@ -4234,19 +4252,19 @@ msgstr ""
 "otuA"
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "%s  :rorrE tnemugrA gnaL"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr "%s  :ni  ]%s[  :fo yna rof snoitalsnart gol daol ot deliaF"
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4618,63 +4636,63 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "%s :gepmff morf atad dedoceD"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr "%(url)s  :LRU rof yrtne maerts gniddA"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "noitamrofni tcartxe ton dluoC"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ".tsilyalp a si sihT"
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr "...yrtne maerts gnidda ,maerts a eb ot sraeppa ofni yrtnE"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "%(url)s :LRU rof `%(type)s` epyt tnetnoc dilavnI"
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ".maerts a eb thgim siht ,epyt-tnetnoc rof lmth/txet toG"
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr "%(url)s  :lru rof \"%(type)s\" epyt-tnetnoc elbanoitseuQ"
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr "%(subject)s :rof yrtnEtsilyalPLRU gniddA"
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr "%(subject)s :rof yrtnEtsilyalPeliFlacoL gniddA"
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "%s  :DI htiw knil tsilyalp dnuopmoc morf oediv derongI"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
@@ -4682,7 +4700,7 @@ msgstr ""
 "%(url)s :LRU  %(title)s  :tsil kcolb gnos ni si taht yrtne gniwolla toN"
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
@@ -4690,46 +4708,46 @@ msgstr ""
 ".mumixam dettimrep naht regnol noitarud ,'%s' yb seirtne ni gnos gnirongI"
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr "%s  :deteled ro etavirp dekram si ti esuaceb oediv ebuTuoY gnidda toN"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "meti dda ton dluoC"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "%s :metI"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "seirtne dab %s deppikS"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr ".seirtne revo gnipool redroeR"
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "%r  :kcart txen gnidaolnwod-erP"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "atad noitarud on"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "yrtne tnerruc ni atad noitarud on"
 
@@ -4900,18 +4918,18 @@ msgid "Failed to get Guest Token due to: %(raw_error)s"
 msgstr "%(raw_error)s :ot eud nekoT tseuG teg ot deliaF"
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr "...stseT dnammoC gnitratS"
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr "%(cmd)s :dnammoc dereffuB"
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr "%(cmd)s :%(t)s fo %(n)s DMC gnissecorP -"
@@ -5427,42 +5445,42 @@ msgstr ""
 ".selif elbatum lla erots nac toBcisuM erehw yrotcerid a ylppuS"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "%s  :noisreV"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "!desolc ylefas eb nac lanimret sihT .ecnatsni toBcisuM wen a denepO"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "%s  :noisrev toBcisuM gnidaoL"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "%s  :denepo goL"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "%s  :noisrev nohtyP"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "%s  :ot yrotcerid gnikrow gnignahC"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5473,7 +5491,7 @@ msgstr ""
 "tonnaC"
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5482,12 +5500,12 @@ msgstr ""
 ".otni toBcisuM denolc uoy redlof emas eht morf `yp.nur` trats ,stluser tseb roF"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr "...selif gifnoc elpmaxe gnitadpU"
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5496,12 +5514,12 @@ msgstr ""
 "etacifitreC"
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr ".gub a eb dluoc ti ,rorre tcaxe eht si ereH"
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5511,7 +5529,7 @@ msgstr ""
 " ,erots tsurt swodniW ot etacifitrec a dda ylisae oT"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5520,17 +5538,17 @@ msgstr ""
 " dluoC"
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ")?edoc eht tide uoy did ,detceted noitacifidom( rorre xatnyS"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ")tluaf ruoy ton ,gub a si siht( rorre xatnyS"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5551,14 +5569,14 @@ msgstr ""
 "!rorre na ot eud toBcisuM trats tonnaC"
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "\n"
 "...yllacitamotua segakcap ycnedneped toBcisuM llatsni ot gnitpmettA"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5594,12 +5612,12 @@ msgstr ""
 "!dellatsni eb ton yam seicnedneped toBcisuM"
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "!dekrow seicnedneped gnillatsni epoh stel ,KO"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
@@ -5608,42 +5626,67 @@ msgstr ""
 "toBcisuM"
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr " :rorre evoba eht desuac hcihw noitpecxe ehT"
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "...tratser tfos a gniod si toBcisuM"
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "...tratser ssecorp lluf a gniod si toBcisuM"
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "tob gnitrats rorrE"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr ".pool tneve gnisolC"
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "...sdnoces %s ni gnitratseR"
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr ".enod llA"
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "!gnisolc er'ew ,KO"
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""

--- a/i18n/xx/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/xx/LC_MESSAGES/musicbot_logs.po
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-05-02 07:00-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -478,20 +478,20 @@ msgstr ""
 "?tratser ebyaM .ddo si sihT .dellecnac saw eciov ot noitcennoc toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "%s :lennahc ni kaeps ot gnitseuqer si toBcisuM"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr ".kaeps ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr ".kaeps ot tseuqer ton dluoc toBcisuM"
 
@@ -626,7 +626,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr "%(url)s == %(guild_id)s dliug yrotsih LRU gnitteS"
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "%s :LRU htiw yrtne rof tes lianbmuht oN"
@@ -710,19 +710,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "...tsilyalpotua reyalp revo gnipooL"
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr "%(raw_error)s  :\"%(url)s\" gnos gnissecorp elihw rorrE"
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr "%(raw_error)s :\"%(url)s\" gnos gnitcartxe rorrE"
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ".liab dna noitcartxe tsilyalp otua eht pots ot sdeen toBcisuM"
 
@@ -1104,7 +1104,7 @@ msgstr ":tsiL dliuG"
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr "%s - "
@@ -1789,12 +1789,12 @@ msgid "You must be in a voice channel to use this command."
 msgstr ".dnammoc siht esu ot lennahc eciov a ni eb tsum uoY"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr " :)(ofni_tcartxe htiw eussI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1925,7 +1925,7 @@ msgid "The player is not currently looping."
 msgstr ".gnipool yltnerruc ton si reyalp ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "!sregetni eb tsum snoitisop gnoS"
 
@@ -1947,39 +1947,39 @@ msgid "Local media playback is not enabled."
 msgstr ".delbane ton si kcabyalp aidem lacoL"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ".detroppus yltnerruc ton ro dilavni si LRU yfitopS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ".delbane ton si yfitopS tub ,LRU yfitopS a detceteD"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ")%(max)s( timil gnos deueuqne ruoy dehcaer evah uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "!delbasid sti nehw niaga yrt esaelp ,delbane si edom ekoaraK"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ".dnammoc maerts eht gnisu yrT .deyalp eb tonnac oediv tahT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr "%(url)s  :rof %(extractor)s htiw stluser on denruter hcraeS"
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1989,7 +1989,7 @@ msgstr ""
 " dessecorP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1997,100 +1997,100 @@ msgstr ""
 ")sdnoces %(max)s( noitarud xam revo erew sgnos lla ,dedda erew sgnos oN"
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "yek rotcartxe sa 'tsilyalp:ebutuoy' htiw yrtne na detcartxE"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ")%(max)s > %(length)s( timil sdeecxe noitarud gnoS"
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr "%s noitisop ta )s(gnos deddA"
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr "%d :noitisop rof gniyalp litnu emit etamitse tonnaC"
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr "%s :tseuqer maerts eht morf ofni teg ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ".detroppus tey ton si stsilyalp gnimaertS"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ")%(max)s( timil meti tsilyalp ruoy dehcaer evah uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 ".noitamrofni erom rof `hcraes pleh` esU  .yreuq hcraes a yficeps esaelP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "soediv %(max)s naht erom rof hcraes tonnac uoY"
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr "%s :kcol nommus rof gnitiaW"
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr "%s :rof deriuqca kcol nommuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "!lennahc eciov a gninioj yrT .eciov ot detcennoc ton era uoY"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr "%(channel)s/%(guild)s gninioJ"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ".revres eht fo rebmem a ton si taht resu a wollof tonnac toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ".gniyalp ton si reyalP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 ".dnammoc yalp a htiw gnihtemos yalP .gniyalp yltnerruc gnihton si erehT"
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
@@ -2098,23 +2098,23 @@ msgstr ""
 "%(path)s :ta )%(id)s(%(guild)s rof elif eueuq eteled ot snoissimrep gnissiM"
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr "%(path)s :elif eueuq eteled ot gniyrt elihw rorre level SO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "!evomer ot eueuq eht ni gnihtoN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .snoitisop dilavnI"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
@@ -2123,13 +2123,13 @@ msgstr ""
 ".eueuq eht morf egnar nevig eht ni sgnos eht lla evomer ot noissimrep eht evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s` resu morf eueuq eht ni dnuof gnihtoN"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -2138,38 +2138,38 @@ msgstr ""
 ".eueuq eht morf yrtne taht evomer ot noissimrep eht evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .rebmun yrtne dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "!gniyalp ton si reyalp ehT !piks t'naC"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ".gnos depool a piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ".piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ".gnos depool a piks ot noissimrep evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "rebmun dilav a ton si `%(new_volume)s`"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -2179,7 +2179,7 @@ msgstr ""
 ".%(new_volume)s si %(adjustment)s%(old_volume)s :dedivorp egnahc emulov elbanosaernU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -2187,7 +2187,7 @@ msgstr ""
 ".001 dna 1 neewteb eulav a edivorP .%(volume)s :dedivorp emulov elbanosaernU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -2196,28 +2196,28 @@ msgstr ""
 ".deeps tes tonnac ,gniyalp si kcart oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ".aidem demaerts ot deilppa eb tonnac deepS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ".tes ot deeps a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ".001 dna 5.0 neewteb rebmun a esU .dilavni si dedivorp uoy deeps ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "`%(option)s` :dnammoc rof noitpo dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -2227,28 +2227,28 @@ msgstr ""
 ":rorre ot eud sesaila evas ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "saila ot dnammoc a dna saila na ylppus tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ".evomer ot eman saila na ylppus tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ".tsixe ton seod `%(alias)s` saila ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac gifnoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -2258,7 +2258,7 @@ msgstr ""
 ":rorre gniwollof eht ot eud gifnoC daoler ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -2267,17 +2267,17 @@ msgstr ""
 "noitces evloser ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ".eman noitces a edivorp esaelp ,suougibma si nevig noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ".dnammoc siht rof eman noitpo dna eman noitces a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -2287,97 +2287,97 @@ msgstr ""
 ".elbaliava ton si `%(section)s` noitces ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ".ksid ot evas tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "`%(option)s`  :noitpo eht evas ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ".deyalpsid eb tonnac eulav ,elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ".gnittes etadpu tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ".dnammoc bus siht rof eulav dna ,noitpo ,noitces a edivorp tsum uoY"
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr "%(value)s == %(config)s no htiw tes gnioD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ".tluafed ot teser tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr "%(value)s tluafed ot %(config)s gnitteseR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "!tluafed ot teser ton saw `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ".daetsni dnammoc gifnoc eht esu ,detacerped si dnammoc noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "raelc ro ,etadpu ,ofni :esu ,deificeps noitpo dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "...ofni erom rof sgol kcehc ,ehcac eteled ot **deliaF**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ".rebmun elohw a eb tsum tnemugra egap eueuQ"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos eueuQ !deueuq sgnos on era erehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2387,12 +2387,12 @@ msgstr ""
 ".sdnuob fo tuo si rebmun egap detseuqeR"
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr ".yrtne tsilyalp tnerruc eht deppikS"
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -2402,17 +2402,17 @@ msgstr ""
 " tes htgneLeueuQ evah yam uoY"
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr ".eueuq eht etanigap ot seirtne hguone toN"
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ".ot snoitcaer dda ot egassem on ,egassem eueuq tsop ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2421,17 +2421,17 @@ msgstr ""
 ".egassem eueuq eht ot ecnerefer a teg ro ekam t'ndluoc toBcisuM .niaga taht yrT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ".lennahc MD etavirp no egrup esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ".LRU dilav a ton saw LRU nevig ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2442,12 +2442,12 @@ msgstr ""
 "lru tupni morf ofni tcartxe ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ".tsilyalp a eb ot mees ton seod sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2456,17 +2456,17 @@ msgstr ""
 "dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ".niaga yrT  .resU drocsid eht enimreted ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac snoissimreP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2476,23 +2476,23 @@ msgstr ""
 ":rorre na ot eud snoissimreP daoler ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ".dnammoc siht rof eman noitpo ro puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ".dnammoc siht rof tes ot eulav dna ,noitpo ,puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ".eman noissimrep dna puorg a seriuqer dnammoc-bus %(option)s ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2502,47 +2502,47 @@ msgstr ""
 ".elbaliava ton si `%(group)s` puorg ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noissimrep ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ".stsixe ydaerla ti `%(group)s` puorg dda tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ".puorg ni-tliub evomer tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ".elbatide ton si puorg renwo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "`%(group)s`  :puorg eht evas ot deliaF"
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr "%(value)s :eulav htiw %(option)s no tes gnioD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noissimreP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2552,7 +2552,7 @@ msgstr ""
 "?semit ynam oot seman egnahc uoy diD .emanresu egnahc ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2562,12 +2562,12 @@ msgstr ""
 "  :rorre ot eud emanresu egnahc ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ".noissimrep on :emankcin egnahc ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2577,12 +2577,12 @@ msgstr ""
 "  :rorre ot eud emankcin tes ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ".xiferp a sa esu ot revres siht morf eb tsum ijome motsuC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2591,28 +2591,28 @@ msgstr ""
 "!delbane ton si revres rep xiferP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ".sdliug ni desu eb ylno nac dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ".noitamrofni erom rof dnammoc pleh eht esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ".elbaliava ton si ti `%(locale)s` ot egaugnal tes tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ".elif a hcatta ro LRU a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2622,63 +2622,63 @@ msgstr ""
 "  :rorre ot eud ratava egnahc ot elbanU"
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ".melborp a eb dluoc sihT  !dliug on htiw %s a dnuof toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "`%(guild)s` revres ot detcennoc yltnerruc toN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "tigpu ro ,pippu ,edargpu ,lluf ,tfos  :fo eno esu ,nevig noitpo dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ".eman ro DI na edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "`%(input)s` eman ro DI eht htiw dnuof saw dliug oN"
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr "%(uuid)s :DI tniopkaerb gubed gnitavitcA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "?dellatsni ti si ,`hpargjbo` tropmi ton dluoC"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr ".)(lave htiw nar edoc gubeD"
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr ".)(cexe htiw nar edoc gubeD"
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr ".etucexe ot deliaf edoc gubeD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2694,54 +2694,54 @@ msgstr ""
 ":edoc gubed etucexe ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "%(options)s :fo eno eb tsum dnammoc-buS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ".elbatucexe tig etacol ton dluoC"
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ".dnammoc tig aiv setadpu rof gnikcehc elihw deliaF"
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr ".troper pip ni atem gnissim egakcaP"
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ".rorre emos ot eud sutats etadpu pip teg ot deliaF"
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr ".yrtne tneilc eciov egnarts a toG"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ".delbane ydaerla seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ").elif seikooc gnissiM( .delbane eb ot dedaolpu eb tsum seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "%(raw_error)s  :rorre ot eud seikooc elbane ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2751,56 +2751,56 @@ msgstr ""
 "%(raw_error)s  :rorre ot eud elif seikooc emaner ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 ".elif eikooc a gnidaolpu elihw niaga yrt ,dnuof erew sdaolpu dehcatta oN"
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr "%(raw_error)s  :elif seikooc delbasid ,dlo evomer ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "%(raw_error)s  :drocsid morf elif seikooc eht gnidaolnwod rorrE"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "%(raw_error)s  :ksid ot seikooc evas ton dluoC"
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "%s  :wohemos ,lennahc on htiw egassem a toG"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ")%s( flesym morf dnammoc gnirongI"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ")%s( tob rehto morf dnammoc gnirongI"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "%s  :epyt fo lennahc morf dnammoc gnirongI"
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
@@ -2809,121 +2809,121 @@ msgstr ""
 "toBcisuM"
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ".derongi lennahc rellac ,lennahc dnuob a sah revres rellaC"
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ".dewolla rellac ,lennahc dnuob on sah revres rellaC"
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr "%s  :revres ni )%s( lennahc dnuobnU"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr "%(command)s :dnammoc deirt  %(name)s/%(id)s :tsil kcolb ni resU"
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr "%(message)s :%(name)s/%(id)s morf egasseM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "%(group)s  :puorg snoissimrep ruoy rof dewolla ton si dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ".lennahc ecioV a ni eb ot uoy seriuqer dnammoc sihT"
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr "%(params)r :smarap rof seulav gnissim ,egasu dnammoc dilavnI"
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr "%(err_text)s :%(err_name)s :%(command)s ni rorrE"
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr "%(command)s :dnammoc gnildnah elihw noitpecxE"
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "%s  :dnammoc gnissim rof pleh etareneg tonnaC"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "%s  :dnammoc rof atad pleh gnissiM"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ".ytivitcani ot eud %s ni %s lennahc eciov gnivaeL"
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr ".detcennoc emoceb sah toBcisuM"
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr ".detcennocsid emoceb sah toBcisuM"
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "%s  :tnevE tekcoS a toG"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "dehsinif ydaer_no erofeb detadpu etatSecioV"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ".lennahc eciov dnuob a si ti sa %s ni %s gnirongI"
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ".stuoemit gnildnaH .ytpme sa detceted neeb sah %s"
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ".remit gnillecnac ,%s denioj resu A"
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
@@ -2931,30 +2931,30 @@ msgstr ""
 ".stuoemit gnildnaH .ytpme si %s lennahc eciov eht dna devom tog tob ehT"
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ".ytpme ton si %s lennahc eciov eht dna devom tog tob ehT"
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "%s resu gniwollof regnol oN"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr "%(channel)s  :lennahc ot `%(user)s` resu gniwolloF"
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr ".enoN si lennahc.erofeb tcennocsid etatSecioV"
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2964,97 +2964,97 @@ msgstr ""
 "eciov morf detcennocsiD"
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 "%(guild)s  :dliug ni  %(type)s :epyt htiw lennahc nioj-otua esu tonnaC"
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "%s  :dliuG  ?deteled ti saw ,lennahc denioj-otua eht dnif tonnaC"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "%s  :lennahc no dliug denioj-otua ot gnitcennoceR"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "%s  :lennahc nioj otua tonnaC"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "%s :dliug ot dedda neeb sah toB"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ".dnuof ton renwo tob ot eud '%s' dliug tfeL"
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "%s dliug rof redlof atad gnitaerC"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "%s :dliug morf devomer neeb sah toB"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr ":tsil dliug detadpU"
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ".elbaliava emoceb sah \"%s\" dliuG"
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ".ytilibaliava ot eud \"%s\" ni reyalp gnimuseR"
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ".elbaliavanu emoceb sah \"%s\" dliuG"
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ".ytilibaliavanu ot eud \"%s\" ni reyalp gnisuaP"
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "%s  :rof etadpu dliuG"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr "%(old)s :saW --  %(new)s :won si %(attr)s etubirtta dliuG"
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr "%(changes)s  --  %(channel)s  :rof etadpu lennahC"
@@ -3072,12 +3072,12 @@ msgid "Loading config from:  %s"
 msgstr "%s  :morf gifnoc gnidaoL"
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr "...selif snoitpo gifnoc wen gnitareneG"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3100,7 +3100,7 @@ msgstr ""
 ".elif snoitpo gifnoc tluafed gnitaerc rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3130,7 +3130,7 @@ msgstr ""
 ".gifnoc gnidaer elihw rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -3140,7 +3140,7 @@ msgstr ""
 "tonnaC"
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
@@ -3149,7 +3149,7 @@ msgstr ""
 "tamroFetaDsgoL noitpo gifnoC"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3168,12 +3168,12 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ".htaPehcaCoiduA gnitadilav elihw nworht saw noitpecxe nA"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3195,13 +3195,13 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "%s  :ni derots eb lliw ehcaC oiduA"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3221,7 +3221,7 @@ msgstr ""
 ".snoitpo gifnoc gnidaer elihw rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
@@ -3230,7 +3230,7 @@ msgstr ""
 "egasseMsutatS"
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -3240,17 +3240,17 @@ msgstr ""
 "tsum deeps kcabyalp tluafed ehT"
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "...atad ecivres htiw snoitpo gnitadilaV"
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "IPA aiv DI renwo deriuqcA"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3271,12 +3271,12 @@ msgstr ""
 ".yllacitamotua 'DIrenwO' gnihctef elihw rorrE"
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ".deecorp tonnac ,ecnatsni resu a evah ton seod toBcisuM"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3295,12 +3295,12 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "...sevitanretla rof gnikcehC .dnuof ton elif snoitpo gifnoC"
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -3310,13 +3310,13 @@ msgstr ""
 "%(ini_file)s gnimaneR"
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr "%(example_file)s  :elif snoitpo elpmaxe gnitsixe gniypoC"
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -3328,12 +3328,12 @@ msgstr ""
 ".selif snoitpo elpmaxe ro snoitpo gifnoc etacol ton dluoC"
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ".elif noitpo gifnoc a dnif ot gniyrt elihw gnorw tnew gnihtemoS"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3355,7 +3355,7 @@ msgstr ""
 ".gifnoc gnitacol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3379,12 +3379,12 @@ msgstr ""
 ".gifnoc gnidaol rorrE"
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ".elbaliava ton si taht retteg sah noitpo gifnoC !guB veD"
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
@@ -3393,43 +3393,43 @@ msgstr ""
 "!guB veD"
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr ".ylsuoiverp gnissim saw noitpO"
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "%s :gnissiM !gifnoc desrap ni ton noitces gifnoC"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr "%(value)s  =  %(config)s :noitpo gifnoc devaS"
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "%s  :gifnoc evas ot deliaF"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 ".delbasid si revloseR  !snoitces INI neewteb euqinu ton era seman noitpO"
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "%s  :ta elif INI tluafed evas ot deliaF"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3449,7 +3449,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3469,7 +3469,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3489,7 +3489,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -3499,7 +3499,7 @@ msgstr ""
 "dilavnI"
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -3509,7 +3509,7 @@ msgstr ""
 "]%(section)s[ noitpO"
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -3519,7 +3519,7 @@ msgstr ""
 "eulav a sah %(option)s > ]%(section)s[ noitpO"
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
@@ -3527,47 +3527,47 @@ msgstr ""
 "%(new_o)s > ]%(new_s)s[  ot  %(old_o)s > ]%(old_s)s[ yrtne elif INI gnimaneR"
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "...snoitpo demaner htiw elif gifnoc gnidargpU"
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ".yllaunam ti edargpu ot deen ll'uoY  .gifnoc edargpu ot deliaF"
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "%s  :dnuof ton elif tsil kcolB"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "%s  :elif morf tsil kcolb daol ton dluoC"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "%s  :elif tsil kcolb eht etadpu ton dluoC"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ".seirtne %s htiw tsil kcolB resU dedaoL"
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "%s  :ot demaner eb lliw ti ,elif tsilkcalb ycagel a dnuof eW"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ".seirtne %s htiw tsil kcolB gnoS a dedaoL"
@@ -3632,39 +3632,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "%s  :tnegA resU esu ot PLDTY gnicroF"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "%s  :morf pld-ty rof seikooc esu lliw toBcisuM"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ".revres yxorp derugifnoc ruoy esu lliw pld-tY"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "...sredaeh on evah ot smees DAEH"
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ".tuoemit ot eud deliaf sredaeh aidem gnikcehC"
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "%s  :rof tseuqer DAEH deliaF"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr " :noitpecxe tseuqeR DAEH"
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3674,79 +3674,79 @@ msgstr ""
 ":)NOSJ ton( ofnI noitcartxE LDTY dezitinaS"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "%s  :)NOSJ ton( ofnI noitcartxE LDTY dezitinaS"
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr "%s  :detseuqer tsilyalPotuA"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ".atad on denruter noitcartxe ofni gnoS"
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr "%(kws)s ,%(args)s ,'%(subject)s'  :htiw ofni_tcartxe dellaC"
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ").snwodtuhs no lamron si sihT( .desolc si pool ,noitcartxe nur tonnaC"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ".desolc si pool tneve ,noitcartxe eunitnoc tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ".detroppus ton ro dilavni si LRU yfitopS"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "%(raw_error)s :atad aidem gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "LRU maerts htiw rorrE daolnwoD"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "maerts tcerid a si tnetnoc gnimussA"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ".LRU dilavni na maerts tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "%(raw_error)s :atad maerts gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 ".ecaps htiw noloc gnicalper retfa niaga gniyrt ,sreldnaHgnitroppuSoN thguaC"
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -3756,48 +3756,48 @@ msgstr ""
 "%(extractor)s rotcartxE"
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr "%(kws)s ,%(args)s  :htiw ofni_tcartxe_efas dellaC"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ".dnuof eb ton dluoc elif aidem lacol ehT"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ".tsixe ton seod tsilyalp ehT"
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr "%(raw_error)s :ot eud '%(track)s' kcart ssecorp ton dluoC"
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
 ".eueuq eht ot tsilyalp otua gnidda elihw noitpecxe deldnahnu na tog toBcisuM"
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "tciDesnopseRpldtY morf tcejbus_tupni__ gnissiM"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 ".siht diova ot eurT=ssecorp tes ,tciDesnopseRpldtY ni tsil a ton si seirtnE"
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr "%(url)s :rof rorre noitarud ,gninraW"
@@ -5069,65 +5069,15 @@ msgstr ".setadpu rof gnikcehc deppikS"
 msgid "Optional checks passed."
 msgstr ".dessap skcehc lanoitpO"
 
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr "+9.3 nohtyP rof gnikcehC"
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr "%s si noisrev sihT .deriuqer si +9.3 nohtyP"
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr "...9.3 nohtyP etacol ot gnitpmettA"
-
 #. Used by: warning
 #: run.py:402
 msgid "Could not locate py.exe"
 msgstr "exe.yp etacol ton dluoC"
 
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr " `9.3- exe.yp` etucexe ton dluoC"
-
 #. Used by: info
 #: run.py:417
 msgid "Python 3 found.  Launching bot..."
 msgstr "...tob gnihcnuaL  .dnuof 3 nohtyP"
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr "\"9.3nohtyp\" gniyrT"
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ".htap no 9.3nohtyp etacol ton dluoC"
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-"\n"
-"yp.nur %s :gnisu tob gnihcnual-eR  .dnuof 9.3 nohtyP\n"
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
-msgstr ""
-"31.3 ot 9.3 noisrev nohtyP gnisu tob eht nur esaelP  .rehgih ro 9.3 nohtyP "
-"dnif ton dluoC"
 
 #. Used by: info
 #: run.py:477
@@ -5234,25 +5184,25 @@ msgstr ""
 ".sreganam egakcap metsys aiv elbaliava gepmFF ekam sortsid ynam ,xuniL nO"
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "ecived siht no sniamer ecaps eerf fo BM%s naht sseL"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
 msgstr "...seicnedneped ro toBcisuM ot setadpu rof gnikcehC\n"
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ".dnammoc `tig` aiv elbaliava setadpu toBcisuM oN"
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
@@ -5261,14 +5211,14 @@ msgstr ""
 "dluoC"
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr ""
 "\n"
 ":detadpu eb nac segakcap gniwollof ehT"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr ""
@@ -5276,12 +5226,12 @@ msgstr ""
 "%s  :noisrev ot  %s  "
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ".dnammoc `pip` aiv elbaliava setadpu ycnedneped oN"
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
@@ -5290,7 +5240,7 @@ msgstr ""
 "dluoC"
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -5300,35 +5250,35 @@ msgstr ""
 ":dnammoc eht gnisu yb etadpu dediug a nur nac uoY"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr ".timil mumixam eht evoba si eulaV"
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr ".evitagen eb ton tsum eulaV"
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "%s ot 0 morf rebmun a eb tsum tpeK sgoL xaM rof eulaV"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr ".elbaliava ton si '%s' level goL"
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "%s  :fo eno eb tsum leveL goL"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
@@ -5337,39 +5287,39 @@ msgstr ""
 "hcnuaL"
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr ":buhtiG aiv elbaliavA"
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ":drocsid ruo nioj ,tob siht htiw troppus dna pleh erom roF"
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr ".esneciL TIM eht rednu dedivorp si erawtfos sihT"
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr ".sliated etelpmoc rof elif txet `ESNECIL` eht eeS"
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 ".toBcisuM ni txet lla rof egaugnal detceted metsys / tluafed eht edirrevO"
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ".toBcisuM morf segassem gol edis-revres lla rof egaugnal siht esU"
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -5378,27 +5328,27 @@ msgstr ""
 ".toBcisuM morf drocsid ot tnes segassem lla rof egaugnal siht esU"
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr ".tixe dna noitamrofni noisrev toBcisuM eht tnirP"
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ".kcehc etadpu eht gnidulcni ,skcehc putrats lanoitpo lla pikS"
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr ".putrats ta kcehc ecaps ksid eht ylno pikS"
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr ".putrats ta kcehc etadpu eht ylno pikS"
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
@@ -5407,7 +5357,7 @@ msgstr ""
 "elbasiD"
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -5417,13 +5367,13 @@ msgstr ""
 "yficepS"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr "%s :fo eno eb tsuM .gifnoc ni tes sgnittes level gol eht edirrevO"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -5433,7 +5383,7 @@ msgstr ""
 ".selif gol gnitator nehw desu tamrof etad tluafed eht edirrevO"
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5445,42 +5395,42 @@ msgstr ""
 ".selif elbatum lla erots nac toBcisuM erehw yrotcerid a ylppuS"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "%s  :noisreV"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "!desolc ylefas eb nac lanimret sihT .ecnatsni toBcisuM wen a denepO"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "%s  :noisrev toBcisuM gnidaoL"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "%s  :denepo goL"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "%s  :noisrev nohtyP"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "%s  :ot yrotcerid gnikrow gnignahC"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -5491,7 +5441,7 @@ msgstr ""
 "tonnaC"
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -5500,12 +5450,12 @@ msgstr ""
 ".otni toBcisuM denolc uoy redlof emas eht morf `yp.nur` trats ,stluser tseb roF"
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr "...selif gifnoc elpmaxe gnitadpU"
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
@@ -5514,12 +5464,12 @@ msgstr ""
 "etacifitreC"
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr ".gub a eb dluoc ti ,rorre tcaxe eht si ereH"
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -5529,7 +5479,7 @@ msgstr ""
 " ,erots tsurt swodniW ot etacifitrec a dda ylisae oT"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
@@ -5538,17 +5488,17 @@ msgstr ""
 " dluoC"
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ")?edoc eht tide uoy did ,detceted noitacifidom( rorre xatnyS"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ")tluaf ruoy ton ,gub a si siht( rorre xatnyS"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -5569,14 +5519,14 @@ msgstr ""
 "!rorre na ot eud toBcisuM trats tonnaC"
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 "\n"
 "...yllacitamotua segakcap ycnedneped toBcisuM llatsni ot gnitpmettA"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -5612,81 +5562,187 @@ msgstr ""
 "!dellatsni eb ton yam seicnedneped toBcisuM"
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "!dekrow seicnedneped gnillatsni epoh stel ,KO"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-"...tixe tsum toBcisuM .segakcap llatsni ot gniyrt retfa rorrEtropmI na tog "
-"toBcisuM"
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr " :rorre evoba eht desuac hcihw noitpecxe ehT"
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "...tratser tfos a gniod si toBcisuM"
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "...tratser ssecorp lluf a gniod si toBcisuM"
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "tob gnitrats rorrE"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr ".pool tneve gnisolC"
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "...sdnoces %s ni gnitratseR"
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr ".enod llA"
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "!gnisolc er'ew ,KO"
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr "+9.3 nohtyP rof gnikcehC"
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr "%s si noisrev sihT .deriuqer si +9.3 nohtyP"
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr "...9.3 nohtyP etacol ot gnitpmettA"
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr " `9.3- exe.yp` etucexe ton dluoC"
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr "\"9.3nohtyp\" gniyrT"
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ".htap no 9.3nohtyp etacol ton dluoC"
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+#~ "\n"
+#~ "yp.nur %s :gnisu tob gnihcnual-eR  .dnuof 9.3 nohtyP\n"
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
+#~ "31.3 ot 9.3 noisrev nohtyP gnisu tob eht nur esaelP  .rehgih ro 9.3 nohtyP "
+#~ "dnif ton dluoC"
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+#~ "...tixe tsum toBcisuM .segakcap llatsni ot gniyrt retfa rorrEtropmI na tog "
+#~ "toBcisuM"
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr " :rorre evoba eht desuac hcihw noitpecxe ehT"

--- a/i18n/xx/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/xx/LC_MESSAGES/musicbot_messages.po
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Just-Some-Bots/MusicBot release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-13 10:11-0700\n"
+"POT-Creation-Date: 2025-05-02 07:00-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,29 +40,29 @@ msgstr ""
 ".sesaila gnidaol elihw rorrE"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ".dnammoc siht esu tonnac dna delbane-eciov ton si rebmeM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ".lennahc eciov eht ni ton nehw dnammoc siht esu tonnac uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr "`%(name)s`  :lennahc ni tcennoC ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr "`%(name)s`  :lennahc ni kaepS ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -71,24 +71,24 @@ msgstr ""
 ".lennahc eht ot tcennoc ton dluoc toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 "?tratser ebyaM .ddo si sihT .dellecnac saw eciov ot noitcennoc toBcisuM"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr ".kaeps ot noissimrep evah ton seod toBcisuM"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr ".kaeps ot tseuqer ton dluoc toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -97,12 +97,12 @@ msgstr ""
 ".lennahc eciov a ni ton si tob ehT"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ".tneilCecioV eht teg t'ndid ew ,gnorw si gnihtemoS"
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
@@ -110,19 +110,19 @@ msgstr ""
 "!eciov ni ton si `%(user)s` retseuqer sa `%(title)s` gnos txen gnippikS"
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr "!%(channel)s ni gniyalp won si `%(title)s` gnos ruoy - %(mention)s"
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr "!%(author)s yb dedda `%(title)s` :%(channel)s ni gniyalp woN"
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr "!%(channel)s ni `%(title)s` yrtne dedda yllacitamotua gniyalp woN"
@@ -130,18 +130,18 @@ msgstr "!%(channel)s ni `%(title)s` yrtne dedda yllacitamotua gniyalp woN"
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ":LRU"
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr "!eciov ni ton era yeht sa %(user)s yb dedda sgnos gnippikS"
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -153,12 +153,12 @@ msgstr ""
 ":rorre na ot eud `%(song)s` gnos rof deliaf kcabyalP"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ".tcejbo esnopser dilavni na gnidnes deirT ]guB veD["
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -181,13 +181,13 @@ msgstr ""
 "!nigoL IPA drocsiD deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ".tsil kcolb gnos eht yb dekcolb si `%(subject)s` gnos detseuqer ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -196,12 +196,12 @@ msgstr ""
 ".yromem reyalp otni kcab ti gniypoc yb eueuq tsilyalp otua eht teseR"
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "}NGIS DNAH KO{N\\"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
@@ -209,14 +209,14 @@ msgstr ""
 ".sdnammoc elbaliava lla tsil ro ,dnammoc a fo noitpircsed dna egasu wohS"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr ""
 "\n"
 "**:dnammoc siht rof sesailA**"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
@@ -224,7 +224,7 @@ msgstr ""
 "`%(args)s %(command)s` fo saila `%(alias)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -236,7 +236,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -248,12 +248,12 @@ msgstr ""
 "%(is_alias)s"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "dnammoc hcus oN"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -264,7 +264,7 @@ msgstr ""
 ".esu ruoy rof dettimrep sdnammoc ylno swohs evoba tsil ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -286,22 +286,22 @@ msgstr ""
 "*)xiferp tuohtiw(* **:eman yb sdnammoC**"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr ".resu denoitnem a kcolB    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr ".resu denoitnem a kcolbnU    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr ".resu denoitnem a fo sutats kcolb eht wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
@@ -311,42 +311,42 @@ msgstr ""
 ".tsil kcolb resu eht ni sresu eht eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ".rebmun DI rieht edivorp ro resu a noitnem tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ".selpmaxe egasu rof `resukcolb pleh` esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ".deificeps uoy )s(resu eht dnif ton dluoc toBcisuM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ".tsil kcolb eht ot dedda eb tonnac renwo ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr ".delbane yltnerruc si tsil kcolb resU"
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr ".delbasid yltnerruc si tsil kcolb resU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ".dedda ydaerla era yeht ,detsil uoy sresu eht dda tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -356,12 +356,12 @@ msgstr ""
 ".tsil kcolb eht ot dedda neeb evah )s(resu %(number)s"
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr ".tsilkcalb eht ni era sresu esoht fo enoN"
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
@@ -369,7 +369,7 @@ msgstr ""
 ".dekcolb ton si `%(user)s` :resU"
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
@@ -377,7 +377,7 @@ msgstr ""
 ".dekcolb si `%(user)s` :resU"
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -389,7 +389,7 @@ msgstr ""
 "**:sutats tsil kcolB**"
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -399,7 +399,7 @@ msgstr ""
 ".tsil kcolb eht morf devomer neeb evah )s(resu %(number)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -417,23 +417,23 @@ msgstr ""
 ".atad gnos detcartxe dna stseuqer gnos ot deilppa tsil kcolb a eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ".gniyalp yltnerruc si gnos on fi tcejbus gnos a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ".selpmaxe egasu rof `gnoskcolb pleh` esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ".tsil kcolb gnos eht ni ydaerla si `%(subject)s` tcejbuS"
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -443,12 +443,12 @@ msgstr ""
 ".tsil kcolb gnos eht ot `%(subject)s` tcejbus deddA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ".devomer eb tonnac dna tsil kcolb gnos eht ni ton si tcejbus ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -458,7 +458,7 @@ msgstr ""
 ".tsil kcolb eht morf devomer neeb sah `%(subject)s` tcejbuS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
@@ -467,14 +467,14 @@ msgstr ""
 ".tsilyalp tnerruc eht morf/ot gnos gniyalp yltnerruc ro gnos deificeps eht sevomer ro sddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr ""
 "\n"
 ".tsilyalp sdliug eht ot eueuq eritne eht sddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
@@ -484,7 +484,7 @@ msgstr ""
 ".eueuq kcabyalp lamron eht ot tsilyalp otua nevig eht ni skcart lla ddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
@@ -494,7 +494,7 @@ msgstr ""
 ".elif tsilyalp deman eht morf sgnos lla raelC    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
@@ -503,7 +503,7 @@ msgstr ""
 ".selif tsilyalp gnitsixe fo tsil a dna tsilyalp detceles yltnerruc eht wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
@@ -512,7 +512,7 @@ msgstr ""
 ".dezimodnar sselnu kcart tsrif eht ta gnitratser ,eueuq tsilyalp otua eht daoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
@@ -521,7 +521,7 @@ msgstr ""
 ".tsilyalp otua dliug eht sdaoler dna dliug siht rof tluafed sa tsilyalp a teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
@@ -530,71 +530,71 @@ msgstr ""
 "tsilyalp nevig eht daoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:3338
+#: musicbot/bot.py:3337
 msgid ""
 "Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
+"Auto playlists use their own queue, only playing when the main queue is empty."
 msgstr ""
-".ytpme si eueuq niam eht nehw gniyalp ylno ,eueuq nwo rieht a esu stsilyalp otuA\n"
+".ytpme si eueuq niam eht nehw gniyalp ylno ,eueuq nwo rieht esu stsilyalp otuA\n"
 ".sgnittes dliug-rep dna selif tsilyalp otua eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 ".selpmaxe egasu rof `tsilyalpotua pleh` esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "dilavni si knil gnos deilppus ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "!dnammoc yalp a htiw sgnos emos ddA .ytpme si eueuq ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ".tsilyalpotua eht ni ydaerla era eueuq eht ni sgnos llA"
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr ".tsilyalpotua eht ot sgnos %(number)d deddA"
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ".tsilyalpotua eht ot `%(url)s` deddA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ".tsilyalpotua eht ni ydaerla si gnos sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ".tsilyalpotua eht morf `%(url)s` devomeR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ".tsilyalpotua eht ni tey ton si gnos sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr "`%(file)s` :tsilyalp eht fo ypoc hserf a dedaoL"
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -604,42 +604,42 @@ msgstr ""
 "**:stsilyalP elbaliavA**`%(playlist)s` **:tsilyalP tnerruC**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ".emanelif tsilyalp a edivorp tsum uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
 msgstr "!ksid ot ti evas ot sgnos dda tsum uoy ,wen si tsilyalp sihT\n"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr "%(note)s`%(name)s` :ot detadpu neeb sah revres siht rof tsilyalp ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr "`%(playlist)s` :eman eht htiw stsixe elif tsilyalp oN"
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ".deraelc neeb sah `%(playlist)s` tsilyalp ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ".dnammoc siht esu ot lennahc eciov a ni eb tsum uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -649,7 +649,7 @@ msgstr ""
 ".eueuq eht ot dedda eb lliw `%(playlist)s` tsilyalp ni skcart ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -659,25 +659,25 @@ msgstr ""
 ":rorre ot eud ofni tcartxe ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr "`%(playlist)s` tsilyalp morf eueuq eht ot )s(kcart %(number)d deddA"
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ".ksid morf dedaoler neeb sah tsilyalp ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 ".revres rehtona ot tob siht dda ot desu eb nac taht knil etivni na etareneG"
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -687,7 +687,7 @@ msgstr ""
 ":revres drocsid a ot em dda ot ereh kcilC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
@@ -697,28 +697,28 @@ msgstr ""
 ".sgnos eueuq yam srebmem ekoarak ylno ,delbane elihW .ffo ro no edom ekoarak elggoT"
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ".delbane won si edom ekoaraK }NGIS DNAH KO{N\\"
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ".delbasid won si edom ekoaraK }NGIS DNAH KO{N\\"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "stsilyalp tseuqer ot dewolla ton era uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ")%(max)s si xam tub %(songs)s( seirtne ynam oot sah tsilyalP"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -730,12 +730,12 @@ msgstr ""
 ".timil eueuq ruoy deecxe lliw seirtne tsilyalp ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ".won kcabyalp gnimuser ,desuap ylsuoiverp saw toB"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -753,7 +753,7 @@ msgstr ""
 ".detrats eb lliw kcabyalp ,desuap ro gniyalp si gnos on fI .eueuq eht ni deyalp eb ot gnos a ddA"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
@@ -762,13 +762,13 @@ msgstr ""
 ".eueuq eht ot meht gnidda erofeb seirtne tsilyalp selffuhs taht dnammoc yalP"
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr "`%(request)s` morf eueuq eht otni smeti tsilyalp delffuhS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -778,7 +778,7 @@ msgstr ""
 ".tsal naht rehtar yalp ot txen eht sa gnos eht sdda taht dnammoc yalp A"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
@@ -788,7 +788,7 @@ msgstr ""
 ".yletaidemmi syalp dna gnos tnerruc yna spiks hcihw dnammoc yalp A"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -802,33 +802,33 @@ msgstr ""
 ".emit nevig eht ta gnos tnerruc eht stratseR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ".gniyalp gnihton si ereht fi kees esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ".noitarud nwonknu na sah ti ,kcart tnerruc no kees esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ".smaerts rof detroppus ton si gnikeeS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ".kcabyalp noitisop ot emit a tuohtiw kees esu tonnaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ".sdnoces ni emit dilav a ot `%(input)s` trevnoc ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -838,7 +838,7 @@ msgstr ""
 "`%(seconds)s`( `%(input)s` ot kees tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
@@ -846,7 +846,7 @@ msgstr ""
 ".gnos tnerruc eht ni )sdnoces `%(seconds).2f`( `%(input)s` emit ot gnikeeS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -858,65 +858,65 @@ msgstr ""
 ".gnipool gnos ro tsilyalp selggoT"
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos yalP .gniyalp yltnerruc era sgnos oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 ".selpmaxe egasu rof `taeper pleh` dnammoc eht esU .dnammoc-bus dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr ".gnitaeper won si tsilyalP"
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr ".gnitaeper regnol on si tsilyalP"
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr ".gnos tnerruc eht pool won lliw reyalP"
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr ".gnos tnerruc eht pool regnol on lliw reyalP"
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "!gnos a gnipool ydaerla si reyalP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ".gnipool yltnerruc ton si reyalp ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr ".gnitaeper regnol on si gnoS"
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr ".gnitaeper won si gnoS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 "\n"
 ".OT noitisop ot MORF noitisop ta gnos evoM    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
@@ -926,22 +926,22 @@ msgstr ""
 ".srebmun noitisop rieht gnisu eueuq eht ni sgnos gnitsixe pawS"
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos yalP .deueuq sgnos on era erehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "!sregetni eb tsum snoitisop gnoS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "!ezis tsilyalp eht edistuo noitisop a evag uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
@@ -949,7 +949,7 @@ msgstr ""
 "!%(to)s noitisop ot eueuq ni %(from)s noitisop morf gnos devom yllufsseccuS"
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -963,41 +963,41 @@ msgstr ""
 ":DI tsilyalP a sniatnoc knil sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ".delbane ton si kcabyalp aidem lacoL"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ".detroppus yltnerruc ton ro dilavni si LRU yfitopS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ".delbane ton si yfitopS tub ,LRU yfitopS a detceteD"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ")%(max)s( timil gnos deueuqne ruoy dehcaer evah uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "!delbasid sti nehw niaga yrt esaelp ,delbane si edom ekoaraK"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ".dnammoc maerts eht gnisu yrT .deyalp eb tonnac oediv tahT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4437
+#: musicbot/bot.py:4436
 #, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr "%(url)s  :rof stluser on denruter hcraes ebuTuoY"
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr "%(url)s  :rof %(extractor)s htiw stluser on denruter hcraeS"
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -1203,7 +1203,7 @@ msgid "Show information on what is currently playing."
 msgstr ".gniyalp yltnerruc si tahw no noitamrofni wohS"
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "]tsilyalpotua["
 
@@ -1240,7 +1240,7 @@ msgstr ":ssergorP"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos eueuQ !deueuq sgnos on era erehT"
 
@@ -1356,37 +1356,82 @@ msgstr ".eueuq eht morf sgnos lla deraelC"
 
 #. Used by: _Dd
 #: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+"\n"
+".]NOITISOP[ ta ro eueuq eht fo dne eht ta gnos a evomeR    "
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+"\n"
+".OT noitisop ot MORF noitisop morf sgnos evomeR    "
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+"\n"
+".resu denoitnem eht yb dedda sgnos evomeR    "
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
 msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
 "Use the queue command to find position number of your track.\n"
 "However, positions of all songs are changed when a new song starts playing.\n"
 msgstr ""
 "\n"
 ".gniyalp strats gnos wen a nehw degnahc era sgnos lla fo snoitisop ,revewoH\n"
 ".kcart ruoy fo rebmun noitisop dnif ot dnammoc eueuq eht esU\n"
-".devomer si eueuq eht fo dne eht ta gnos eht ,dettimo si noitisop eht fI\n"
-".noitisop eueuq nevig eht ta yllanoitpo ,eueuq eht morf gnos a evomeR"
+".devomer si eueuq eht fo dne eht ta gnos eht ,dettimo era snoitisop ro noitisop ,noitnem-resu eht fI\n"
+".resu denoitnem eht yb dedda eueuq eht morf sgnos lla evomeR\n"
+".deificeps OT noitisop ot MORF noitisop morf eueuq eht morf sgnos elpitlum evomeR\n"
+".deificeps NOITISOP ta eueuq eht morf gnos a evomeR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "!evomer ot eueuq eht ni gnihtoN"
 
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .snoitisop dilavnI"
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+"\n"
+".eueuq eht morf egnar nevig eht ni sgnos eht lla evomer ot noissimrep eht evah ton od uoY"
+
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr "!%(to)s hguorht %(from)s sgnos devomer yllufsseccuS"
+
+#. Used by: _D
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "`%(user)s` yb dedda `%(track)s` devomeR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s` resu morf eueuq eht ni dnuof gnihtoN"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1395,24 +1440,24 @@ msgstr ""
 ".eueuq eht morf yrtne taht evomer ot noissimrep eht evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .rebmun yrtne dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "`%(user)s` yb dedda `%(track)s` yrtne devomeR"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "`%(track)s` yrtne devomeR"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1424,23 +1469,23 @@ msgstr ""
 ".gnos gniyalp tnerruc eht piks ot etov ro pikS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "!gniyalp ton si reyalp ehT !piks t'naC"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ".tiaw esaelp ,gnidaolnwod si `%(track)s` gnos txen ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ".tiaw esaelP .yltrohs deyalp eb lliw gnos txen ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1449,7 +1494,7 @@ msgstr ""
 ".gnineppah si ddo gnihtemoS"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1458,28 +1503,28 @@ msgstr ""
 ".gnineppah si egnarts gnihtemoS"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ".gnos depool a piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ".`%(track)s` deppiks ecroF"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ".piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ".gnos depool a piks ot noissimrep evah ton od uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1489,12 +1534,12 @@ msgstr ""
 ".degdelwonkca saw `%(track)s` rof piks ruoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr "!pu gnimoc gnos txeN "
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1504,7 +1549,7 @@ msgstr ""
 ".degdelwonkca saw `%(track)s` rof piks ruoY"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1516,25 +1561,25 @@ msgstr ""
 ".001 ot 1 morf toBcisuM fo level emulov tuptuo eht teS"
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "`%%%(volume)s` :emulov tnerruC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "rebmun dilav a ton si `%(new_volume)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "**%(new)d** ot **%(old)d** morf emulov detadpU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1544,7 +1589,7 @@ msgstr ""
 ".%(new_volume)s si %(adjustment)s%(old_volume)s :dedivorp egnahc emulov elbanosaernU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1552,7 +1597,7 @@ msgstr ""
 ".001 dna 1 neewteb eulav a edivorP .%(volume)s :dedivorp emulov elbanosaernU"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1564,7 +1609,7 @@ msgstr ""
 ".ylno kcart gniyalp yltnerruc eht fo deeps kcabyalp eht egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1573,49 +1618,49 @@ msgstr ""
 ".deeps tes tonnac ,gniyalp si kcart oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ".aidem demaerts ot deilppa eb tonnac deepS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ".tes ot deeps a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ".001 dna 5.0 neewteb rebmun a esU .dilavni si dedivorp uoy deeps ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ".kcart tnerruc rof `%(speed).3f` ot deeps kcabyalp gnitteS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 "\n"
 ".stnemugra lanoitpo htiw saila wen na ddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 "\n"
 ".eman nevig eht htiw saila na evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 "\n"
 ".elif gifnoc eht ot/morf sesaila evas ro daoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1624,23 +1669,23 @@ msgstr ""
 "swollA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "`%(option)s` :dnammoc rof noitpo dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr ".elif gifnoc morf dedaoler sesailA"
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr ".elif gifnoc ot devas sesailA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1650,42 +1695,42 @@ msgstr ""
 ":rorre ot eud sesaila evas ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "saila ot dnammoc a dna saila na ylppus tsum uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "`%(command)s` fo saila na won si `%(alias)s` .dedda saila weN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ".evomer ot eman saila na ylppus tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ".tsixe ton seod `%(alias)s` saila ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ".devomer saw `%(alias)s` sailA"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "\n"
 ".snoitpo gifnoc gnissim yna tuoba txet pleh swohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1694,42 +1739,42 @@ msgstr ""
 ".elif gifnoc gnidaol ecnis degnahc neeb evah hcihw snoitpo fo seman eht stsiL    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 "\n"
 ".snoitces rieht dna snoitpo gifnoc elbaliava eht tsiL    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 "\n"
 ".ksid morf elif ini.snoitpo eht daoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 "\n"
 ".noitpo cificeps a rof txet pleh swohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr ""
 "\n"
 ".noitpo eht fo eulav tnerruc eht yalpsiD    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 "\n"
 ".elif snoitpo eht ot eulav tnerruc eht sevaS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1738,29 +1783,29 @@ msgstr ""
 ".elif ot ton tub ,noisses eht rof gifnoc eht stes dna noitpo eht setadilaV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 "\n"
 ".eulav tluafed sti ot noitpo eht teseR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr ".drocsiD nihtiw morf noitarugifnoc ini.snoitpo eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac gifnoC"
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*!rof detnuocca dna tneserp era snoitpo gifnoc llA*"
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -1772,12 +1817,12 @@ msgstr ""
 "**:snoitpO gnissiM**"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr ".degnahc eb ot raeppa snoitpo gifnoc oN"
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1787,7 +1832,7 @@ msgstr ""
 "**:snoitpO degnahC**"
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1803,12 +1848,12 @@ msgstr ""
 ":snoitpO elbaliavA ##"
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "!yllufsseccus elif morf dedaoler snoitpo gifnoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1818,7 +1863,7 @@ msgstr ""
 ":rorre gniwollof eht ot eud gifnoC daoler ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1827,17 +1872,17 @@ msgstr ""
 "noitces evloser ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ".eman noitces a edivorp esaelp ,suougibma si nevig noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ".dnammoc siht rof eman noitpo dna eman noitces a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1847,24 +1892,24 @@ msgstr ""
 ".elbaliava ton si `%(section)s` noitces ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noitpo ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ".elif gifnoc eht gnitide yb tes eb ylno nac noitpo sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "%(default)s :ot tes si noitpo siht tluafed yB"
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1878,31 +1923,31 @@ msgstr ""
 "`%(config)s` **:noitpO**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ".ksid ot evas tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "`%(option)s`  :noitpo eht evas ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "`%(config)s`  :noitpo eht devas yllufsseccuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ".deyalpsid eb tonnac eulav ,elbatide ton si `%(option)s` noitpO"
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1914,24 +1959,24 @@ msgstr ""
 "`%(config)s` **:noitpO**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ".gnittes etadpu tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ".dnammoc bus siht rof eulav dna ,noitpo ,noitces a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noitpO"
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1941,19 +1986,19 @@ msgstr ""
 ".noisses siht rof detadpu saw `%(config)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ".tluafed ot teser tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "!tluafed ot teser ton saw `%(option)s` noitpO"
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1963,17 +2008,17 @@ msgstr ""
 ".`%(default)s` eulav tluafed sti ot teser saw `%(config)s` noitpO"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr ".daetsni dnammoc gifnoc eht esu ,dnammoc detacerpeD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ".daetsni dnammoc gifnoc eht esu ,detacerped si dnammoc noitpo ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1982,33 +2027,33 @@ msgstr ""
 ".stimil derugifnoc ot gnidrocca ehcac raelc ro egarots ehcac tuoba noitamrofni yalpsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "raelc ro ,etadpu ,ofni :esu ,deificeps noitpo dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "delbasiD"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "delbanE"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr "syad %(time)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "detimilnU"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -2024,22 +2069,22 @@ msgstr ""
 "*%(state)s* **:ehcaC oediV**"
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr ".deraelc neeb sah ehcaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "...ofni erom rof sgol kcehc ,ehcac eteled ot **deliaF**"
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr ".raelc ot dnuof ehcac oN"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -2049,12 +2094,12 @@ msgstr ""
 ".eueuq reyalp tnerruc eht tuoba noitamrofni yalpsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ".rebmun elohw a eb tsum tnemugra egap eueuQ"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2064,12 +2109,12 @@ msgstr ""
 ".sdnuob fo tuo si rebmun egap detseuqeR"
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr ")noitarud nwonknu("
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -2082,7 +2127,7 @@ msgstr ""
 "`%(title)s` :gniyalp yltnerruC"
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -2095,7 +2140,7 @@ msgstr ""
 "`%(title)s` :eltiT**:%(index)s# yrtnE**"
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -2109,12 +2154,12 @@ msgstr ""
 ".eueuq eht ni seirtne `%(total)s` era erehT%(progress)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "eueuq ni sgnoS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2123,7 +2168,7 @@ msgstr ""
 ".egassem eueuq eht ot ecnerefer a teg ro ekam t'ndluoc toBcisuM .niaga taht yrT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -2135,38 +2180,38 @@ msgstr ""
 ".lennahc txet gnillac eht morf sdnammoc dna segassem tob evomer dna rof hcraeS"
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ".hcraes ot segassem fo rebmun a edivorp esaelP .retemarap dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ".lennahc MD etavirp no egrup esu tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ".)s(egassem %(number)s pu denaelC"
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr ".segassem eganam ot noissimrep evah ton seod toB"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ".elif a ot tsilyalp a fo sLRU laudividni eht pmuD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ".LRU dilav a ton saw LRU nevig ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2177,18 +2222,18 @@ msgstr ""
 "lru tupni morf ofni tcartxe ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ".tsilyalp a eb ot mees ton seod sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "%(url)s  :rof pmud tsilyalp eht si ereH"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2198,19 +2243,19 @@ msgstr ""
 ".resu denoitnem a fo DI eht ro ,DI resU drocsiD ruoy yalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "`%(id)s` si DI resu ruoY"
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "`%(id)s` si `%(username)s` rof DI resu ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2222,25 +2267,25 @@ msgstr ""
 ".yrogetac detceles eht rof sDI drocsiD eht tsiL"
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "%(cats)s :seirogetac dilaV"
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr ":detseuqer uoy sDI eht era ereH"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 ".resu denoitnem eht fo snoissimrep eht ro ,snoissimrep ruoy fo tsil a teG"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2249,12 +2294,12 @@ msgstr ""
 "dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ".niaga yrT  .resU drocsid eht enimreted ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2268,7 +2313,7 @@ msgstr ""
 ":era %(server)s ni snoissimrep dnammoc ruoY"
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2282,78 +2327,78 @@ msgstr ""
 ":era %(server)s ni %(username)s rof snoissimrep dnammoc ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 "\n"
 ".snoitpo noissimrep tsil dna spuorg dedaol wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 "\n"
 ".elif ini.snoissimrep eht morf snoissimrep sdaoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 "\n"
 ".stluafed htiw puorg wen ddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr ""
 "\n"
 ".puorg gnitsixe evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 "\n"
 ".noitpo noissimrep eht rof txet pleh wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 "\n"
 ".noissimrep dna puorg nevig rof eulav noissimrep wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr ""
 "\n"
 ".elif ot puorg snoissimrep evaS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr ""
 "\n"
 ".puorg eht rof eulav noissimrep teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ".drocsid nihtiw morf noitarugifnoc ini.snoissimrep eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac snoissimreP"
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "!yllufsseccus elif morf dedaoler snoissimreP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2363,7 +2408,7 @@ msgstr ""
 ":rorre na ot eud snoissimreP daoler ot elbanU"
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2378,23 +2423,23 @@ msgstr ""
 ":spuorG elbaliavA ##"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ".dnammoc siht rof eman noitpo ro puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ".dnammoc siht rof tes ot eulav dna ,noitpo ,puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ".eman noissimrep dna puorg a seriuqer dnammoc-bus %(option)s ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2404,24 +2449,24 @@ msgstr ""
 ".elbaliava ton si `%(group)s` puorg ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noissimrep ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ".elif snoissimrep eht gnitide yb tes eb ylno nac noissimrep sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "`%(value)s` :ot tes si noissimrep siht tluafed yB"
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2435,13 +2480,13 @@ msgstr ""
 "`%(option)s` **:noissimreP**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ".stsixe ydaerla ti `%(group)s` puorg dda tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2453,12 +2498,12 @@ msgstr ""
 "`%(group)s`  :puorg wen dedda yllufsseccuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ".puorg ni-tliub evomer tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2468,24 +2513,24 @@ msgstr ""
 "`%(group)s`  :puorg devomer yllufsseccuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ".elbatide ton si puorg renwo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "`%(group)s`  :puorg eht evas ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "`%(group)s`  :puorg eht devas yllufsseccuS"
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2497,13 +2542,13 @@ msgstr ""
 "`%(permission)s` **:noissimreP**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noissimreP"
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2513,7 +2558,7 @@ msgstr ""
 ".noisses siht rof detadpu saw `%(permission)s` noissimreP"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2522,7 +2567,7 @@ msgstr ""
 ".drocsid no emanresu s'tob eht egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2532,7 +2577,7 @@ msgstr ""
 "?semit ynam oot seman egnahc uoy diD .emanresu egnahc ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2542,23 +2587,23 @@ msgstr ""
 "  :rorre ot eud emanresu egnahc ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "`%(name)s` ot emanresu s'tob eht teS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr ".emankcin s'toBcisuM eht egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ".noissimrep on :emankcin egnahc ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2568,23 +2613,23 @@ msgstr ""
 "  :rorre ot eud emankcin tes ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "`%(nick)s` ot emankcin s'tob eht teS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr ".xiferp dnammoc revres-rep a teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr ".xiferp dnammoc revres-rep eht raelC    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2593,23 +2638,23 @@ msgstr ""
 ".revres eht ni xiferp dnammoc tluafed eht edirrevO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ".xiferp a sa esu ot revres siht morf eb tsum ijome motsuC"
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr ".deraelc si xiferp dnammoc revreS"
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "%(prefix)s  :won si xiferp dnammoc revreS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2618,43 +2663,43 @@ msgstr ""
 "!delbane ton si revres rep xiferP"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr ""
 "\n"
 ".esu ot elbaliava sedoc egaugnal wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 "\n"
 ".revres siht rof egaugnal derised eht teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 "\n"
 ".egaugnal tluafed s'tob ot egaugnal revres eht teseR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ".revres gnillac eht ni segassem rof desu egaugnal eht eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ".sdliug ni desu eb ylno nac dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ".noitamrofni erom rof dnammoc pleh eht esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2668,25 +2713,25 @@ msgstr ""
 "`%(locale)s` **:egaugnaL tnerruC**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ".elbaliava ton si ti `%(locale)s` ot egaugnal tes tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "`%(locale)s` :ot tes won revres siht rof egaugnaL"
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "`%(locale)s` :ot teser neeb sah revres siht rof egaugnaL"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2696,12 +2741,12 @@ msgstr ""
 ".ratava s'toBcisuM egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ".elif a hcatta ro LRU a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2711,41 +2756,41 @@ msgstr ""
 "  :rorre ot eud ratava egnahc ot elbanU"
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr ".ratava s'tob eht degnahC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ".revres drocsid eht morf tcennocsid ot toBcisuM ecroF"
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "`%(guild)s` revres morf detcennocsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "]GUB[ ?tneilc eciov sselreyalp a detcennocsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "`%(guild)s` revres ot detcennoc yltnerruc toN"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "\n"
 ".noitpo tluafed ehT .tratser ssecorp tuohtiw daoler ot tpmettA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
@@ -2753,21 +2798,21 @@ msgstr ""
 ".gnihtyreve gnidaoler ,ssecorp toBcisuM eritne eht tratser ot tpmettA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "\n"
 ".tratser erofeb segakcap pip etadpu ot tpmetta tub ,tratser lluF    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "\n"
 ".tsrif tig htiw edoc ecruos toBcisuM etadpu tub ,tratser lluF    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2776,7 +2821,7 @@ msgstr ""
 ".gnitratser ylluf erofeb edoc ecruos dna ycnedneped lla etadpu ot tpmettA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2790,26 +2835,26 @@ msgstr ""
 ".syaw tnereffid fo rebmun a ni toBcisuM eht tratser ot stpmettA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "tigpu ro ,pippu ,edargpu ,lluf ,tfos  :fo eno esu ,nevig noitpo dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "...ecnatsni tnerruc gnitratseR %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "...ssecorp tob gnitratseR %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2817,29 +2862,29 @@ msgstr ""
 "...tob eht tratser dna segakcap pip deriuqer edargpu ot yrt lliW %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "...tob eht tratser dna tig htiw edoc tob etadpu ot yrt lliW %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "...tob eht tratser dna gnihtyreve edargpu ot yrt lliW %(emoji)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ".ssecorp toBcisuM eht esolc dna slennahc eciov lla morf tcennocsiD"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr ".DI revres ro eman yb nevig revres drocsid eht evaeL   "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2849,34 +2894,34 @@ msgstr ""
 ".revres drocsiD nevig eht evael ot toBcisuM ecroF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ".eman ro DI na edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "`%(input)s` eman ro DI eht htiw dnuof saw dliug oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr "renwO nwonknU"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ")`%(id)s` :DI ,`%(owner)s` :renwO( `%(name)s` :dliug eht tfeL"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ".sdnammoc fo gnitset etamotua ot desu dnammoC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2886,48 +2931,48 @@ msgstr ""
 ".esle gnihton seod tub ,LACITIRC level ta gol a seussi dnammoc sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "%(uuid)s  :DI htiw tniopkaerb deggoL"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 "\n"
 ".hpargjbo yb detroper sepyt nommoc tsom weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 "\n"
 ".tuptuo )(htworg_wohs.hpargjbo detimil weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 "\n"
 ".stcejbo gnikael fo sepyt nommoc tsom weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 "\n"
 ".stcejbo gnikael fo statsepyt weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 "\n"
 ".hpargjbo no stnemugra dna noitcnuf nevig eht etaulavE    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2939,12 +2984,12 @@ msgstr ""
 ".egasu yromem otni thgisni niag ot ,dellatsni si ti fi ,hpargjbo htiw tcaretnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "?dellatsni ti si ,`hpargjbo` tropmi ton dluoC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2970,7 +3015,7 @@ msgstr ""
 ".epocs dnammoc eht ni edoc nohtyp yrartibra etucexe lliw dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2986,7 +3031,7 @@ msgstr ""
 ":edoc gubed etucexe ot deliaF"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2995,23 +3040,23 @@ msgstr ""
 ".edoc eht morf sdnammoc ro ,snoissimrep ,snoitpo rof 'nwodkram' etaerC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "%(options)s :fo eno eb tsum dnammoc-buS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr ".selif INI tluafed sekaM"
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "ti kcehc oG .ksid ot elif INI detseuqer eht devaS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -3020,29 +3065,29 @@ msgstr ""
 ".seicnedneped ro toBcisuM ot setadpu rof kcehc dna noisrev tob tnerruc eht yalpsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ".elbatucexe tig etacol ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ".etomer `%(branch)s` hcnarb ni setadpu oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ".etomer hcnarb `%(branch)s` ni elbaliava era stimmoc weN"
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ".sliated rof sgol ees ,gnikcehc elihw rorrE"
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
@@ -3050,22 +3095,22 @@ msgstr ""
 "`%(version)s` :noisrev ot `%(name)s` rof etadpU"
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr ".dnuof seicnedneped rof setadpu oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ".daolnwod rof elbaliava toBcisuM rof setadpu era erehT"
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "!etad-ot-pu yllatot si toBcisuM"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -3085,25 +3130,25 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ".tratser / trats tsal ecnis emit ro ,emitpu toBcisuM eht syalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "`%(time)s` rof enilno neeb sah %(name)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 ".stneilc eciov detcennoc lla dna IPA drocsiD rof noitamrofni ycnetal yalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3113,14 +3158,14 @@ msgstr ""
 ".spbk %(bitrate)s gnisu `%(region)s` :noiger ni ).gvA `sm %(avg).0f`( `sm %(delay).0f` -"
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 "\n"
 ".detcennoc stneilc eciov oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3134,19 +3179,19 @@ msgstr ""
 "`sm %(delay).0f` **:ycnetaL IPA**"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ".detcennoc si toBcisuM fi ycnetal ecioV dna ycnetal IPA yalpsiD"
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "otua"
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -3156,18 +3201,18 @@ msgstr ""
 "%(delay).0f` **:ycnetaL ecioV**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "%(voice)s`sm %(delay).0f` **:ycnetaL IPA**"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr ".tahc eht ni rebmun noisrev toBcisuM yalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -3177,17 +3222,17 @@ msgstr ""
 "toBcisuM/stoB-emoS-tsuJ/moc.buhtig//:sptth"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ".tnemhcatta txt.seikooc a gnisu elif txt.seikooc eht etadpU    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ".ti gniteled tuohtiw elif txt.seikooc elbasid ro elbanE    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -3212,28 +3257,28 @@ msgstr ""
 ".pld-ty ni erutaef seikooc eht fo tnemeganam swollA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ".delbane ydaerla seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ").elif seikooc gnissiM( .delbane eb ot dedaolpu eb tsum seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "%(raw_error)s  :rorre ot eud seikooc elbane ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr ".delbane neeb evah seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -3243,63 +3288,63 @@ msgstr ""
 "%(raw_error)s  :rorre ot eud elif seikooc emaner ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr ".delbasid neeb evah seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 ".elif eikooc a gnidaolpu elihw niaga yrt ,dnuof erew sdaolpu dehcatta oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "%(raw_error)s  :drocsid morf elif seikooc eht gnidaolnwod rorrE"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "%(raw_error)s  :ksid ot seikooc evas ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr ".delbane dna dedaolpu seikooC"
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr ".segassem etavirp ni tob siht esu tonnac uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "%(group)s  :puorg snoissimrep ruoy rof dewolla ton si dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ".lennahc ecioV a ni eb ot uoy seriuqer dnammoc sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "%(name)s **:dnammoC**"
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "rorrE noitpecxE"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3310,19 +3355,19 @@ msgstr ""
 "**:xiferp htiw elpmaxE**"
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr ""
 "\n"
 ".nevig noitpircsed oN"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr ".nevig egasu oN"
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3336,13 +3381,13 @@ msgstr ""
 "**:egasu elpmaxE**"
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ".ytivitcani ot eud %(channel)s lennahc eciov gnivaeL"
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ".ti ni dnuof gnieb ton renwo tob ot eud `%(guild)s` tfeL"
@@ -4016,24 +4061,24 @@ msgstr ""
 ".metsys ruoy no noisrev PI ro sserdda PI cificeps a ot dnib ot pld-ty ecroF"
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ".tsil kcolb eht gniytpme tuohtiw ,erutaef tsil kcolb resu eht elggoT"
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ".tsil kcolb eht gniytpme tuohtiw ,erutaef tsil kcolb gnos eht elbanE"
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 ".enil rep eno ,sDI resU drocsiD gnitsil elif txet a ot htap elif lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -4042,7 +4087,7 @@ msgstr ""
 ".enil rep eno sesarhp ro ,sdrow ,sLRU stsil taht elif txet a ot htap elif lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -4051,7 +4096,7 @@ msgstr ""
 ".selif tsilyalp otua gniniatnoc yrotcerid a ot htap lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -4065,7 +4110,7 @@ msgstr ""
 ".derots eb nac selif aidem elbayalp erehw htap yrotcerid lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -4074,7 +4119,7 @@ msgstr ""
 "yrotcerid lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -4086,7 +4131,7 @@ msgstr ""
 ".tpek selif fo rebmun eht timil dna ,tratser ta noitator elif gol citamotua erugifnoC"
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -4099,7 +4144,7 @@ msgstr ""
 ".delbane si tpeKxaMsgoL nehw desu tamrof etad elif gol eht erugifnoC"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4122,7 +4167,7 @@ msgstr ""
 ".elif snoitpo gifnoc tluafed gnitaerc rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4152,7 +4197,7 @@ msgstr ""
 ".gifnoc gnidaer elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -4171,7 +4216,7 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -4193,7 +4238,7 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -4213,7 +4258,7 @@ msgstr ""
 ".snoitpo gifnoc gnidaer elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4234,7 +4279,7 @@ msgstr ""
 ".yllacitamotua 'DIrenwO' gnihctef elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4253,7 +4298,7 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -4275,7 +4320,7 @@ msgstr ""
 ".gifnoc gnitacol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -4299,7 +4344,7 @@ msgstr ""
 ".gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4319,7 +4364,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4339,7 +4384,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4360,7 +4405,7 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
@@ -4369,7 +4414,7 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
@@ -4378,7 +4423,7 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
@@ -4387,7 +4432,7 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
@@ -4396,7 +4441,7 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
@@ -4405,68 +4450,68 @@ msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr "%(url)s"
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr "%(image)s%(fields)s%(url)s%(content)s%(title)s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "...sredaeh on evah ot smees DAEH"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ".atad on denruter noitcartxe ofni gnoS"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ".desolc si pool tneve ,noitcartxe eunitnoc tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ".detroppus ton ro dilavni si LRU yfitopS"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "%(raw_error)s :atad aidem gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ".LRU dilavni na maerts tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "%(raw_error)s :atad maerts gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ".dnuof eb ton dluoc elif aidem lacol ehT"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ".tsixe ton seod tsilyalp ehT"
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "nwonknU"
 
@@ -4489,13 +4534,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr "%(raw_error)s :rorre pld-ty a ot eud deliaf daolnwoD"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr "%(raw_error)s :noitpecxe deldnahnu na ot eud deliaf daolnwoD"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ".aidem detseuqer eht rof atad tcartxe ot deliaF"
 
@@ -4701,28 +4746,28 @@ msgstr ""
 ".aidem detseuqer eht yalp ot noissimrep evah ton od uoY"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "noitamrofni tcartxe ton dluoC"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ".tsilyalp a si sihT"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr "%(url)s :LRU rof `%(type)s` epyt tnetnoc dilavnI"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "atad noitarud on"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "yrtne tnerruc ni atad noitarud on"
 
@@ -4802,3 +4847,21 @@ msgstr ".dnammoc siht esu nac renwo eht ylnO"
 #: musicbot/utils.py:194
 msgid "Only dev users can use this command."
 msgstr ".dnammoc siht esu nac sresu ved ylnO"
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""

--- a/i18n/xx/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/xx/LC_MESSAGES/musicbot_messages.po
@@ -6,7 +6,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-05-02 07:00-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
@@ -130,7 +130,7 @@ msgstr "!%(channel)s ni `%(title)s` yrtne dedda yllacitamotua gniyalp woN"
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ":LRU"
 
@@ -649,7 +649,7 @@ msgstr ""
 ".eueuq eht ot dedda eb lliw `%(playlist)s` tsilyalp ni skcart ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -931,7 +931,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos yalP .deueuq sgnos on era erehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "!sregetni eb tsum snoitisop gnoS"
 
@@ -968,39 +968,39 @@ msgid "Local media playback is not enabled."
 msgstr ".delbane ton si kcabyalp aidem lacoL"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ".detroppus yltnerruc ton ro dilavni si LRU yfitopS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ".delbane ton si yfitopS tub ,LRU yfitopS a detceteD"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ")%(max)s( timil gnos deueuqne ruoy dehcaer evah uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "!delbasid sti nehw niaga yrt esaelp ,delbane si edom ekoaraK"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ".dnammoc maerts eht gnisu yrT .deyalp eb tonnac oediv tahT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr "%(url)s  :rof %(extractor)s htiw stluser on denruter hcraeS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
@@ -1008,7 +1008,7 @@ msgstr ""
 ")sdnoces %(max)s( noitarud xam revo erew sgnos lla ,dedda erew sgnos oN"
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -1018,13 +1018,13 @@ msgstr ""
 ".deyalp eb ot sgnos **%(number)s** deueuqnE"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ")%(max)s > %(length)s( timil sdeecxe noitarud gnoS"
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -1034,24 +1034,24 @@ msgstr ""
 ".deyalp eb ot `%(track)s` deueuqnE"
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "!txen gniyalP"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr "`%(eta)s` :gniyalp litnu emit detamitse - %(position)s"
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ".gniyalp litnu emit etamitse tonnac - %(position)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -1065,25 +1065,25 @@ msgstr ""
 ".maertS a sa eueuq eht ot LRU aidem a ddA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ".detroppus tey ton si stsilyalp gnimaertS"
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr "`%(track)s` kcart gnimaerts woN"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 "\n"
 ".yreuq hcraes eht htiw stluser fo rebmun a rof ecivres htiw hcraeS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
@@ -1093,7 +1093,7 @@ msgstr ""
 ".stluser fo rebmun motsuc a teg tub yreuq rof ebuTuoY hcraeS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -1117,266 +1117,266 @@ msgstr ""
 ".eueuq ot dda ot stluser morf tceles dna ecivres detroppus a hcraeS"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ")%(max)s( timil meti tsilyalp ruoy dehcaer evah uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 ".noitamrofni erom rof `hcraes pleh` esU  .yreuq hcraes a yficeps esaelP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr "soediv %(max)s naht erom rof hcraes tonnac uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "...soediv rof gnihcraeS"
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr "%(error)s :rorre na ot eud deliaf hcraeS"
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr ".dnuof soediv oN"
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr ".rebmun gnidnopserroc eht epyt ,gnos a tceles oT"
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ":%(service)s morf stluser hcraeS"
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr "%(length)s | **%(track)s** .**%(index)s**"
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
 msgstr "lecnaC .**0**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "gnos a kciP"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ".eueuq eht ot )%(url)s(]%(track)s[ gnos deddA"
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr "%(url)s :%(total)s fo %(number)s tluseR"
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "!pu thgir gnimoc ,thgirlA"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr ".gniyalp yltnerruc si tahw no noitamrofni wohS"
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "]tsilyalpotua["
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "gniyalp woN"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr ":gnimaerts yltnerruC"
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr ":gniyalp yltnerruC"
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr ":yB deddA"
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr "`%(user)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr ":ssergorP"
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ".dnammoc yalp a htiw gnihtemos eueuQ !deueuq sgnos on era erehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr ".ni er'uoy lennahc eht nioj ot toBcisuM lleT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "!lennahc eciov a gninioj yrT .eciov ot detcennoc ton era uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr "`%(channel)s` ot detcennoC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 "\n"
 ".revres a ni slennahc egnahc yeht nehw resu a wollof toBcisuM sekaM"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr "`%(user)s` resu gniwollof regnol oN"
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ".slennahc eciov neewteb `%(user)s` resu gniwollof woN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ".revres eht fo rebmem a ton si taht resu a wollof tonnac toBcisuM"
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ".slennahc eciov neewteb `%(user)s` resu wollof lliW"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr ".gniyalp yltnerruc si kcart a fi kcabyalp esuaP"
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr "`%(channel)s` ni cisum desuaP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ".gniyalp ton si reyalP"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ".desuap ylsuoiverp saw reyalp eht fi kcabyalp semuseR"
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr "`%(channel)s` ni cisum demuseR"
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "eueuq cisum demuseR"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr ".desuap ton si reyalP"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr ".eueuq eht ni skcart tnerruc lla elffuhS"
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr ".eueuq eht ni sgnos lla delffuhS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr ".eueuq eht ni yltnerruc sgnos lla sevomeR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 ".dnammoc yalp a htiw gnihtemos yalP .gniyalp yltnerruc gnihton si erehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr ".eueuq eht morf sgnos lla deraelC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 "\n"
 ".]NOITISOP[ ta ro eueuq eht fo dne eht ta gnos a evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 "\n"
 ".OT noitisop ot MORF noitisop morf sgnos evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 "\n"
 ".resu denoitnem eht yb dedda sgnos evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -1394,17 +1394,17 @@ msgstr ""
 ".deificeps NOITISOP ta eueuq eht morf gnos a evomeR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "!evomer ot eueuq eht ni gnihtoN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .snoitisop dilavnI"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
@@ -1413,25 +1413,25 @@ msgstr ""
 ".eueuq eht morf egnar nevig eht ni sgnos eht lla evomer ot noissimrep eht evah ton od uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr "!%(to)s hguorht %(from)s sgnos devomer yllufsseccuS"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr "`%(user)s` yb dedda `%(track)s` devomeR"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr "`%(user)s` resu morf eueuq eht ni dnuof gnihtoN"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1440,24 +1440,24 @@ msgstr ""
 ".eueuq eht morf yrtne taht evomer ot noissimrep eht evah ton od uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ".snoitisop eueuq dnif ot dnammoc eueuq eht esU .rebmun yrtne dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr "`%(user)s` yb dedda `%(track)s` yrtne devomeR"
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr "`%(track)s` yrtne devomeR"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1469,23 +1469,23 @@ msgstr ""
 ".gnos gniyalp tnerruc eht piks ot etov ro pikS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "!gniyalp ton si reyalp ehT !piks t'naC"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ".tiaw esaelp ,gnidaolnwod si `%(track)s` gnos txen ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ".tiaw esaelP .yltrohs deyalp eb lliw gnos txen ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1494,7 +1494,7 @@ msgstr ""
 ".gnineppah si ddo gnihtemoS"
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
@@ -1503,28 +1503,28 @@ msgstr ""
 ".gnineppah si egnarts gnihtemoS"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ".gnos depool a piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ".`%(track)s` deppiks ecroF"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ".piks ecrof ot noissimrep evah ton od uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ".gnos depool a piks ot noissimrep evah ton od uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1534,12 +1534,12 @@ msgstr ""
 ".degdelwonkca saw `%(track)s` rof piks ruoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr "!pu gnimoc gnos txeN "
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1549,7 +1549,7 @@ msgstr ""
 ".degdelwonkca saw `%(track)s` rof piks ruoY"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1561,25 +1561,25 @@ msgstr ""
 ".001 ot 1 morf toBcisuM fo level emulov tuptuo eht teS"
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr "`%%%(volume)s` :emulov tnerruC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr "rebmun dilav a ton si `%(new_volume)s`"
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "**%(new)d** ot **%(old)d** morf emulov detadpU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1589,7 +1589,7 @@ msgstr ""
 ".%(new_volume)s si %(adjustment)s%(old_volume)s :dedivorp egnahc emulov elbanosaernU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
@@ -1597,7 +1597,7 @@ msgstr ""
 ".001 dna 1 neewteb eulav a edivorP .%(volume)s :dedivorp emulov elbanosaernU"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1609,7 +1609,7 @@ msgstr ""
 ".ylno kcart gniyalp yltnerruc eht fo deeps kcabyalp eht egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1618,49 +1618,49 @@ msgstr ""
 ".deeps tes tonnac ,gniyalp si kcart oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ".aidem demaerts ot deilppa eb tonnac deepS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ".tes ot deeps a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ".001 dna 5.0 neewteb rebmun a esU .dilavni si dedivorp uoy deeps ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ".kcart tnerruc rof `%(speed).3f` ot deeps kcabyalp gnitteS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 "\n"
 ".stnemugra lanoitpo htiw saila wen na ddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 "\n"
 ".eman nevig eht htiw saila na evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 "\n"
 ".elif gifnoc eht ot/morf sesaila evas ro daoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
@@ -1669,23 +1669,23 @@ msgstr ""
 "swollA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr "`%(option)s` :dnammoc rof noitpo dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr ".elif gifnoc morf dedaoler sesailA"
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr ".elif gifnoc ot devas sesailA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1695,42 +1695,42 @@ msgstr ""
 ":rorre ot eud sesaila evas ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "saila ot dnammoc a dna saila na ylppus tsum uoY"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr "`%(command)s` fo saila na won si `%(alias)s` .dedda saila weN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ".evomer ot eman saila na ylppus tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ".tsixe ton seod `%(alias)s` saila ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ".devomer saw `%(alias)s` sailA"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 "\n"
 ".snoitpo gifnoc gnissim yna tuoba txet pleh swohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
@@ -1739,42 +1739,42 @@ msgstr ""
 ".elif gifnoc gnidaol ecnis degnahc neeb evah hcihw snoitpo fo seman eht stsiL    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 "\n"
 ".snoitces rieht dna snoitpo gifnoc elbaliava eht tsiL    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 "\n"
 ".ksid morf elif ini.snoitpo eht daoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 "\n"
 ".noitpo cificeps a rof txet pleh swohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr ""
 "\n"
 ".noitpo eht fo eulav tnerruc eht yalpsiD    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 "\n"
 ".elif snoitpo eht ot eulav tnerruc eht sevaS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
@@ -1783,29 +1783,29 @@ msgstr ""
 ".elif ot ton tub ,noisses eht rof gifnoc eht stes dna noitpo eht setadilaV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 "\n"
 ".eulav tluafed sti ot noitpo eht teseR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr ".drocsiD nihtiw morf noitarugifnoc ini.snoitpo eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac gifnoC"
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*!rof detnuocca dna tneserp era snoitpo gifnoc llA*"
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -1817,12 +1817,12 @@ msgstr ""
 "**:snoitpO gnissiM**"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr ".degnahc eb ot raeppa snoitpo gifnoc oN"
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1832,7 +1832,7 @@ msgstr ""
 "**:snoitpO degnahC**"
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1848,12 +1848,12 @@ msgstr ""
 ":snoitpO elbaliavA ##"
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "!yllufsseccus elif morf dedaoler snoitpo gifnoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1863,7 +1863,7 @@ msgstr ""
 ":rorre gniwollof eht ot eud gifnoC daoler ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
@@ -1872,17 +1872,17 @@ msgstr ""
 "noitces evloser ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ".eman noitces a edivorp esaelp ,suougibma si nevig noitpo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ".dnammoc siht rof eman noitpo dna eman noitces a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1892,24 +1892,24 @@ msgstr ""
 ".elbaliava ton si `%(section)s` noitces ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noitpo ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ".elif gifnoc eht gnitide yb tes eb ylno nac noitpo sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr "%(default)s :ot tes si noitpo siht tluafed yB"
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1923,31 +1923,31 @@ msgstr ""
 "`%(config)s` **:noitpO**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ".ksid ot evas tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr "`%(option)s`  :noitpo eht evas ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr "`%(config)s`  :noitpo eht devas yllufsseccuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ".deyalpsid eb tonnac eulav ,elbatide ton si `%(option)s` noitpO"
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1959,24 +1959,24 @@ msgstr ""
 "`%(config)s` **:noitpO**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ".gnittes etadpu tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ".dnammoc bus siht rof eulav dna ,noitpo ,noitces a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noitpO"
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1986,19 +1986,19 @@ msgstr ""
 ".noisses siht rof detadpu saw `%(config)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ".tluafed ot teser tonnaC .elbatide ton si `%(option)s` noitpO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr "!tluafed ot teser ton saw `%(option)s` noitpO"
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -2008,17 +2008,17 @@ msgstr ""
 ".`%(default)s` eulav tluafed sti ot teser saw `%(config)s` noitpO"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr ".daetsni dnammoc gifnoc eht esu ,dnammoc detacerpeD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ".daetsni dnammoc gifnoc eht esu ,detacerped si dnammoc noitpo ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -2027,33 +2027,33 @@ msgstr ""
 ".stimil derugifnoc ot gnidrocca ehcac raelc ro egarots ehcac tuoba noitamrofni yalpsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "raelc ro ,etadpu ,ofni :esu ,deificeps noitpo dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "delbasiD"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "delbanE"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr "syad %(time)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "detimilnU"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -2069,22 +2069,22 @@ msgstr ""
 "*%(state)s* **:ehcaC oediV**"
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr ".deraelc neeb sah ehcaC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "...ofni erom rof sgol kcehc ,ehcac eteled ot **deliaF**"
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr ".raelc ot dnuof ehcac oN"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
@@ -2094,12 +2094,12 @@ msgstr ""
 ".eueuq reyalp tnerruc eht tuoba noitamrofni yalpsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ".rebmun elohw a eb tsum tnemugra egap eueuQ"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -2109,12 +2109,12 @@ msgstr ""
 ".sdnuob fo tuo si rebmun egap detseuqeR"
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr ")noitarud nwonknu("
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -2127,7 +2127,7 @@ msgstr ""
 "`%(title)s` :gniyalp yltnerruC"
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -2140,7 +2140,7 @@ msgstr ""
 "`%(title)s` :eltiT**:%(index)s# yrtnE**"
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -2154,12 +2154,12 @@ msgstr ""
 ".eueuq eht ni seirtne `%(total)s` era erehT%(progress)s"
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "eueuq ni sgnoS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
@@ -2168,7 +2168,7 @@ msgstr ""
 ".egassem eueuq eht ot ecnerefer a teg ro ekam t'ndluoc toBcisuM .niaga taht yrT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -2180,38 +2180,38 @@ msgstr ""
 ".lennahc txet gnillac eht morf sdnammoc dna segassem tob evomer dna rof hcraeS"
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ".hcraes ot segassem fo rebmun a edivorp esaelP .retemarap dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ".lennahc MD etavirp no egrup esu tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ".)s(egassem %(number)s pu denaelC"
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr ".segassem eganam ot noissimrep evah ton seod toB"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ".elif a ot tsilyalp a fo sLRU laudividni eht pmuD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ".LRU dilav a ton saw LRU nevig ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2222,18 +2222,18 @@ msgstr ""
 "lru tupni morf ofni tcartxe ton dluoC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ".tsilyalp a eb ot mees ton seod sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr "%(url)s  :rof pmud tsilyalp eht si ereH"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
@@ -2243,19 +2243,19 @@ msgstr ""
 ".resu denoitnem a fo DI eht ro ,DI resU drocsiD ruoy yalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr "`%(id)s` si DI resu ruoY"
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr "`%(id)s` si `%(username)s` rof DI resu ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -2267,25 +2267,25 @@ msgstr ""
 ".yrogetac detceles eht rof sDI drocsiD eht tsiL"
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr "%(cats)s :seirogetac dilaV"
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr ":detseuqer uoy sDI eht era ereH"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 ".resu denoitnem eht fo snoissimrep eht ro ,snoissimrep ruoy fo tsil a teG"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
@@ -2294,12 +2294,12 @@ msgstr ""
 "dilavnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ".niaga yrT  .resU drocsid eht enimreted ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -2313,7 +2313,7 @@ msgstr ""
 ":era %(server)s ni snoissimrep dnammoc ruoY"
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -2327,78 +2327,78 @@ msgstr ""
 ":era %(server)s ni %(username)s rof snoissimrep dnammoc ehT"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 "\n"
 ".snoitpo noissimrep tsil dna spuorg dedaol wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 "\n"
 ".elif ini.snoissimrep eht morf snoissimrep sdaoleR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 "\n"
 ".stluafed htiw puorg wen ddA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr ""
 "\n"
 ".puorg gnitsixe evomeR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 "\n"
 ".noitpo noissimrep eht rof txet pleh wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 "\n"
 ".noissimrep dna puorg nevig rof eulav noissimrep wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr ""
 "\n"
 ".elif ot puorg snoissimrep evaS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr ""
 "\n"
 ".puorg eht rof eulav noissimrep teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ".drocsid nihtiw morf noitarugifnoc ini.snoissimrep eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ".emit emas eht ta snoitnem resu dna lennahc esu tonnac snoissimreP"
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "!yllufsseccus elif morf dedaoler snoissimreP"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2408,7 +2408,7 @@ msgstr ""
 ":rorre na ot eud snoissimreP daoler ot elbanU"
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -2423,23 +2423,23 @@ msgstr ""
 ":spuorG elbaliavA ##"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ".dnammoc siht rof eman noitpo ro puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ".dnammoc siht rof tes ot eulav dna ,noitpo ,puorg a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ".eman noissimrep dna puorg a seriuqer dnammoc-bus %(option)s ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2449,24 +2449,24 @@ msgstr ""
 ".elbaliava ton si `%(group)s` puorg ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ".elbaliava ton si `%(option)s` noissimrep ehT"
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ".elif snoissimrep eht gnitide yb tes eb ylno nac noissimrep sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr "`%(value)s` :ot tes si noissimrep siht tluafed yB"
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -2480,13 +2480,13 @@ msgstr ""
 "`%(option)s` **:noissimreP**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ".stsixe ydaerla ti `%(group)s` puorg dda tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -2498,12 +2498,12 @@ msgstr ""
 "`%(group)s`  :puorg wen dedda yllufsseccuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ".puorg ni-tliub evomer tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2513,24 +2513,24 @@ msgstr ""
 "`%(group)s`  :puorg devomer yllufsseccuS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ".elbatide ton si puorg renwo ehT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr "`%(group)s`  :puorg eht evas ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr "`%(group)s`  :puorg eht devas yllufsseccuS"
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2542,13 +2542,13 @@ msgstr ""
 "`%(permission)s` **:noissimreP**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr "!detadpu ton saw `%(option)s` noissimreP"
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2558,7 +2558,7 @@ msgstr ""
 ".noisses siht rof detadpu saw `%(permission)s` noissimreP"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2567,7 +2567,7 @@ msgstr ""
 ".drocsid no emanresu s'tob eht egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
@@ -2577,7 +2577,7 @@ msgstr ""
 "?semit ynam oot seman egnahc uoy diD .emanresu egnahc ot deliaF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2587,23 +2587,23 @@ msgstr ""
 "  :rorre ot eud emanresu egnahc ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr "`%(name)s` ot emanresu s'tob eht teS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr ".emankcin s'toBcisuM eht egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ".noissimrep on :emankcin egnahc ot elbanU"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2613,23 +2613,23 @@ msgstr ""
 "  :rorre ot eud emankcin tes ot deliaF"
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr "`%(nick)s` ot emankcin s'tob eht teS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr ".xiferp dnammoc revres-rep a teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr ".xiferp dnammoc revres-rep eht raelC    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2638,23 +2638,23 @@ msgstr ""
 ".revres eht ni xiferp dnammoc tluafed eht edirrevO"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ".xiferp a sa esu ot revres siht morf eb tsum ijome motsuC"
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr ".deraelc si xiferp dnammoc revreS"
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr "%(prefix)s  :won si xiferp dnammoc revreS"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2663,43 +2663,43 @@ msgstr ""
 "!delbane ton si revres rep xiferP"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr ""
 "\n"
 ".esu ot elbaliava sedoc egaugnal wohS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 "\n"
 ".revres siht rof egaugnal derised eht teS    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 "\n"
 ".egaugnal tluafed s'tob ot egaugnal revres eht teseR    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ".revres gnillac eht ni segassem rof desu egaugnal eht eganaM"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ".sdliug ni desu eb ylno nac dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ".noitamrofni erom rof dnammoc pleh eht esU .nevig dnammoc-bus dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2713,25 +2713,25 @@ msgstr ""
 "`%(locale)s` **:egaugnaL tnerruC**"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ".elbaliava ton si ti `%(locale)s` ot egaugnal tes tonnaC"
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr "`%(locale)s` :ot tes won revres siht rof egaugnaL"
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr "`%(locale)s` :ot teser neeb sah revres siht rof egaugnaL"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2741,12 +2741,12 @@ msgstr ""
 ".ratava s'toBcisuM egnahC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ".elif a hcatta ro LRU a edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2756,41 +2756,41 @@ msgstr ""
 "  :rorre ot eud ratava egnahc ot elbanU"
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr ".ratava s'tob eht degnahC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ".revres drocsid eht morf tcennocsid ot toBcisuM ecroF"
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr "`%(guild)s` revres morf detcennocsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "]GUB[ ?tneilc eciov sselreyalp a detcennocsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr "`%(guild)s` revres ot detcennoc yltnerruc toN"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 "\n"
 ".noitpo tluafed ehT .tratser ssecorp tuohtiw daoler ot tpmettA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
@@ -2798,21 +2798,21 @@ msgstr ""
 ".gnihtyreve gnidaoler ,ssecorp toBcisuM eritne eht tratser ot tpmettA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 "\n"
 ".tratser erofeb segakcap pip etadpu ot tpmetta tub ,tratser lluF    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 "\n"
 ".tsrif tig htiw edoc ecruos toBcisuM etadpu tub ,tratser lluF    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
@@ -2821,7 +2821,7 @@ msgstr ""
 ".gnitratser ylluf erofeb edoc ecruos dna ycnedneped lla etadpu ot tpmettA    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2835,26 +2835,26 @@ msgstr ""
 ".syaw tnereffid fo rebmun a ni toBcisuM eht tratser ot stpmettA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 "tigpu ro ,pippu ,edargpu ,lluf ,tfos  :fo eno esu ,nevig noitpo dilavnI"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr "...ecnatsni tnerruc gnitratseR %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr "...ssecorp tob gnitratseR %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
@@ -2862,29 +2862,29 @@ msgstr ""
 "...tob eht tratser dna segakcap pip deriuqer edargpu ot yrt lliW %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr "...tob eht tratser dna tig htiw edoc tob etadpu ot yrt lliW %(emoji)s"
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr "...tob eht tratser dna gnihtyreve edargpu ot yrt lliW %(emoji)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ".ssecorp toBcisuM eht esolc dna slennahc eciov lla morf tcennocsiD"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr ".DI revres ro eman yb nevig revres drocsid eht evaeL   "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
@@ -2894,34 +2894,34 @@ msgstr ""
 ".revres drocsiD nevig eht evael ot toBcisuM ecroF"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ".eman ro DI na edivorp tsum uoY"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr "`%(input)s` eman ro DI eht htiw dnuof saw dliug oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr "renwO nwonknU"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ")`%(id)s` :DI ,`%(owner)s` :renwO( `%(name)s` :dliug eht tfeL"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ".sdnammoc fo gnitset etamotua ot desu dnammoC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
@@ -2931,48 +2931,48 @@ msgstr ""
 ".esle gnihton seod tub ,LACITIRC level ta gol a seussi dnammoc sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr "%(uuid)s  :DI htiw tniopkaerb deggoL"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 "\n"
 ".hpargjbo yb detroper sepyt nommoc tsom weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 "\n"
 ".tuptuo )(htworg_wohs.hpargjbo detimil weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 "\n"
 ".stcejbo gnikael fo sepyt nommoc tsom weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 "\n"
 ".stcejbo gnikael fo statsepyt weiV    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 "\n"
 ".hpargjbo no stnemugra dna noitcnuf nevig eht etaulavE    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2984,12 +2984,12 @@ msgstr ""
 ".egasu yromem otni thgisni niag ot ,dellatsni si ti fi ,hpargjbo htiw tcaretnI"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "?dellatsni ti si ,`hpargjbo` tropmi ton dluoC"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -3015,7 +3015,7 @@ msgstr ""
 ".epocs dnammoc eht ni edoc nohtyp yrartibra etucexe lliw dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -3031,7 +3031,7 @@ msgstr ""
 ":edoc gubed etucexe ot deliaF"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -3040,23 +3040,23 @@ msgstr ""
 ".edoc eht morf sdnammoc ro ,snoissimrep ,snoitpo rof 'nwodkram' etaerC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr "%(options)s :fo eno eb tsum dnammoc-buS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr ".selif INI tluafed sekaM"
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "ti kcehc oG .ksid ot elif INI detseuqer eht devaS"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
@@ -3065,29 +3065,29 @@ msgstr ""
 ".seicnedneped ro toBcisuM ot setadpu rof kcehc dna noisrev tob tnerruc eht yalpsiD"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ".elbatucexe tig etacol ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ".etomer `%(branch)s` hcnarb ni setadpu oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ".etomer hcnarb `%(branch)s` ni elbaliava era stimmoc weN"
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ".sliated rof sgol ees ,gnikcehc elihw rorrE"
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
@@ -3095,22 +3095,22 @@ msgstr ""
 "`%(version)s` :noisrev ot `%(name)s` rof etadpU"
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr ".dnuof seicnedneped rof setadpu oN"
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ".daolnwod rof elbaliava toBcisuM rof setadpu era erehT"
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "!etad-ot-pu yllatot si toBcisuM"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -3130,25 +3130,25 @@ msgstr ""
 "%(status)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ".tratser / trats tsal ecnis emit ro ,emitpu toBcisuM eht syalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr "`%(time)s` rof enilno neeb sah %(name)s"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 ".stneilc eciov detcennoc lla dna IPA drocsiD rof noitamrofni ycnetal yalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3158,14 +3158,14 @@ msgstr ""
 ".spbk %(bitrate)s gnisu `%(region)s` :noiger ni ).gvA `sm %(avg).0f`( `sm %(delay).0f` -"
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 "\n"
 ".detcennoc stneilc eciov oN"
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3179,19 +3179,19 @@ msgstr ""
 "`sm %(delay).0f` **:ycnetaL IPA**"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ".detcennoc si toBcisuM fi ycnetal ecioV dna ycnetal IPA yalpsiD"
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "otua"
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -3201,18 +3201,18 @@ msgstr ""
 "%(delay).0f` **:ycnetaL ecioV**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr "%(voice)s`sm %(delay).0f` **:ycnetaL IPA**"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr ".tahc eht ni rebmun noisrev toBcisuM yalpsiD"
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -3222,17 +3222,17 @@ msgstr ""
 "toBcisuM/stoB-emoS-tsuJ/moc.buhtig//:sptth"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ".tnemhcatta txt.seikooc a gnisu elif txt.seikooc eht etadpU    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ".ti gniteled tuohtiw elif txt.seikooc elbasid ro elbanE    "
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -3257,28 +3257,28 @@ msgstr ""
 ".pld-ty ni erutaef seikooc eht fo tnemeganam swollA"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ".delbane ydaerla seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ").elif seikooc gnissiM( .delbane eb ot dedaolpu eb tsum seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr "%(raw_error)s  :rorre ot eud seikooc elbane ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr ".delbane neeb evah seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -3288,63 +3288,63 @@ msgstr ""
 "%(raw_error)s  :rorre ot eud elif seikooc emaner ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr ".delbasid neeb evah seikooC"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 ".elif eikooc a gnidaolpu elihw niaga yrt ,dnuof erew sdaolpu dehcatta oN"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr "%(raw_error)s  :drocsid morf elif seikooc eht gnidaolnwod rorrE"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr "%(raw_error)s  :ksid ot seikooc evas ton dluoC"
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr ".delbane dna dedaolpu seikooC"
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr ".segassem etavirp ni tob siht esu tonnac uoY"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr "%(group)s  :puorg snoissimrep ruoy rof dewolla ton si dnammoc sihT"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ".lennahc ecioV a ni eb ot uoy seriuqer dnammoc sihT"
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr "%(name)s **:dnammoC**"
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "rorrE noitpecxE"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -3355,19 +3355,19 @@ msgstr ""
 "**:xiferp htiw elpmaxE**"
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr ""
 "\n"
 ".nevig noitpircsed oN"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr ".nevig egasu oN"
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -3381,13 +3381,13 @@ msgstr ""
 "**:egasu elpmaxE**"
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ".ytivitcani ot eud %(channel)s lennahc eciov gnivaeL"
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ".ti ni dnuof gnieb ton renwo tob ot eud `%(guild)s` tfeL"
@@ -3776,7 +3776,7 @@ msgstr ""
 ".elbissop erehw erom neve egasu UPC secuder tub ,oiduAsupOesU ot ralimiS"
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -3787,7 +3787,7 @@ msgstr ""
 ".pldty hguorht toBcisuM yb desu ecivres hcraes tluafed eht stes noitpo sihT"
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
@@ -3796,12 +3796,12 @@ msgstr ""
 "toBcisuM elbanE"
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ".meht gniyalp erofeb skcart tsilyalp otua eht selffuhS"
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -3810,7 +3810,7 @@ msgstr ""
 ".gnos wen a syalp resu a nehw sgnos tsilyalp otua fo piks citamotua elbanE"
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3819,7 +3819,7 @@ msgstr ""
 "evomeR"
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3831,7 +3831,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3841,7 +3841,7 @@ msgstr ""
 "gnivas elbanE"
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
@@ -3850,7 +3850,7 @@ msgstr ""
 "elbanE"
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -3859,13 +3859,13 @@ msgstr ""
 ".pu trats no nioj yllacitamotua dluohs toBcisuM taht sDI lennahC ecioV fo tsil A"
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ".yawa thgir ti eteled ro ,aidem dedaolnwod peek ot toBcisuM wollA"
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -3875,7 +3875,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
@@ -3883,7 +3883,7 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -3892,7 +3892,7 @@ msgstr ""
 ",delbane si soediVevaS fI"
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
@@ -3901,7 +3901,7 @@ msgstr ""
 "yllacitamotuA"
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3930,14 +3930,14 @@ msgstr ""
 "tob eht ,ytpme tfel fI .sutats s'tob eht sa esu ot egassem motsuc a yficepS"
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ".sreyalp desuap no ofni troper lliw segassem sutats ,delbane fI"
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3946,12 +3946,12 @@ msgstr ""
 ",delbane fI"
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ".putrats ta sgol eht ni sgnittes gifnoc toBcisuM yalpsiD"
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3960,14 +3960,14 @@ msgstr ""
 ",delbane fI"
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 ".lennahc eciov a gniretne nehw flesti nefaed yllacitamotua lliw toBcisuM"
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3978,7 +3978,7 @@ msgstr ""
 ",gninetsil era sresu on nehw lennahc eciov a evael lliw toBcisuM ,delbane fI"
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3987,7 +3987,7 @@ msgstr ""
 ".lennahc eciov evitcani na gnivael erofeb tiaw ot emit fo doirep a teS"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
@@ -3996,7 +3996,7 @@ msgstr ""
 ",delbane fI"
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -4007,7 +4007,7 @@ msgstr ""
 ".eciov evael neht emit fo tnuoma siht rof tiaw ,gniyalp regnol on ro desuap nehW"
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -4020,7 +4020,7 @@ msgstr ""
 ".ytilibaliava dna egatuo krowten tceted ot sgnip demit esu ot toBcisuM wollA"
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -4031,7 +4031,7 @@ msgstr ""
 ".redaolnwod aidem pldty htiw esu ot sgnittes yxorp SPTTH/PTTH ,latnemirepxE"
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -4048,7 +4048,7 @@ msgstr ""
 ".pld-ty ni redaeh tnegA-resU citats a tes ot noitpo latnemirepxE"
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4061,24 +4061,24 @@ msgstr ""
 ".metsys ruoy no noisrev PI ro sserdda PI cificeps a ot dnib ot pld-ty ecroF"
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ".tsil kcolb eht gniytpme tuohtiw ,erutaef tsil kcolb resu eht elggoT"
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ".tsil kcolb eht gniytpme tuohtiw ,erutaef tsil kcolb gnos eht elbanE"
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 ".enil rep eno ,sDI resU drocsiD gnitsil elif txet a ot htap elif lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -4087,7 +4087,7 @@ msgstr ""
 ".enil rep eno sesarhp ro ,sdrow ,sLRU stsil taht elif txet a ot htap elif lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -4096,7 +4096,7 @@ msgstr ""
 ".selif tsilyalp otua gniniatnoc yrotcerid a ot htap lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -4110,7 +4110,7 @@ msgstr ""
 ".derots eb nac selif aidem elbayalp erehw htap yrotcerid lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
@@ -4119,7 +4119,7 @@ msgstr ""
 "yrotcerid lanoitpo nA"
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -4131,7 +4131,7 @@ msgstr ""
 ".tpek selif fo rebmun eht timil dna ,tratser ta noitator elif gol citamotua erugifnoC"
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -4144,7 +4144,7 @@ msgstr ""
 ".delbane si tpeKxaMsgoL nehw desu tamrof etad elif gol eht erugifnoC"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4167,7 +4167,7 @@ msgstr ""
 ".elif snoitpo gifnoc tluafed gnitaerc rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4197,7 +4197,7 @@ msgstr ""
 ".gifnoc gnidaer elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -4216,7 +4216,7 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -4238,7 +4238,7 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -4258,7 +4258,7 @@ msgstr ""
 ".snoitpo gifnoc gnidaer elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4279,7 +4279,7 @@ msgstr ""
 ".yllacitamotua 'DIrenwO' gnihctef elihw rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4298,7 +4298,7 @@ msgstr ""
 ".snoitpo gifnoc gnitadilav rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -4320,7 +4320,7 @@ msgstr ""
 ".gifnoc gnitacol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -4344,7 +4344,7 @@ msgstr ""
 ".gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4364,7 +4364,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4384,7 +4384,7 @@ msgstr ""
 ".eulav gifnoc gnidaol rorrE"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -4463,49 +4463,49 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr "%(image)s%(fields)s%(url)s%(content)s%(title)s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "...sredaeh on evah ot smees DAEH"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ".atad on denruter noitcartxe ofni gnoS"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ".desolc si pool tneve ,noitcartxe eunitnoc tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ".detroppus ton ro dilavni si LRU yfitopS"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr "%(raw_error)s :atad aidem gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ".LRU dilavni na maerts tonnaC"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr "%(raw_error)s :atad maerts gnidaolnwod elihw pld-ty ni rorrE"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ".dnuof eb ton dluoc elif aidem lacol ehT"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ".tsixe ton seod tsilyalp ehT"
 
@@ -4849,7 +4849,7 @@ msgid "Only dev users can use this command."
 msgstr ".dnammoc siht esu nac sresu ved ylnO"
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4858,7 +4858,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/zh_CN/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/zh_CN/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -431,20 +431,20 @@ msgid ""
 msgstr "MusicBot 与语音的连接已取消。这是奇异的。可能要重新启动吗？"
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot 请求在频道中说话: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot 没有发言权限。"
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot 无法请求发言。"
 
@@ -567,7 +567,7 @@ msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "没有为 URL 条目设置缩略图： %s"
@@ -650,19 +650,19 @@ msgid "Looping over player autoplaylist..."
 msgstr "正在循环播放器自动布局列表..."
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot 需要停止自动播放列表提取和保释。"
 
@@ -1021,7 +1021,7 @@ msgstr "公会列表："
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr ""
@@ -1558,7 +1558,7 @@ msgid "The player is not currently looping."
 msgstr "玩家目前没有循环中。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "歌曲位置必须是整数！"
 
@@ -1579,33 +1579,33 @@ msgid "Local media playback is not enabled."
 msgstr "本地媒体播放未启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL 无效或目前不支持。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "检测到 Spotify 网址，但Spotify 未启用。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke模式已启用，请禁用后再试一次！"
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr "与extract_info() 有关的问题： "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1613,12 +1613,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "无法播放该视频。请尝试使用流命令。"
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1626,148 +1626,148 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr "提取了“youtube:playlist”作为提取器键的条目"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "尚不支持流播放列表。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr "请指定一个搜索查询。使用 \"help search \" 获取更多信息。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "您没有连接到语音。请尝试加入一个语音频道！"
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot 不能关注不是服务器成员的用户。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "播放器未播放。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "队列中没有要移除的内容！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "无效的条目编号。使用队列命令来查找队列位置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "无法跳过！玩家没有在玩！"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "您没有权限强制跳过循环歌曲。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "您没有强制跳过的权限。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "您没有权限跳过循环歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1775,42 +1775,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "速度不能应用于流媒体。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "您必须提供一个速度来设置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "您提供的速度无效。请使用0.5 至 100之间的数字。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1818,28 +1818,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "您必须为别名提供别名和命令"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "您必须提供一个别名来移除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "配置不能同时使用频道和用户提到。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1847,24 +1847,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "无法解析选项名称中的部分名称。请提供一个有效的部分和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "给定的选项含混，请提供一个章节名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "您必须提供此命令的部分名称和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1872,97 +1872,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "您必须为此子命令提供一个章节、选项和值。"
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "选项命令已废弃，请使用配置命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "指定的选项无效，使用：信息、更新或清除"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**删除缓存失败，请检查日志获取更多信息..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "队列页面参数必须是一个整数。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "没有播放队列的歌曲！队列中有播放命令的歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1970,39 +1970,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr "跳过当前播放列表条目。"
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr "没有足够的条目来分页队列。"
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr "无法发布队列消息，没有消息添加反应。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "无法在私有DM频道上使用净化。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "给定的 URL 不是有效的 URL。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2010,29 +2010,29 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "这似乎不是一个播放列表。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "无效的用户ID或服务器昵称，请重新检查ID，然后重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "无法确定 Discord 用户，请重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "权限不能同时使用频道和用户提到。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2040,23 +2040,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "您必须为此命令提供一个组或选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "您必须为此命令设置一个组、选项和值。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2064,54 +2064,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "无法删除内置组。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "所有者群组不可编辑。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2119,12 +2119,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "无法更改昵称：没有权限。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2132,12 +2132,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "自定义表情必须来自此服务器才能用作前缀。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2146,28 +2146,28 @@ msgstr ""
 "使用配置命令来更新前缀。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "此命令只能用于公会。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "给定的子命令无效。请使用帮助命令获取更多信息。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "您必须提供一个 URL 或附加文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2175,62 +2175,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot找到了一个 %s 没有公会！这可能是一个问题。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "给定的选项无效，请使用其中一项：软、完整、升级、上传或上传。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "您必须提供一个ID或名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "无法导入 `objgraph` ，是否安装？"
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr "调试代码使用 eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr "调试代码与 exec() 一起运行。"
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr "调试代码执行失败。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2241,54 +2241,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "无法找到 git 可执行文件。"
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr "通过 git 命令检查更新失败。"
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr "Pip报告中缺少元数据。"
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr "由于某些错误，Pip更新状态失败。"
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr "获取一个奇怪的语音客户端条目。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookie 已启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookie 必须上传才能启用。(正在使用 cookies 文件)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2296,183 +2296,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "没有找到附加的上传文件，上传cookie文件时再试一次。"
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "获取一条没有频道的消息，或者说：  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "忽略自身的命令 (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "忽略其它机器人的命令(%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "忽略频道类型的命令：  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "此命令要求您在语音频道中。"
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "无法为缺失的命令生成帮助：  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "缺少命令的帮助数据：  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr "MusicBot 已连接。"
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot 已断开连接。"
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "获取一个套接字事件:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr "在 on_ready 完成之前更新语音状态"
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "忽略 %s 中的 %s ，因为它是一个绑定的语音频道。"
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s 被检测为空。处理超时。"
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "一个用户加入 %s，取消计时器。"
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "机器人移动了，音频道 %s 为空。处理超时。"
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "机器人移动了，声音频道 %s 不是空的。"
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr "不再关注用户 %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr "频道前没有语音状态断开连接。"
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2480,96 +2480,96 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "找不到自动加入的频道，是否删除？公会:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "重新连接到频道上的自动加入公会:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "无法自动加入频道:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "帐号已添加到公会: %s"
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "由于找不到机器人所有人，左公会为%s' 。"
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "为公会创建数据文件夹 %s"
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "机器人已从公会中移除： %s"
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr "更新公会列表："
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "公会\"%s\"已经可用。"
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "由于可用，恢复玩家“%s”。"
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "公会\"%s\" 已不可用。"
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "由于不可用而暂停玩家 \"%s\"。"
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "公会更新:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2587,7 +2587,7 @@ msgid "Loading config from:  %s"
 msgstr "正在加载配置：  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2605,7 +2605,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2613,14 +2613,14 @@ msgid ""
 msgstr "不能存储超过 %s 的日志文件。选项LogsMaxKept 将被限制。"
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr "配置选项 LogsDateFormat 是空的，这将破坏日志文件的旋转。使用默认值。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2632,12 +2632,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "验证AudioCachePath时出现异常。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2651,13 +2651,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "音频缓存将存储在:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2670,14 +2670,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr "状态消息配置选项太长，它将被限制为128个字符。"
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2685,17 +2685,17 @@ msgid ""
 msgstr "默认播放速度必须在 0.5 和 100.0之间。 %.3f 的选项值将被限制。"
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr "正在通过服务数据验证选项..."
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr "通过 API 获得所有者ID"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2708,12 +2708,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot 没有用户实例，不能继续。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2732,12 +2732,12 @@ msgstr ""
 "  不要在“所有者ID”字段中使用机器人或App ID。"
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "找不到配置选项文件，正在检查替代..."
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2745,18 +2745,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr "试图找到配置选项文件时出了错。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2778,7 +2778,7 @@ msgstr ""
 "  验证配置文件夹和文件存在并且可以通过 MusicBot 读取。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2793,54 +2793,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "开发错误！配置选项有不可用的getter。"
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr "开发错误！配置选项的类型无效，获取类型和默认类型必须相同。"
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr "此前缺少备选办法。"
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "配置部分不在解析后的配置中！缺少： %s"
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "保存配置失败：  %s"
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr "选项名称在INI部分之间并不唯一！解析器已被禁用。"
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "保存默认 INI 文件失败:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2853,7 +2853,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2866,7 +2866,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2879,7 +2879,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2887,7 +2887,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2895,7 +2895,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2903,54 +2903,54 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr "使用重命名选项升级配置文件..."
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "升级配置失败。您需要手动升级。"
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "未找到方块列表文件：  %s"
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "无法从文件加载块列表：  %s"
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "无法更新块列表文件：  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "使用 %s 条目加载用户块列表。"
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "我们找到了一个旧的黑名单文件，它将被重命名为:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "使用 %s 条目加载歌曲方块列表。"
@@ -3008,39 +3008,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "强制YTDLP使用用户代理:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot 将使用 cookie 的 yt-dlp:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp 将使用您配置的代理服务器。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD 似乎没有信头..."
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr "由于超时检查媒体头部失败。"
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "HEAD 请求失败：  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr "HEAD 请求异常： "
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3050,82 +3050,82 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "已卫生化的 YTDL 提取信息(而不是JSON ):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "歌曲信息提取没有返回数据。"
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr "无法运行提取，循环已关闭。(关机时这是正常的。)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "无法继续提取，事件循环已关闭。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL 无效或不支持。"
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr "下载流URL错误"
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr "假设内容是直接流"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "无法生成无效的 URL。"
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr "捕捉到NoSupportingHanders，在用空格替换冒号后再次尝试。"
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "找不到本地媒体文件。"
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "YtdlpResponseDict 缺少__input_subject"
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr "条目不是 YtdlpResponseDict 中的列表, 设置进程=True 以避免这种情况。"
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -4350,13 +4350,13 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr "此设备上剩余的剩余空间小于 %sMB"
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
@@ -4365,42 +4365,42 @@ msgstr ""
 "正在检查对 MusicBot 或依赖关系的更新..."
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr "没有通过 `git` 命令提供的 MusicBot 更新。"
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
 msgstr "无法使用 'git' 命令检查更新。您应该手动检查。"
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr "以下软件包可以更新：\n"
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr "  %s  到版本:  %s\n"
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr "无法通过 `pip` 命令更新依赖信息。"
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
 msgstr "无法使用 \"pip\" 命令检查更新。您应该手动检查。"
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -4410,73 +4410,73 @@ msgstr ""
 "    %s ./update.py"
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr "值高于最大限制。"
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr "值不能为负值。"
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr "最大日志的值必须是 0 到 %s 的数字"
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr "日志关卡 '%s不可用。"
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr "日志级别必须是:  %s"
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
 msgstr "启动使用 discord.py, youtubeDL 和 ffmpeg 构建的音乐播放机器人。"
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr "通过 Github："
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr "为了获得更多的帮助和支持，加入我们的不和："
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr "这种软件是根据MIT许可证提供的。"
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr "详情请参阅`LICENSE`文本文件。"
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr "覆盖 MusicBot 中所有文本的默认值/系统。"
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr "对于来自 MusicBot 的所有服务器端日志消息使用此语言。"
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
@@ -4485,34 +4485,34 @@ msgstr ""
 "这并不阻止每个公会语言的选择。"
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr "打印MusicBot 版本信息并退出。"
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr "跳过所有可选的启动检查，包括更新检查。"
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr "启动时仅跳过磁盘空间检查。"
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr "在启动时仅跳过更新检查。"
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
 msgstr "禁用 MusicBot 在无法导入时无法安装依赖项。"
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4520,13 +4520,13 @@ msgid ""
 msgstr "指定要保存多少日志文件，介于 0 到 %s 之间。(默认： %s)"
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr "覆盖配置中设置的日志级别设置。必须是: %s"
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4534,42 +4534,42 @@ msgid ""
 msgstr "重写旋转日志文件时使用的默认日期格式。这应该包含与 strftime()兼容的值。(默认：'%s')"
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr "版本:  %s"
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "打开了一个新的 MusicBot 实例。此终端可以安全地关闭！"
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "正在加载 MusicBot 版本：  %s"
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr "日志已打开:  %s"
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "更改工作目录到:  %s"
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4577,7 +4577,7 @@ msgid ""
 msgstr "无法启动机器人！您在错误的目录中启动了`run.py`，我们无法定位`musicbot`和`。 它的文件夹以验证新的目录位置。"
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4586,19 +4586,19 @@ msgstr ""
 "如果你没有使用 git 来克隆仓库，你会被强烈敦促."
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr "证书错误不是验证错误，而不是尝试验证和退出。"
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr "这是一个确切的错误，它可能是一个错误。"
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4607,24 +4607,24 @@ msgstr ""
 "您可以在 Microsoft Edge 或 IE中打开失败站点...\n"
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr "无法从默认的信任商店获取发行者证书，请改用 certifi。"
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "语法错误(检测到更改，您是否编辑代码？)"
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "语法错误 (这是一个bug, 而不是你的错误)"
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4637,12 +4637,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "尝试自动安装 MusicBot 依赖软件包...\n"
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4663,55 +4663,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "好的，让我们希望安装依赖关系成功！"
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr "MusicBot 在尝试安装软件包后发生导入错误。MusicBot必须退出..."
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr "造成上述错误的异常： "
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot 正在进行软重启..."
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot 正在重启整个进程..."
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr "启动机器人出错"
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr "关闭活动循环。"
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "在 %s 秒后重启..."
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr "全部完成。"
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr "好的，我们正在关闭！"
 
@@ -4732,31 +4720,31 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4770,7 +4758,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4830,7 +4818,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5061,24 +5049,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5125,25 +5113,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5151,66 +5139,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5237,7 +5179,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5249,25 +5191,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5280,29 +5222,143 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr "MusicBot 在尝试安装软件包后发生导入错误。MusicBot必须退出..."
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr "造成上述错误的异常： "
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/zh_CN/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/zh_CN/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -145,7 +145,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr "Spotify没有为我们提供令牌。禁用。"
 
@@ -162,61 +162,43 @@ msgid ""
 "Details: %s. Continuing anyway in 5 seconds..."
 msgstr ""
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr "配置没有 Spotify 应用凭据，正在尝试使用访客模式。"
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr "使用 Spotify 验证成功使用访客模式。"
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr "已初始化，正在连接到 discord。"
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr "通过配置禁用网络ping测试。"
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr "网络Ping 测试正在关闭。"
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr "无法解析 ping 目标。"
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr "网络Ping 测试已取消。"
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr "通过 HTTP 进行网络测试没有要借用的会话。"
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr "无法在您的环境中找到 ping` 可执行文件。"
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -226,7 +208,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -236,7 +218,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -246,35 +228,35 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr "侦测到的 MusicBot 网络再次可用."
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr "语音客户端未连接，正在等待恢复 MusicPlayer..."
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr "MusicBot 检测到网络停用。"
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -282,155 +264,155 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr "正在检查频道以自动加入或恢复..."
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr "丢弃音乐播放器并制作新音乐..."
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr "MusicBot 现在将创建一个新的 MusicPlayer ..."
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr "已完成加入配置频道。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "会员没有语音功能，无法使用此命令。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "您不能在语音频道中使用此命令。"
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr "正在获取机器人应用程序信息。"
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr "断开连接失败或已取消？"
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr "MusicBot 现在有一个语音客户端..."
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -438,71 +420,71 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr "MusicBot 语音客户端连接尝试已取消。无需重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr "MusicBot 与语音的连接已取消。这是奇异的。可能要重新启动吗？"
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr "MusicBot 请求在频道中说话: %s"
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot 没有发言权限。"
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot 无法请求发言。"
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr "在杀死MusicPlayer前断开语音客户端。"
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr "断开连接失败或取消。"
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr "MusicBot 有一个不是语音客户端的语音协议，仍然断开连接..."
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr "断开非公会语音客户端的连接..."
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -510,43 +492,43 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr "MusicPlayer 有一个未连接的语音客户端。"
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -554,7 +536,7 @@ msgid ""
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -562,381 +544,381 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "出错了，我们没有得到语音客户端。"
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr "运行_player_player"
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr "没有为 URL 条目设置缩略图： %s"
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr "没有频道放入正在播放消息"
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr "忽略正在播放的消息，因为它已经被发布。"
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr "运行 on_player_result"
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr "运行 on_player_pause"
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr "运行_player_stop"
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr "运行_player_finished_play_playing"
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr "事件循环已关闭，此处不需要做任何其它事情。"
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr "注销正在进行，忽略此事件。"
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr "语音客户端说它没有连接，我们在这里无法做任何其他事情。"
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr "播放器已完成，队列为空，离开语音频道..."
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr "正在循环播放队列以删除缺失作者的歌曲..."
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr "公会自动播放列表中没有可播放的歌曲，禁用。"
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr "当前自动播放列表中没有内容。用新音乐填充..."
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr "正在循环播放器自动布局列表..."
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr "MusicBot 需要停止自动播放列表提取和保释。"
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr "在玩家完成的活动中，MusicBot 有一个未处理的异常。"
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr "上述异常数据错误："
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr "自动播放列表中没有可播放的歌曲，禁用了。"
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr "已添加 on_player_entry_添加"
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr "自动跳过队列条目的自动播放列表条目。"
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr "MusicPlayer 异常。"
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr "注销正在进行，忽略状态更新事件。"
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr "无法发送无响应对象：  %r"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug ] 试图发送无效的响应对象。"
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr "无法发送私信，发送到后退频道中。"
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr "评分有限的发送消息，但不能重试！"
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr "在后退频道中发送消息失败。"
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr "由于HTTP错误发送失败。"
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr "评分限制信息已删除，但无法重试！"
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr "删除消息失败"
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr "发送消息"
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr "编辑消息失败"
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr "断开和关闭MusicBot"
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr "处理中断信号时抛出异常！"
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr "MusicBot 正在执行关闭步骤..."
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -950,44 +932,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr "正在等待下载线程完成..."
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr "正在等待任务..."
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr "关闭HTTP连接器。"
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr "闭幕会议."
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr "注销已被调用。"
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -995,80 +977,80 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr "MusicBot恢复了不一致的会话。"
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr "准备好完成"
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr "已登录，正在准备好MusicBot..."
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr "客户端在某种程度上是没有的，我们去做保释..."
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr "公会列表："
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr "所有者未知。机器人不在任何公会上。"
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1078,405 +1060,405 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr "无法绑定到 ID 为  %d 的不可信频道"
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr "文本通道绑定："
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr "不绑定到任何文本频道"
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr "没有自动加入频道ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr "无法自动加入私有/非公会频道与 ID:  %d"
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr "无法自动加入不可连接的频道 ID:  %d"
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr "自动加入语音频道："
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr "不自动加入任何语音频道"
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr "正在获取应用程序信息。"
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr "确保数据文件夹存在"
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr "正在验证配置"
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr "正在验证权限配置"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr "已禁用"
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr "已启用"
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr "选项："
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr "随机的"
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr "序列"
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr "    删除正在播放中: %s"
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr "试图处理 Voice Channot 处于无活动状态，但Bot 没有语音..."
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr "正在重置玩家活动计时器。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "没有这种命令"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "您必须提及用户或提供他们的身份号码。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "给定的子命令无效。使用 \"help blockuser\" 作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot 无法找到您指定的用户。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "所有者不能添加到方块列表。"
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "无法添加您列出的用户，他们已经被添加。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "如果没有歌曲正在播放，您必须提供一个歌曲主题。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "给定的子命令无效。使用 \"help blocksong\" 作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "主题不在歌曲块列表中，无法删除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr "给定的子命令无效。使用 \"help autoplaylist\" 作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "提供的歌曲链接无效"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "队列为空。用播放命令添加一些歌曲！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "这首歌已经在自动播放列表中。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "这首歌尚未在自动播放列表中。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "您必须提供一个播放列表文件名。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "您无权请求播放列表"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1485,24 +1467,24 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr "由于网络停电，忽略自动暂停。"
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
 msgstr "MusicPlayer 没有 VoiceClient 或没有频道数据，无法处理自动暂停。"
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr "已经在处理自动暂停，忽略此事件。"
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1510,55 +1492,55 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr "自动暂停等待已取消。"
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr "一个新的 MusicPlayer 正在连接，忽略旧的自动暂停事件。"
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "如果没有播放，无法使用寻找。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "无法在当前轨道上使用寻找，它有未知的持续时间。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "不支持搜索。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "没有时间定位播放，无法使用搜索引擎。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1566,64 +1548,64 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr "无效的子命令。使用命令“help repat”作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "玩家目前没有循环中。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "歌曲位置必须是整数！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "您提供了一个超出播放列表大小的位置！"
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr "无法提示播放列表播放，没有消息添加反应。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "本地媒体播放未启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL 无效或目前不支持。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "检测到 Spotify 网址，但Spotify 未启用。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke模式已启用，请禁用后再试一次！"
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr "与extract_info() 有关的问题： "
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1631,15 +1613,9 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "无法播放该视频。请尝试使用流命令。"
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr ""
 
 #. Used by: info
 #: musicbot/bot.py:4467
@@ -1742,56 +1718,56 @@ msgid "Player is not playing."
 msgstr "播放器未播放。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "队列中没有要移除的内容！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "无效的条目编号。使用队列命令来查找队列位置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "无法跳过！玩家没有在玩！"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "您没有权限强制跳过循环歌曲。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "您没有强制跳过的权限。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "您没有权限跳过循环歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1799,42 +1775,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "速度不能应用于流媒体。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "您必须提供一个速度来设置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "您提供的速度无效。请使用0.5 至 100之间的数字。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1842,28 +1818,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "您必须为别名提供别名和命令"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "您必须提供一个别名来移除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "配置不能同时使用频道和用户提到。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1871,24 +1847,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "无法解析选项名称中的部分名称。请提供一个有效的部分和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "给定的选项含混，请提供一个章节名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "您必须提供此命令的部分名称和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1896,97 +1872,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "您必须为此子命令提供一个章节、选项和值。"
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "选项命令已废弃，请使用配置命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "指定的选项无效，使用：信息、更新或清除"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**删除缓存失败，请检查日志获取更多信息..."
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "队列页面参数必须是一个整数。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "没有播放队列的歌曲！队列中有播放命令的歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1994,39 +1970,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr "跳过当前播放列表条目。"
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr "没有足够的条目来分页队列。"
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr "无法发布队列消息，没有消息添加反应。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "无法在私有DM频道上使用净化。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "给定的 URL 不是有效的 URL。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -2034,29 +2010,29 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "这似乎不是一个播放列表。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "无效的用户ID或服务器昵称，请重新检查ID，然后重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "无法确定 Discord 用户，请重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "权限不能同时使用频道和用户提到。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -2064,23 +2040,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "您必须为此命令提供一个组或选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "您必须为此命令设置一个组、选项和值。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -2088,54 +2064,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "无法删除内置组。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "所有者群组不可编辑。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2143,12 +2119,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "无法更改昵称：没有权限。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2156,12 +2132,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "自定义表情必须来自此服务器才能用作前缀。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2170,28 +2146,28 @@ msgstr ""
 "使用配置命令来更新前缀。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "此命令只能用于公会。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "给定的子命令无效。请使用帮助命令获取更多信息。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "您必须提供一个 URL 或附加文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2199,62 +2175,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr "MusicBot找到了一个 %s 没有公会！这可能是一个问题。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "给定的选项无效，请使用其中一项：软、完整、升级、上传或上传。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "您必须提供一个ID或名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "无法导入 `objgraph` ，是否安装？"
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr "调试代码使用 eval()."
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr "调试代码与 exec() 一起运行。"
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr "调试代码执行失败。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2265,54 +2241,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "无法找到 git 可执行文件。"
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr "通过 git 命令检查更新失败。"
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr "Pip报告中缺少元数据。"
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr "由于某些错误，Pip更新状态失败。"
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr "获取一个奇怪的语音客户端条目。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookie 已启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookie 必须上传才能启用。(正在使用 cookies 文件)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2320,183 +2296,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "没有找到附加的上传文件，上传cookie文件时再试一次。"
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr "获取一条没有频道的消息，或者说：  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr "忽略自身的命令 (%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr "忽略其它机器人的命令(%s)"
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr "忽略频道类型的命令：  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "此命令要求您在语音频道中。"
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr "无法为缺失的命令生成帮助：  %s"
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr "缺少命令的帮助数据：  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr "MusicBot 已连接。"
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr "MusicBot 已断开连接。"
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr "获取一个套接字事件:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr "在 on_ready 完成之前更新语音状态"
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr "忽略 %s 中的 %s ，因为它是一个绑定的语音频道。"
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr "%s 被检测为空。处理超时。"
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr "一个用户加入 %s，取消计时器。"
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr "机器人移动了，音频道 %s 为空。处理超时。"
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr "机器人移动了，声音频道 %s 不是空的。"
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr "不再关注用户 %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr "频道前没有语音状态断开连接。"
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2504,96 +2480,96 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr "找不到自动加入的频道，是否删除？公会:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr "重新连接到频道上的自动加入公会:  %s"
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr "无法自动加入频道:  %s"
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr "帐号已添加到公会: %s"
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr "由于找不到机器人所有人，左公会为%s' 。"
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr "为公会创建数据文件夹 %s"
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr "机器人已从公会中移除： %s"
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr "更新公会列表："
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr "公会\"%s\"已经可用。"
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr "由于可用，恢复玩家“%s”。"
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr "公会\"%s\" 已不可用。"
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr "由于不可用而暂停玩家 \"%s\"。"
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr "公会更新:  %s"
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2611,7 +2587,7 @@ msgid "Loading config from:  %s"
 msgstr "正在加载配置：  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -2629,7 +2605,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2637,14 +2613,14 @@ msgid ""
 msgstr "不能存储超过 %s 的日志文件。选项LogsMaxKept 将被限制。"
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr "配置选项 LogsDateFormat 是空的，这将破坏日志文件的旋转。使用默认值。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2656,12 +2632,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr "验证AudioCachePath时出现异常。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2675,13 +2651,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr "音频缓存将存储在:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2694,14 +2670,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr "状态消息配置选项太长，它将被限制为128个字符。"
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2709,17 +2685,17 @@ msgid ""
 msgstr "默认播放速度必须在 0.5 和 100.0之间。 %.3f 的选项值将被限制。"
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr "正在通过服务数据验证选项..."
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr "通过 API 获得所有者ID"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -2732,12 +2708,12 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr "MusicBot 没有用户实例，不能继续。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -2756,12 +2732,12 @@ msgstr ""
 "  不要在“所有者ID”字段中使用机器人或App ID。"
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr "找不到配置选项文件，正在检查替代..."
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2769,18 +2745,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr "试图找到配置选项文件时出了错。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2802,7 +2778,7 @@ msgstr ""
 "  验证配置文件夹和文件存在并且可以通过 MusicBot 读取。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2817,54 +2793,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr "开发错误！配置选项有不可用的getter。"
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr "开发错误！配置选项的类型无效，获取类型和默认类型必须相同。"
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr "此前缺少备选办法。"
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr "配置部分不在解析后的配置中！缺少： %s"
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr "保存配置失败：  %s"
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr "选项名称在INI部分之间并不唯一！解析器已被禁用。"
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr "保存默认 INI 文件失败:  %s"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2877,7 +2853,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2890,7 +2866,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2903,7 +2879,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2911,7 +2887,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2919,7 +2895,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2927,144 +2903,144 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr "使用重命名选项升级配置文件..."
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr "升级配置失败。您需要手动升级。"
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr "未找到方块列表文件：  %s"
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr "无法从文件加载块列表：  %s"
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr "无法更新块列表文件：  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr "使用 %s 条目加载用户块列表。"
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr "我们找到了一个旧的黑名单文件，它将被重命名为:  %s"
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr "使用 %s 条目加载歌曲方块列表。"
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr "无法用ID0加载公会数据。这可能是代码中的错误！"
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr "一个操作系统错误阻止读取公会数据文件：  %s"
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr "无法保存与 ID 0的公会数据。这可能是代码中的一个错误！"
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr "由于操作系统错误，无法保存公会特定数据。"
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr "由于无效数据，无法序列化公会特定数据。"
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr "强制YTDLP使用用户代理:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr "MusicBot 将使用 cookie 的 yt-dlp:  %s"
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr "Yt-dlp 将使用您配置的代理服务器。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD 似乎没有信头..."
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr "由于超时检查媒体头部失败。"
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr "HEAD 请求失败：  %s"
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr "HEAD 请求异常： "
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -3074,82 +3050,82 @@ msgstr ""
 "%s"
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr "已卫生化的 YTDL 提取信息(而不是JSON ):  %s"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "歌曲信息提取没有返回数据。"
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr "无法运行提取，循环已关闭。(关机时这是正常的。)"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "无法继续提取，事件循环已关闭。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL 无效或不支持。"
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr "下载流URL错误"
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr "假设内容是直接流"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "无法生成无效的 URL。"
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr "捕捉到NoSupportingHanders，在用空格替换冒号后再次尝试。"
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "找不到本地媒体文件。"
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr "YtdlpResponseDict 缺少__input_subject"
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr "条目不是 YtdlpResponseDict 中的列表, 设置进程=True 以避免这种情况。"
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -3192,12 +3168,12 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr "条目数据缺失版本号，不能反序列化。"
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr "条目数据有错误的版本号，不能反序列化。"
 
@@ -3226,7 +3202,7 @@ msgid ""
 msgstr "反序列化的 URL 播放列表条目有作者ID，但没有查找频道！"
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr "无法加载 %s"
@@ -3238,7 +3214,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr "准备进入：  %r"
@@ -3260,7 +3236,7 @@ msgid "Download already cached at:  %s"
 msgstr "下载已缓存于:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -3275,7 +3251,7 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -3283,75 +3259,75 @@ msgid ""
 msgstr "解决EQ问题可能是一个奇怪的安装程序造成的。 这不会影响机器人的工作能力，但意味着您的轨道将不会平等。"
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr "检查条目数据时出现异常。"
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr "尝试通过pymediainfo 获取持续时间:  %s"
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr "无法通过 pymediainfo 获取持续时间。"
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr "尝试通过 ffprobe 获取持续时间:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr "无法在您的路径中找到 ffprobe!"
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr "ffprobe 返回了无法使用的东西。"
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr "由于某种原因无法执行 ffprobe。"
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr "计算平均体积:  %s"
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr "无法在您的路径上找到 ffmpeg ！"
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr "无法解析 json。"
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr "无法解析 json 正常化 “LRA”。"
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr "无法解析 json 正常化 “TP”。"
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr "无法解析 json 正常化 “阈值”。"
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr "无法解析 json 正常化 'offset' 。"
 
@@ -3393,84 +3369,84 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr "解压遇到一个未处理的异常。"
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr "下载失败：  %r"
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "为请求的媒体提取数据失败。"
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr "下载完成：  %r"
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr "反序列化的 StreamPlaylistEnter无法找到与 ID:  %s 的频道"
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr "反序列化的 StreamPlaylistentre 有错误的频道类型:  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr "反序列化的 StreamPlaylistEnter无法找到 ID 的作者：  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr "反序列化的 StreamPlaylistEnter有作者ID，但没有查找渠道！"
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr "反序列化的 LocalFilePlaylistEnter无法找到与 ID:  %s 的频道"
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr "反序列化的本地文件播放列表条目有错误的通道类型：  %s"
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr "反序列化的 LocalFilePlaylistEnter无法找到ID:  %s 的作者"
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
 msgstr "Desertialized LocalFilePlaylistEnt有作者ID，但没有查找渠道！"
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr ""
@@ -3574,19 +3550,19 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr "Lang 参数错误:  %s"
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -3906,116 +3882,116 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr "解码来自 ffmpeg的数据: %s"
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "无法提取信息"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "这是一个播放列表。"
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr "条目信息似乎是一个流，正在添加流条目..."
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr "获取内容类型的文本/html ，这可能是一个串流。"
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr "从与ID的复合播放列表链接忽略视频:  %s"
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr "以 '%s' 忽略条目中的歌曲，持续时间超过允许的最大值。"
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr "不添加 YouTube 视频，因为它已标记为私有或已删除：  %s"
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr "无法添加项目"
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr "项目： %s"
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr "跳过 %s 错误条目"
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr "在条目上重新排序循环."
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr "预下载下一首曲目：  %r"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "无持续时间数据"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "当前条目中没有持续数据"
 
@@ -4558,42 +4534,42 @@ msgid ""
 msgstr "重写旋转日志文件时使用的默认日期格式。这应该包含与 strftime()兼容的值。(默认：'%s')"
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr "版本:  %s"
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr "打开了一个新的 MusicBot 实例。此终端可以安全地关闭！"
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr "正在加载 MusicBot 版本：  %s"
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr "日志已打开:  %s"
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr "Python version:  %s"
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr "更改工作目录到:  %s"
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4601,7 +4577,7 @@ msgid ""
 msgstr "无法启动机器人！您在错误的目录中启动了`run.py`，我们无法定位`musicbot`和`。 它的文件夹以验证新的目录位置。"
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
@@ -4610,19 +4586,19 @@ msgstr ""
 "如果你没有使用 git 来克隆仓库，你会被强烈敦促."
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr "证书错误不是验证错误，而不是尝试验证和退出。"
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr "这是一个确切的错误，它可能是一个错误。"
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
@@ -4631,24 +4607,24 @@ msgstr ""
 "您可以在 Microsoft Edge 或 IE中打开失败站点...\n"
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr "无法从默认的信任商店获取发行者证书，请改用 certifi。"
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr "语法错误(检测到更改，您是否编辑代码？)"
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr "语法错误 (这是一个bug, 而不是你的错误)"
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4661,12 +4637,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr "尝试自动安装 MusicBot 依赖软件包...\n"
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4687,70 +4663,70 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr "好的，让我们希望安装依赖关系成功！"
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
 msgstr "MusicBot 在尝试安装软件包后发生导入错误。MusicBot必须退出..."
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr "造成上述错误的异常： "
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr "MusicBot 正在进行软重启..."
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr "MusicBot 正在重启整个进程..."
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr "启动机器人出错"
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr "关闭活动循环。"
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr "在 %s 秒后重启..."
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr "全部完成。"
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr "好的，我们正在关闭！"
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
@@ -4775,12 +4751,12 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4794,7 +4770,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4862,45 +4838,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -4912,220 +4888,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5144,30 +5120,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5175,18 +5151,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5261,9 +5237,88 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr "配置没有 Spotify 应用凭据，正在尝试使用访客模式。"
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr "使用 Spotify 验证成功使用访客模式。"
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/zh_CN/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/zh_CN/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -702,7 +702,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr "没有播放队列的歌曲。播放一些带有播放命令的歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr "歌曲位置必须是整数！"
 
@@ -734,28 +734,28 @@ msgid "Local media playback is not enabled."
 msgstr "本地媒体播放未启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL 无效或目前不支持。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "检测到 Spotify 网址，但Spotify 未启用。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke模式已启用，请禁用后再试一次！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -763,19 +763,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr "无法播放该视频。请尝试使用流命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -783,13 +783,13 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -797,24 +797,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr "接下来玩！"
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -823,81 +823,81 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr "尚不支持流播放列表。"
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr "    通过搜索查询服务搜索一些结果。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr "请指定一个搜索查询。使用 \"help search \" 获取更多信息。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr "正在搜索视频..."
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr "未找到视频。"
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr "要选择歌曲，请输入相应的数字。"
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
@@ -906,194 +906,194 @@ msgstr ""
 "**0**。取消"
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr "选择一首歌曲"
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr "好吧，正在准备好！"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr "显示当前正在播放的信息。"
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr "正在播放"
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr "正在串流："
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr "当前正在播放："
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr "添加人："
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr "进度："
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "没有播放队列的歌曲！队列中有播放命令的歌曲。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr "告诉MusicBot 加入您所加入的频道。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr "您没有连接到语音。请尝试加入一个语音频道！"
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr "当用户更改服务器中的频道时，让MusicBot跟随用户。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr "MusicBot 不能关注不是服务器成员的用户。"
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr "如果有曲目正在播放，暂停播放。"
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr "播放器未播放。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr "如果玩家先前暂停，恢复播放。"
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr "继续音乐队列"
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr "玩家未暂停。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr "随机播放队列中所有当前曲目。"
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr "随机播放队列中的所有歌曲。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr "移除队列中的所有歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr "清除队列中的所有歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr "队列中没有要移除的内容！"
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1102,24 +1102,24 @@ msgstr ""
 "您必须是排队它或拥有即时跳过权限的人。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "无效的条目编号。使用队列命令来查找队列位置。"
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1127,58 +1127,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr "无法跳过！玩家没有在玩！"
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr "下一首歌即将播放，请稍候。"
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr "您没有权限强制跳过循环歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr "您没有强制跳过的权限。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr "您没有权限跳过循环歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1186,12 +1186,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr " 下一首歌即将开始！"
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1199,7 +1199,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1207,25 +1207,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "音量从 **%(old)d** 更新到 **%(new)d"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1233,14 +1233,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1248,7 +1248,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1257,56 +1257,56 @@ msgstr ""
 "使用配置命令设置默认播放速度。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr "速度不能应用于流媒体。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr "您必须提供一个速度来设置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "您提供的速度无效。请使用0.5 至 100之间的数字。"
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    添加可选参数的新别名。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr "允许管理不一致的别名。要查看别名，请使用帮助命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr "已从配置文件重新加载别名。"
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr "别名保存到配置文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1314,104 +1314,104 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr "您必须为别名提供别名和命令"
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr "您必须提供一个别名来移除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    显示任何缺失配置选项的帮助文本。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr "    列出可用的配置选项及其章节。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    从磁盘重新加载options.ini 文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr "    显示特定选项的帮助文本。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr "    显示选项的当前值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr "    将当前值保存到选项文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr "    验证选项并设置会话配置，但不设置为文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr "    重置选项为默认值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr "从 Discord 内部管理options.ini 配置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "配置不能同时使用频道和用户提到。"
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr "*所有配置选项都已存在并已核算！*"
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr "没有配置选项被更改。"
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1419,7 +1419,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1430,12 +1430,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr "配置选项从文件重新加载成功！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1443,24 +1443,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "无法解析选项名称中的部分名称。请提供一个有效的部分和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "给定的选项含混，请提供一个章节名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr "您必须提供此命令的部分名称和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1468,24 +1468,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr "此选项只能通过编辑配置文件来设置。"
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1495,31 +1495,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1528,24 +1528,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "您必须为此子命令提供一个章节、选项和值。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1553,19 +1553,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1573,17 +1573,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr "已废弃的命令，改用配置命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr "选项命令已废弃，请使用配置命令。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1592,33 +1592,33 @@ msgstr ""
 "使用更新选项将在显示详细信息之前扫描缓存进行外部更改。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "指定的选项无效，使用：信息、更新或清除"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr "已禁用"
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr "已启用"
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr "无限制"
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1629,34 +1629,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr "缓存已清除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**删除缓存失败，请检查日志获取更多信息..."
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr "没有找到要清除的缓存。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr "队列页面参数必须是一个整数。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1664,12 +1664,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr "(未知持续时间)"
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1678,7 +1678,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1688,19 +1688,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr "队列中的歌曲"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1708,38 +1708,38 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "参数无效。请提供一些要搜索的消息。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr "无法在私有DM频道上使用净化。"
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr "机器人没有管理信件的权限。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "将播放列表中的单个URL转储到一个文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr "给定的 URL 不是有效的 URL。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1747,37 +1747,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr "这似乎不是一个播放列表。"
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1785,36 +1785,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr "这里是您请求的ID："
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "获取您的权限列表或上述用户的权限。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "无效的用户ID或服务器昵称，请重新检查ID，然后重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr "无法确定 Discord 用户，请重试。"
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1824,7 +1824,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1834,62 +1834,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    显示加载组并列出权限选项。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    从 permissions.ini 文件重新加载权限。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr "    添加新组为默认值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr "    删除现有群组。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr "    显示权限选项的帮助文本。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    显示给定组的权限值和权限。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr "    保存权限组到文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr "    设置群组的权限值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "从 discord内部管理权限.ini 配置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "权限不能同时使用频道和用户提到。"
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr "从文件重新加载权限成功！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -1897,7 +1897,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1907,23 +1907,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr "您必须为此命令提供一个组或选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "您必须为此命令设置一个组、选项和值。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1931,24 +1931,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr "此权限只能通过编辑权限文件来设置。"
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1958,13 +1958,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -1973,12 +1973,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr "无法删除内置组。"
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1986,24 +1986,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr "所有者群组不可编辑。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2012,13 +2012,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2026,7 +2026,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2035,14 +2035,14 @@ msgstr ""
 "注意：API 可能限制每小时更改两次。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2050,23 +2050,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr "更改 MusicBot 的昵称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr "无法更改昵称：没有权限。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2074,23 +2074,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr "    设置每个服务器的命令前缀。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr "    清除每个服务器命令前缀。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2099,23 +2099,23 @@ msgstr ""
 "必须首先启用启用启用前缀权限的选项。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "自定义表情必须来自此服务器才能用作前缀。"
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr "服务器命令前缀已被清除。"
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2124,37 +2124,37 @@ msgstr ""
 "使用配置命令来更新前缀。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr "    显示可用的语言代码。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr "    为此服务器设置所需的语言。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    重置服务器语言为机器人的默认语言。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr "管理通话服务器中用于邮件的语言。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr "此命令只能用于公会。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "给定的子命令无效。请使用帮助命令获取更多信息。"
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2164,25 +2164,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2191,12 +2191,12 @@ msgstr ""
 "附加一个文件并省略URL参数也可以工作。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr "您必须提供一个 URL 或附加文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2204,62 +2204,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr "更改了机器人头像。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "强制MusicBot断开与 Discord 服务器的连接。"
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "断开一个无声音客户端的连接? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr "    尝试重新加载而不重启进程。默认选项。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr "    完全重启，但尝试在重启前更新Pip包。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    完全重启，但先更新 MusicBot 源代码使用 git 。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr "    尝试在完全重启之前更新所有依赖关系和源代码。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2268,66 +2268,66 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "给定的选项无效，请使用其中一项：软、完整、升级、上传或上传。"
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "断开所有语音频道并关闭 MusicBot 进程。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   留下由名称或服务器ID指定的Discord服务器。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr "您必须提供一个ID或名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
@@ -2339,51 +2339,51 @@ msgid "Unknown"
 msgstr "未知的"
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    查看 objgraphs 报告的最常见类型。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    查看有限的 objgraph.show_growth() 输出。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr "    查看最常见的泄漏对象类型。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr "    查看泄漏对象的类型遗产。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    在objgraph上评估给定的函数和参数。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2391,12 +2391,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "无法导入 `objgraph` ，是否安装？"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2411,7 +2411,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2422,7 +2422,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2431,73 +2431,73 @@ msgstr ""
 "输出用于更新 GitHub 页面，因此不适合正常的参考使用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr "创建默认 INI 文件。"
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "保存了请求的 INI 文件到磁盘。请检查它"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr "无法找到 git 可执行文件。"
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr "检查时出错，详情请查看日志。"
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr "没有找到依赖关系的更新。"
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr "MusicBot有可用下载的更新。"
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot 完全是最新版本！"
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2510,52 +2510,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "显示上次启动/重启后的音乐机器人时机。"
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr "显示Discord API和所有已连接的语音客户端的延迟信息。"
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr "没有语音客户端连接。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "如果MusicBot 已连接，则显示 API 延迟和语音延迟。"
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr "在聊天中显示 MusicBot 版本号。"
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2563,17 +2563,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    使用 cookies.txt 附件更新cookies.txt 文件。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    启用或禁用 cookies.txt 文件而不删除它。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2588,28 +2588,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr "Cookie 已启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookie 必须上传才能启用。(正在使用 cookies 文件)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr "Cookie 已启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2617,62 +2617,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr "Cookie 已被禁用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "没有找到附加的上传文件，上传cookie文件时再试一次。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr "Cookie已上传并启用。"
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr "您不能在私信中使用此机器人。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr "此命令要求您在语音频道中。"
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr "异常错误"
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2680,17 +2680,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr "没有给出任何描述。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr "没有给出任何用法。"
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2700,13 +2700,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2816,7 +2816,7 @@ msgstr ""
 "仅在 BindToChannels 缺少服务器ID时使用。"
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -2889,13 +2889,13 @@ msgstr ""
 "您可以将此设置为 0 到 1, 或 0% 到 100%。"
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr "允许 MusicBot 保存下载的媒体，或立即删除。"
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -2903,14 +2903,14 @@ msgstr "如果启用了保存视频，请设定存储空间的限制。"
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr "如果SaveVideos已启用，设置保存文件的时间限制。"
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -2922,26 +2922,26 @@ msgid "Mention the user who added the song when it is played."
 msgstr "提到播放时添加歌曲的用户。"
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
 msgstr "如果机器人启动时他们在一个可访问的语音频道中，自动加入所有人。"
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
 msgstr "启用 MusicBot 在队列为空时自动播放播放列表中的音乐。"
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr "播放前随机播放列表曲目。"
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -2950,7 +2950,7 @@ msgstr ""
 "这只适用于当前播放的歌曲，如果它是由自动播放列表添加的。"
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
@@ -3005,7 +3005,7 @@ msgstr ""
 "目前此选项不适用于自动播放列表或添加到空队列的歌曲。"
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3022,14 +3022,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr "如果启用，状态信息将报告暂停玩家的信息。"
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -3062,14 +3062,14 @@ msgid ""
 msgstr "使用 q 命令列出队列时每页显示的条目数。"
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
 msgstr "启用 MusicBot 自动从自动播放列表中删除不可播放的条目。"
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr "启动时在日志中显示 MusicBot 配置设置。"
 
@@ -3082,7 +3082,7 @@ msgid ""
 msgstr "启用 InstaSkip 权限的用户跳过投票并强制跳过操作。"
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -3108,13 +3108,13 @@ msgid "Completely remove the footer from embeds."
 msgstr "完全移除嵌套页脚。"
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr "当进入语音频道时，MusicBot 将自动自失效。"
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -3125,7 +3125,7 @@ msgstr ""
 "监听器是频道成员，但不包括机器人，他们没有耳聋。"
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
@@ -3134,14 +3134,14 @@ msgstr ""
 "您可以将其设置为几秒或短语如：4小时"
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
 msgstr "如果启用，MusicBot 将在歌曲队列为空时立即离开频道。"
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -3181,7 +3181,7 @@ msgid ""
 msgstr "如果启用，多个成员正在添加歌曲，MusicBot将为每个成员组织播放一首歌曲。"
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -3194,7 +3194,7 @@ msgstr ""
 "默认情况下已禁用。"
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -3204,7 +3204,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -3225,7 +3225,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr "允许 MusicBot 在使用播放命令时自动取消暂停。"
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -3233,7 +3233,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -3250,23 +3250,23 @@ msgstr ""
 "留空则使用动态生成的 UA 字符串。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "切换用户块列表功能，同时不清空块列表。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr "列出Discord用户ID的文本文件的可选文件路径，每行一个。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "启用歌曲方块列表功能，同时不清空方块列表。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3275,7 +3275,7 @@ msgstr ""
 "任何包含列表中任何行的歌曲标题或URL将被屏蔽。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3284,7 +3284,7 @@ msgstr ""
 "每个文件应该包含一个可播放的 URL 或条款列表、每行一个曲目。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3294,14 +3294,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr "一个可选的目录路径，MusicBot 将存储长时间和短期的缓存来播放。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3310,7 +3310,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3323,7 +3323,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftimestrptimebehaviour"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3341,7 +3341,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3353,7 +3353,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3367,7 +3367,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3380,7 +3380,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3393,7 +3393,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3412,7 +3412,7 @@ msgstr ""
 "  不要在“所有者ID”字段中使用机器人或App ID。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3434,7 +3434,7 @@ msgstr ""
 "  验证配置文件夹和文件存在并且可以通过 MusicBot 读取。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3449,7 +3449,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3462,7 +3462,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3475,7 +3475,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3488,32 +3488,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD 似乎没有信头..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr "歌曲信息提取没有返回数据。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "无法继续提取，事件循环已关闭。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL 无效或不支持。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr "无法生成无效的 URL。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr "找不到本地媒体文件。"
 
@@ -3829,28 +3829,28 @@ msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3878,7 +3878,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -3932,7 +3932,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3940,7 +3940,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3950,7 +3950,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -4019,7 +4019,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -4033,7 +4033,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4042,7 +4042,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4056,7 +4056,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -4064,7 +4064,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -4073,26 +4073,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -4104,28 +4104,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4136,25 +4136,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4163,7 +4163,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/i18n/zh_CN/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/zh_CN/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-11 16:38-0800\n"
 "PO-Revision-Date: 2024-11-12 00:39\n"
@@ -41,29 +41,29 @@ msgstr ""
 "    https://github.com/Just-Some-Bots/MusicBot/"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr "会员没有语音功能，无法使用此命令。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr "您不能在语音频道中使用此命令。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
@@ -72,23 +72,23 @@ msgstr ""
 "请稍后再尝试，如果继续，请重启机器人。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr "MusicBot 与语音的连接已取消。这是奇异的。可能要重新启动吗？"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr "MusicBot 没有发言权限。"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr "MusicBot 无法请求发言。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
@@ -97,43 +97,43 @@ msgstr ""
 "使用召唤命令将机器人带到您的语音频道。"
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr "出错了，我们没有得到语音客户端。"
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -142,12 +142,12 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr "[Dev Bug ] 试图发送无效的响应对象。"
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -161,13 +161,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
@@ -176,29 +176,29 @@ msgstr ""
 "此命令将在未来版本中被删除，替换为自动布局命令(s)。"
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr "\\N{OK HAND SIGN}"
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr "显示命令的使用情况和描述，或列出所有可用的命令。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr "**此命令的别名：**\n"
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -207,7 +207,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -216,12 +216,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr "没有这种命令"
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -229,7 +229,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -243,64 +243,64 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr "    屏蔽提及的用户。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr "    取消屏蔽提及的用户。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr "    显示提及用户的方块状态。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr "您必须提及用户或提供他们的身份号码。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr "给定的子命令无效。使用 \"help blockuser\" 作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr "MusicBot 无法找到您指定的用户。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr "所有者不能添加到方块列表。"
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr "用户块列表当前已启用。"
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr "用户块列表目前已禁用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr "无法添加您列出的用户，他们已经被添加。"
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -308,24 +308,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr "这些用户中没有一个在黑名单上。"
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -334,7 +334,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -342,7 +342,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -353,23 +353,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr "如果没有歌曲正在播放，您必须提供一个歌曲主题。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr "给定的子命令无效。使用 \"help blocksong\" 作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -377,12 +377,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr "主题不在歌曲块列表中，无法删除。"
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -390,85 +390,85 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr "    添加或删除指定的歌曲或正在播放的歌曲到当前播放列表中。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr "    将整个队列添加到公会播放列表。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr "    设置这个公会的默认播放列表并重新加载公会自动播放列表。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr "给定的子命令无效。使用 \"help autoplaylist\" 作为使用示例。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr "提供的歌曲链接无效"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr "队列为空。用播放命令添加一些歌曲！"
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr "队列中的所有歌曲已经在自动播放列表中。"
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr "%(number)d 首歌曲添加到自动布局列表。"
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr "这首歌已经在自动播放列表中。"
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr "这首歌尚未在自动播放列表中。"
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr "您必须提供一个播放列表文件名。"
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
@@ -477,19 +477,19 @@ msgstr ""
 "此播放列表是新的，您必须添加歌曲才能保存到磁盘！"
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr "生成一个可用于将此机器人添加到另一个服务器的邀请链接。"
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -497,35 +497,35 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr "\\N{OK HAND SIGN} Karaoke模式已启用。"
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr "\\N{OK HAND SIGN} Karaoke模式现已禁用。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr "您无权请求播放列表"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -534,12 +534,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr "帐号先前已暂停，现在恢复播放。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -550,34 +550,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -586,33 +586,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr "如果没有播放，无法使用寻找。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr "无法在当前轨道上使用寻找，它有未知的持续时间。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr "不支持搜索。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr "没有时间定位播放，无法使用搜索引擎。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -620,14 +620,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -635,91 +635,91 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr "目前没有歌曲正在播放。播放一些带有播放命令的歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr "无效的子命令。使用命令“help repat”作为使用示例。"
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr "播放列表正在重复。"
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr "播放列表已不再重复。"
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr "播放器现在将循环当前歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr "播放器将不再循环当前歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr "玩家正在循环一首歌！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr "玩家目前没有循环中。"
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr "歌曲已不再重复。"
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr "歌曲现在重复了。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr "    将歌曲放在方位上移动到方形位置，\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr "没有播放队列的歌曲。播放一些带有播放命令的歌曲。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr "歌曲位置必须是整数！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr "您提供了一个超出播放列表大小的位置！"
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -729,33 +729,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr "本地媒体播放未启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr "Spotify URL 无效或目前不支持。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr "检测到 Spotify 网址，但Spotify 未启用。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr "Karaoke模式已启用，请禁用后再试一次！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -763,15 +763,9 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr "无法播放该视频。请尝试使用流命令。"
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
-msgstr ""
 
 #. Used by: CommandError
 #: musicbot/bot.py:4478
@@ -939,7 +933,7 @@ msgid "Show information on what is currently playing."
 msgstr "显示当前正在播放的信息。"
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr "[autoplaylist]"
 
@@ -976,7 +970,7 @@ msgstr "进度："
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr "没有播放队列的歌曲！队列中有播放命令的歌曲。"
 
@@ -1081,34 +1075,25 @@ msgstr "移除队列中的所有歌曲。"
 msgid "Cleared all songs from the queue."
 msgstr "清除队列中的所有歌曲。"
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr "队列中没有要移除的内容！"
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
@@ -1117,24 +1102,24 @@ msgstr ""
 "您必须是排队它或拥有即时跳过权限的人。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr "无效的条目编号。使用队列命令来查找队列位置。"
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1142,58 +1127,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr "无法跳过！玩家没有在玩！"
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr "下一首歌即将播放，请稍候。"
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr "您没有权限强制跳过循环歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr "您没有强制跳过的权限。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr "您没有权限跳过循环歌曲。"
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1201,12 +1186,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr " 下一首歌即将开始！"
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1214,7 +1199,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1222,25 +1207,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr "音量从 **%(old)d** 更新到 **%(new)d"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1248,14 +1233,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1263,7 +1248,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
@@ -1272,56 +1257,56 @@ msgstr ""
 "使用配置命令设置默认播放速度。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr "速度不能应用于流媒体。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr "您必须提供一个速度来设置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr "您提供的速度无效。请使用0.5 至 100之间的数字。"
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr "    添加可选参数的新别名。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr "允许管理不一致的别名。要查看别名，请使用帮助命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr "已从配置文件重新加载别名。"
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr "别名保存到配置文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1329,104 +1314,104 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr "您必须为别名提供别名和命令"
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr "您必须提供一个别名来移除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr "    显示任何缺失配置选项的帮助文本。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr "    列出可用的配置选项及其章节。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr "    从磁盘重新加载options.ini 文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr "    显示特定选项的帮助文本。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr "    显示选项的当前值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr "    将当前值保存到选项文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr "    验证选项并设置会话配置，但不设置为文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr "    重置选项为默认值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr "从 Discord 内部管理options.ini 配置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr "配置不能同时使用频道和用户提到。"
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr "*所有配置选项都已存在并已核算！*"
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr "没有配置选项被更改。"
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1434,7 +1419,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1445,12 +1430,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr "配置选项从文件重新加载成功！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1458,24 +1443,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr "无法解析选项名称中的部分名称。请提供一个有效的部分和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr "给定的选项含混，请提供一个章节名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr "您必须提供此命令的部分名称和选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1483,24 +1468,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr "此选项只能通过编辑配置文件来设置。"
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1510,31 +1495,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1543,24 +1528,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr "您必须为此子命令提供一个章节、选项和值。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1568,19 +1553,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1588,17 +1573,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr "已废弃的命令，改用配置命令。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr "选项命令已废弃，请使用配置命令。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
@@ -1607,33 +1592,33 @@ msgstr ""
 "使用更新选项将在显示详细信息之前扫描缓存进行外部更改。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr "指定的选项无效，使用：信息、更新或清除"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr "已禁用"
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr "已启用"
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr "无限制"
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1644,34 +1629,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr "缓存已清除。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr "**删除缓存失败，请检查日志获取更多信息..."
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr "没有找到要清除的缓存。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr "队列页面参数必须是一个整数。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1679,12 +1664,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr "(未知持续时间)"
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1693,7 +1678,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1703,19 +1688,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr "队列中的歌曲"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1723,38 +1708,38 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr "参数无效。请提供一些要搜索的消息。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr "无法在私有DM频道上使用净化。"
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr "机器人没有管理信件的权限。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr "将播放列表中的单个URL转储到一个文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr "给定的 URL 不是有效的 URL。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1762,37 +1747,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr "这似乎不是一个播放列表。"
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1800,36 +1785,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr "这里是您请求的ID："
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr "获取您的权限列表或上述用户的权限。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr "无效的用户ID或服务器昵称，请重新检查ID，然后重试。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr "无法确定 Discord 用户，请重试。"
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1839,7 +1824,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1849,62 +1834,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr "    显示加载组并列出权限选项。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr "    从 permissions.ini 文件重新加载权限。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr "    添加新组为默认值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr "    删除现有群组。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr "    显示权限选项的帮助文本。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr "    显示给定组的权限值和权限。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr "    保存权限组到文件。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr "    设置群组的权限值。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr "从 discord内部管理权限.ini 配置。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr "权限不能同时使用频道和用户提到。"
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr "从文件重新加载权限成功！"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -1912,7 +1897,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1922,23 +1907,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr "您必须为此命令提供一个组或选项名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr "您必须为此命令设置一个组、选项和值。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1946,24 +1931,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr "此权限只能通过编辑权限文件来设置。"
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1973,13 +1958,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -1988,12 +1973,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr "无法删除内置组。"
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -2001,24 +1986,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr "所有者群组不可编辑。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -2027,13 +2012,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -2041,7 +2026,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
@@ -2050,14 +2035,14 @@ msgstr ""
 "注意：API 可能限制每小时更改两次。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2065,23 +2050,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr "更改 MusicBot 的昵称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr "无法更改昵称：没有权限。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2089,23 +2074,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr "    设置每个服务器的命令前缀。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr "    清除每个服务器命令前缀。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
@@ -2114,23 +2099,23 @@ msgstr ""
 "必须首先启用启用启用前缀权限的选项。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr "自定义表情必须来自此服务器才能用作前缀。"
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr "服务器命令前缀已被清除。"
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
@@ -2139,37 +2124,37 @@ msgstr ""
 "使用配置命令来更新前缀。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr "    显示可用的语言代码。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr "    为此服务器设置所需的语言。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr "    重置服务器语言为机器人的默认语言。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr "管理通话服务器中用于邮件的语言。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr "此命令只能用于公会。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr "给定的子命令无效。请使用帮助命令获取更多信息。"
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -2179,25 +2164,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
@@ -2206,12 +2191,12 @@ msgstr ""
 "附加一个文件并省略URL参数也可以工作。\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr "您必须提供一个 URL 或附加文件。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2219,62 +2204,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr "更改了机器人头像。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr "强制MusicBot断开与 Discord 服务器的连接。"
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr "断开一个无声音客户端的连接? [BUG]"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr "    尝试重新加载而不重启进程。默认选项。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr "    完全重启，但尝试在重启前更新Pip包。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr "    完全重启，但先更新 MusicBot 源代码使用 git 。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr "    尝试在完全重启之前更新所有依赖关系和源代码。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2283,122 +2268,122 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr "给定的选项无效，请使用其中一项：软、完整、升级、上传或上传。"
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr "断开所有语音频道并关闭 MusicBot 进程。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr "   留下由名称或服务器ID指定的Discord服务器。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr "您必须提供一个ID或名称。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr "未知的"
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr "    查看 objgraphs 报告的最常见类型。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr "    查看有限的 objgraph.show_growth() 输出。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr "    查看最常见的泄漏对象类型。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr "    查看泄漏对象的类型遗产。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr "    在objgraph上评估给定的函数和参数。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2406,12 +2391,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr "无法导入 `objgraph` ，是否安装？"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2426,7 +2411,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2437,7 +2422,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -2446,73 +2431,73 @@ msgstr ""
 "输出用于更新 GitHub 页面，因此不适合正常的参考使用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr "创建默认 INI 文件。"
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr "保存了请求的 INI 文件到磁盘。请检查它"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr "无法找到 git 可执行文件。"
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr "检查时出错，详情请查看日志。"
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr "没有找到依赖关系的更新。"
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr "MusicBot有可用下载的更新。"
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr "MusicBot 完全是最新版本！"
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2525,52 +2510,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr "显示上次启动/重启后的音乐机器人时机。"
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr "显示Discord API和所有已连接的语音客户端的延迟信息。"
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr "没有语音客户端连接。\n"
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr "如果MusicBot 已连接，则显示 API 延迟和语音延迟。"
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr "auto"
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr "在聊天中显示 MusicBot 版本号。"
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2578,17 +2563,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr "    使用 cookies.txt 附件更新cookies.txt 文件。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr "    启用或禁用 cookies.txt 文件而不删除它。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2603,28 +2588,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr "Cookie 已启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr "Cookie 必须上传才能启用。(正在使用 cookies 文件)"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr "Cookie 已启用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2632,62 +2617,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr "Cookie 已被禁用。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr "没有找到附加的上传文件，上传cookie文件时再试一次。"
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr "Cookie已上传并启用。"
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr "您不能在私信中使用此机器人。"
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr "此命令要求您在语音频道中。"
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr "异常错误"
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2695,17 +2680,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr "没有给出任何描述。\n"
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr "没有给出任何用法。"
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2715,13 +2700,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -3265,23 +3250,23 @@ msgstr ""
 "留空则使用动态生成的 UA 字符串。"
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr "切换用户块列表功能，同时不清空块列表。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr "列出Discord用户ID的文本文件的可选文件路径，每行一个。"
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr "启用歌曲方块列表功能，同时不清空方块列表。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
@@ -3290,7 +3275,7 @@ msgstr ""
 "任何包含列表中任何行的歌曲标题或URL将被屏蔽。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
@@ -3299,7 +3284,7 @@ msgstr ""
 "每个文件应该包含一个可播放的 URL 或条款列表、每行一个曲目。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -3309,14 +3294,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr "一个可选的目录路径，MusicBot 将存储长时间和短期的缓存来播放。"
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -3325,7 +3310,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3338,7 +3323,7 @@ msgstr ""
 "    https://docs.python.org/3/library/datetime.html#strftimestrptimebehaviour"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3356,7 +3341,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3368,7 +3353,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3382,7 +3367,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3395,7 +3380,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3408,7 +3393,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3427,7 +3412,7 @@ msgstr ""
 "  不要在“所有者ID”字段中使用机器人或App ID。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3449,7 +3434,7 @@ msgstr ""
 "  验证配置文件夹和文件存在并且可以通过 MusicBot 读取。"
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3464,7 +3449,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3477,7 +3462,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3490,7 +3475,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3503,32 +3488,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr "HEAD 似乎没有信头..."
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr "歌曲信息提取没有返回数据。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr "无法继续提取，事件循环已关闭。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr "Spotify URL 无效或不支持。"
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr "无法生成无效的 URL。"
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr "找不到本地媒体文件。"
 
@@ -3551,13 +3536,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr "为请求的媒体提取数据失败。"
 
@@ -3712,28 +3697,28 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr "无法提取信息"
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr "这是一个播放列表。"
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr "无持续时间数据"
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr "当前条目中没有持续数据"
 
@@ -3810,21 +3795,21 @@ msgid "Only dev users can use this command."
 msgstr "只有dev 用户可以使用此命令。"
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -3832,13 +3817,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
@@ -3850,22 +3835,22 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3893,61 +3878,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3955,7 +3940,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3965,7 +3950,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -3989,40 +3974,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -4030,13 +4008,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -4055,7 +4033,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -4064,7 +4042,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -4095,28 +4073,119 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr "管理自动播放列表文件和每个公会设置。"

--- a/i18n/zh_TW/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/zh_TW/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -129,7 +129,7 @@ msgid "Unhandled exception for task:  %(task)r  --  %(raw_error)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:320 musicbot/bot.py:342
+#: musicbot/bot.py:320
 msgid "Spotify did not provide us with a token. Disabling."
 msgstr ""
 
@@ -146,61 +146,43 @@ msgid ""
 "Details: %s. Continuing anyway in 5 seconds..."
 msgstr ""
 
-#. Used by: warning
-#: musicbot/bot.py:336
-msgid ""
-"The config did not have Spotify app credentials, attempting to use guest "
-"mode."
-msgstr ""
-
 #. Used by: info
-#: musicbot/bot.py:346
-msgid "Authenticated with Spotify successfully using guest mode."
-msgstr ""
-
-#. Used by: warning
-#: musicbot/bot.py:351
-#, python-format
-msgid "Could not start Spotify client using guest mode. Details: %s."
-msgstr ""
-
-#. Used by: info
-#: musicbot/bot.py:356
+#: musicbot/bot.py:339
 msgid "Initialized, now connecting to discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:367
+#: musicbot/bot.py:350
 msgid "Network ping test is disabled via config."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:371
+#: musicbot/bot.py:354
 msgid "Network ping test is closing down."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:382
+#: musicbot/bot.py:365
 msgid "Could not resolve ping target."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:412
+#: musicbot/bot.py:395
 msgid "Network ping test cancelled."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:426
+#: musicbot/bot.py:409
 msgid "Network testing via HTTP does not have a session to borrow."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:451
+#: musicbot/bot.py:434
 msgid "Could not locate `ping` executable in your environment."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:477
+#: musicbot/bot.py:460
 #, python-format
 msgid ""
 "MusicBot could not locate a `ping` command path.  Will attempt to use HTTP ping instead.\n"
@@ -210,7 +192,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:487
+#: musicbot/bot.py:470
 #, python-format
 msgid ""
 "MusicBot was denied permission to execute the `ping` command.  Will attempt to use HTTP ping instead.\n"
@@ -220,7 +202,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:497
+#: musicbot/bot.py:480
 #, python-format
 msgid ""
 "Your environment may not allow the `ping` system command.  Will attempt to use HTTP ping instead.\n"
@@ -230,35 +212,35 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:512
+#: musicbot/bot.py:495
 msgid "MusicBot detected network is available again."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:517
+#: musicbot/bot.py:500
 msgid "VoiceClient is not connected, waiting to resume MusicPlayer..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:521
+#: musicbot/bot.py:504
 #, python-format
 msgid "Resuming playback of player:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:532
+#: musicbot/bot.py:515
 msgid "MusicBot detected a network outage."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:536
+#: musicbot/bot.py:519
 #, python-format
 msgid ""
 "Pausing MusicPlayer due to network availability:  (%(guild_id)s) %(player)r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:557
+#: musicbot/bot.py:540
 #, python-format
 msgid ""
 "Looking for owner in guild: %(guild)s (required voice: %(required)s) and "
@@ -266,155 +248,155 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:571
+#: musicbot/bot.py:554
 msgid "Checking for channels to auto-join or resume..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:583
+#: musicbot/bot.py:566
 #, python-format
 msgid "Guild not available, cannot auto join:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:591
+#: musicbot/bot.py:574
 #, python-format
 msgid "Found resumable voice channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:604
+#: musicbot/bot.py:587
 #, python-format
 msgid "Will try resuming voice session instead of Auto-Joining channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:621
+#: musicbot/bot.py:604
 #, python-format
 msgid "Found owner in voice channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:626
+#: musicbot/bot.py:609
 #, python-format
 msgid "Ignoring resumable channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:631
+#: musicbot/bot.py:614
 #, python-format
 msgid "Ignoring Auto-Join channel, AutoSummon to owner in channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:643
+#: musicbot/bot.py:626
 #, python-format
 msgid "Already connected to channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:652
+#: musicbot/bot.py:635
 #, python-format
 msgid "Attempting to join channel:  %(channel)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:659
+#: musicbot/bot.py:642
 msgid "Discarding MusicPlayer and making a new one..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:679
+#: musicbot/bot.py:662
 msgid "MusicBot will make a new MusicPlayer now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:700
+#: musicbot/bot.py:683
 #, python-format
 msgid "Not joining %(guild)s/%(channel)s, it isn't a supported voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:703
+#: musicbot/bot.py:686
 msgid "Finished joining configured channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:748
+#: musicbot/bot.py:731
 msgid "Getting bot Application Info."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:773
+#: musicbot/bot.py:756
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:782
+#: musicbot/bot.py:765
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  %s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:796
+#: musicbot/bot.py:779
 #, python-format
 msgid "Reusing bots VoiceClient from guild:  %s"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:801
+#: musicbot/bot.py:784
 #, python-format
 msgid "Forcing disconnect on stale VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:807
+#: musicbot/bot.py:790
 msgid "Disconnect failed or was cancelled?"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:815
+#: musicbot/bot.py:798
 #, python-format
 msgid "MusicBot is unable to connect to the channel right now:  %(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:830
+#: musicbot/bot.py:813
 msgid "MusicBot has a VoiceClient now..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:835
+#: musicbot/bot.py:818
 #, python-format
 msgid ""
 "Retrying connection after a timeout error (%(attempt)s) while trying to "
@@ -422,65 +404,65 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:840
+#: musicbot/bot.py:823
 msgid "MusicBot VoiceClient connection attempt was cancelled. No retry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:854 musicbot/bot.py:8782
+#: musicbot/bot.py:837 musicbot/bot.py:8866
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:858 musicbot/bot.py:8784
+#: musicbot/bot.py:841 musicbot/bot.py:8868
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:871
+#: musicbot/bot.py:854
 #, python-format
 msgid "Disconnecting a MusicPlayer in guild:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:883
+#: musicbot/bot.py:866
 msgid "Disconnecting VoiceClient before we kill the MusicPlayer."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:891 musicbot/bot.py:910 musicbot/bot.py:922
-#: musicbot/bot.py:945
+#: musicbot/bot.py:874 musicbot/bot.py:893 musicbot/bot.py:905
+#: musicbot/bot.py:928
 msgid "The disconnect failed or was cancelled."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:901
+#: musicbot/bot.py:884
 msgid ""
 "MusicBot has a VoiceProtocol that is not a VoiceClient. Disconnecting "
 "anyway..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:914
+#: musicbot/bot.py:897
 #, python-format
 msgid "Disconnecting a rogue VoiceClient in guild:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:938
+#: musicbot/bot.py:921
 msgid "Disconnecting a non-guild VoiceClient..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:948
+#: musicbot/bot.py:931
 #, python-format
 msgid ""
 "MusicBot.voice_clients list contains a non-VoiceClient object?\n"
@@ -488,36 +470,36 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:958
+#: musicbot/bot.py:941
 #, python-format
 msgid "We still have a MusicPlayer ref in guild (%(guild_id)s):  %(player)r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:971
+#: musicbot/bot.py:954
 #, python-format
 msgid "Guild (%(guild)s) wants a player, optional:  %(player)r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:983
+#: musicbot/bot.py:966
 msgid "MusicPlayer has a VoiceClient that is not connected."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:984
+#: musicbot/bot.py:967
 #, python-format
 msgid "MusicPlayer obj:  %r"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:985
+#: musicbot/bot.py:968
 #, python-format
 msgid "VoiceClient obj:  %r"
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1005
+#: musicbot/bot.py:988
 #, python-format
 msgid ""
 "Getting a MusicPlayer for guild:  %(guild)s  In Channel:  %(channel)s  "
@@ -525,7 +507,7 @@ msgid ""
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:1021
+#: musicbot/bot.py:1004
 #, python-format
 msgid ""
 "Created player via deserialization for guild %(guild_id)s with %(number)s "
@@ -533,364 +515,364 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1075
+#: musicbot/bot.py:1058
 msgid "Running on_player_play"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1150
+#: musicbot/bot.py:1133
 #, python-format
 msgid "Setting URL history guild %(guild_id)s == %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1202
+#: musicbot/bot.py:1201
 msgid "no channel to put now playing message into"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1214
+#: musicbot/bot.py:1213
 msgid "ignored now-playing message as it was already posted."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1238
+#: musicbot/bot.py:1237
 msgid "Running on_player_resume"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1251
+#: musicbot/bot.py:1250
 msgid "Running on_player_pause"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1267
+#: musicbot/bot.py:1266
 msgid "Running on_player_stop"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1277
+#: musicbot/bot.py:1276
 msgid "Running on_player_finished_playing"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1279 musicbot/bot.py:1325 musicbot/bot.py:1396
+#: musicbot/bot.py:1278 musicbot/bot.py:1324 musicbot/bot.py:1395
 msgid "Event loop is closed, nothing else to do here."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1283 musicbot/bot.py:1329 musicbot/bot.py:1400
+#: musicbot/bot.py:1282 musicbot/bot.py:1328 musicbot/bot.py:1399
 msgid "Logout under way, ignoring this event."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1300
+#: musicbot/bot.py:1299
 msgid "VoiceClient says it is not connected, nothing else we can do here."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1307
+#: musicbot/bot.py:1306
 msgid "Player finished and queue is empty, leaving voice channel..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1321
+#: musicbot/bot.py:1320
 msgid "Looping over queue to expunge songs with missing author..."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1360
+#: musicbot/bot.py:1359
 #, python-format
 msgid ""
 "Author `%(user)s` absent, skipped (deleted) entry from queue:  %(song)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1379
+#: musicbot/bot.py:1378
 msgid "No playable songs in the Guild autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1384
+#: musicbot/bot.py:1383
 msgid "No content in current autoplaylist. Filling with new music..."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:1392
+#: musicbot/bot.py:1391
 msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1433 musicbot/downloader.py:666
+#: musicbot/bot.py:1432 musicbot/downloader.py:686
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1444 musicbot/downloader.py:673
+#: musicbot/bot.py:1443 musicbot/downloader.py:693
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1464
+#: musicbot/bot.py:1463
 msgid "MusicBot got an unhandled exception in player finished event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1470
+#: musicbot/bot.py:1469
 #, python-format
 msgid "Expanding auto playlist with entries extracted from:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1494
+#: musicbot/bot.py:1493
 #, python-format
 msgid "Error adding song from autoplaylist: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1497
+#: musicbot/bot.py:1496
 msgid "Exception data for above error:"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1503
+#: musicbot/bot.py:1502
 msgid "No playable songs in the autoplaylist, disabling."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1523
+#: musicbot/bot.py:1522
 msgid "Running on_player_entry_added"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1533
+#: musicbot/bot.py:1532
 msgid "Automatically skipping auto-playlist entry for queued entry."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1553
+#: musicbot/bot.py:1552
 #, python-format
 msgid "MusicPlayer exception for entry: %r"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1559
+#: musicbot/bot.py:1558
 msgid "MusicPlayer exception."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:1583
+#: musicbot/bot.py:1582
 #, python-format
 msgid "Auto playlist track could not be played:  %r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1622
+#: musicbot/bot.py:1621
 msgid "Logout under way, ignoring status update event."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1723
+#: musicbot/bot.py:1722
 #, python-format
 msgid "Update bot status:  %(status)s -- %(activity)r"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1751
+#: musicbot/bot.py:1750
 #, python-format
 msgid "Serializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1777
+#: musicbot/bot.py:1776
 #, python-format
 msgid "Deserializing queue for %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1795
+#: musicbot/bot.py:1794
 #, python-format
 msgid "Writing current song for %s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1862
+#: musicbot/bot.py:1861
 #, python-format
 msgid "sending embed to: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1865
+#: musicbot/bot.py:1864
 #, python-format
 msgid "sending text to: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1870
+#: musicbot/bot.py:1869
 #, python-format
 msgid "Cannot send message to \"%s\", no permission"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1877
+#: musicbot/bot.py:1876
 #, python-format
 msgid "Cannot send message to \"%s\", invalid or deleted channel"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1885
+#: musicbot/bot.py:1884
 #, python-format
 msgid "Message is over the message size limit (%s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:1893
+#: musicbot/bot.py:1892
 msgid "Could not send private message, sending in fallback channel instead."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1911
+#: musicbot/bot.py:1910
 #, python-format
 msgid "Rate limited send message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1917
+#: musicbot/bot.py:1916
 #, python-format
 msgid "Cancelled message retry for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1922
+#: musicbot/bot.py:1921
 msgid "Rate limited send message, but cannot retry!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1928
+#: musicbot/bot.py:1927
 msgid "Failed to send message in fallback channel."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1933 musicbot/bot.py:1997 musicbot/bot.py:2067
+#: musicbot/bot.py:1932 musicbot/bot.py:1996 musicbot/bot.py:2066
 msgid "Failed to send due to an HTTP error."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1959
+#: musicbot/bot.py:1958
 #, python-format
 msgid "Cannot delete message \"%s\", no permission"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1964
+#: musicbot/bot.py:1963
 #, python-format
 msgid "Cannot delete message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1982
+#: musicbot/bot.py:1981
 #, python-format
 msgid "Rate limited message delete, retrying in %s seconds."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1987
+#: musicbot/bot.py:1986
 msgid "Rate limited message delete, but cannot retry!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1990
+#: musicbot/bot.py:1989
 msgid "Failed to delete message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:1992
+#: musicbot/bot.py:1991
 #, python-format
 msgid "Got HTTPException trying to delete message: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2027
+#: musicbot/bot.py:2026
 #, python-format
 msgid "Cannot edit message \"%s\", message not found"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2031
+#: musicbot/bot.py:2030
 msgid "Sending message instead"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2048
+#: musicbot/bot.py:2047
 #, python-format
 msgid "Rate limited edit message, retrying in %s seconds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2054
+#: musicbot/bot.py:2053
 #, python-format
 msgid "Cancelled message edit for:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2060
+#: musicbot/bot.py:2059
 msgid "Failed to edit message"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2062
+#: musicbot/bot.py:2061
 #, python-format
 msgid "Got HTTPException trying to edit message %s to: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2084
+#: musicbot/bot.py:2083
 #, python-format
 msgid "Cancelled delete for message (ID: %(id)s):  %(content)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2146
+#: musicbot/bot.py:2145
 #, python-format
 msgid "Caught a signal from the OS: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2150
+#: musicbot/bot.py:2149
 msgid "Disconnecting and closing down MusicBot..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:2153
+#: musicbot/bot.py:2152
 msgid "Exception thrown while handling interrupt signal!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2168
+#: musicbot/bot.py:2167
 msgid "MusicBot is now doing shutdown steps..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -904,44 +886,44 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2190
+#: musicbot/bot.py:2189
 msgid "Waiting for download threads to finish up..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2216
+#: musicbot/bot.py:2215
 #, python-format
 msgid "Will wait for task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2223
+#: musicbot/bot.py:2222
 #, python-format
 msgid "Will try to cancel task:  %(name)s  (%(func)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2231
+#: musicbot/bot.py:2230
 msgid "Awaiting pending tasks..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2237
+#: musicbot/bot.py:2236
 msgid "Closing HTTP Connector."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2243
+#: musicbot/bot.py:2242
 msgid "Closing aiohttp session."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:2255
+#: musicbot/bot.py:2254
 msgid "Logout has been called."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2267
+#: musicbot/bot.py:2266
 #, python-format
 msgid ""
 "Exception in %(event)s:\n"
@@ -949,80 +931,80 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:2283
+#: musicbot/bot.py:2282
 #, python-format
 msgid "Exception in %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2290
+#: musicbot/bot.py:2289
 msgid "MusicBot resumed a session with discord."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2307
+#: musicbot/bot.py:2306
 msgid "Finish on_ready"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2314
+#: musicbot/bot.py:2313
 msgid "Logged in, now getting MusicBot ready..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:2317
+#: musicbot/bot.py:2316
 msgid "ClientUser is somehow none, we gotta bail..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2326
+#: musicbot/bot.py:2325
 #, python-format
 msgid "MusicBot:  %(id)s/%(name)s#%(desc)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2337
+#: musicbot/bot.py:2336
 #, python-format
 msgid "Owner:     %(id)s/%(name)s#%(desc)s\n"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2345 musicbot/bot.py:2372
+#: musicbot/bot.py:2344 musicbot/bot.py:2371
 msgid "Guild List:"
 msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2349 musicbot/bot.py:2375 musicbot/bot.py:8968
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
 #, python-format
 msgid " - %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2358
+#: musicbot/bot.py:2357
 #, python-format
 msgid "Left %s due to bot owner not found"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2363
+#: musicbot/bot.py:2362
 #, python-format
 msgid "Not proceeding with checks in %s servers due to unavailability"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2369
+#: musicbot/bot.py:2368
 #, python-format
 msgid "Owner could not be found on any guild (id: %s)\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2378
+#: musicbot/bot.py:2377
 msgid "Owner unknown, bot is not on any guilds."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2382
+#: musicbot/bot.py:2381
 #, python-format
 msgid ""
 "To make the bot join a guild, paste this link in your browser. \n"
@@ -1032,348 +1014,348 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2399
+#: musicbot/bot.py:2398
 #, python-format
 msgid "Got None for bound channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2419
+#: musicbot/bot.py:2418
 msgid "Bound to text channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2437 musicbot/bot.py:2487
+#: musicbot/bot.py:2436 musicbot/bot.py:2486
 #, python-format
 msgid " - %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2441 musicbot/bot.py:2443
+#: musicbot/bot.py:2440 musicbot/bot.py:2442
 msgid "Not bound to any text channels"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2538
+#: musicbot/bot.py:2537
 #, python-format
 msgid "Event on_ready has fired %s times"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2554
+#: musicbot/bot.py:2553
 msgid "Getting application info."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2572
+#: musicbot/bot.py:2571
 msgid "Ensuring data folders exist"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2587
+#: musicbot/bot.py:2586
 msgid "Validating config"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2590
+#: musicbot/bot.py:2589
 msgid "Validating permissions config"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2600
+#: musicbot/bot.py:2599
 msgid "Enabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2603
+#: musicbot/bot.py:2602
 msgid "Options:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2605
+#: musicbot/bot.py:2604
 #, python-format
 msgid "  Command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2610
+#: musicbot/bot.py:2609
 #, python-format
 msgid "  Default volume: %d%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2612
+#: musicbot/bot.py:2611
 #, python-format
 msgid "  Skip threshold: %(num)d votes or %(percent).0f%%"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2624
+#: musicbot/bot.py:2623
 #, python-format
 msgid "  Now Playing @mentions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2631
+#: musicbot/bot.py:2630
 #, python-format
 msgid "  Auto-Playlist: %(status)s (order: %(order)s)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "random"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2634
+#: musicbot/bot.py:2633
 msgid "sequential"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2654
+#: musicbot/bot.py:2653
 #, python-format
 msgid "  Auto-Pause: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2656
+#: musicbot/bot.py:2655
 #, python-format
 msgid "  Delete Messages: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2661
+#: musicbot/bot.py:2660
 #, python-format
 msgid "    Delete Invoking: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2668
+#: musicbot/bot.py:2667
 #, python-format
 msgid "  Debug Mode: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2672
+#: musicbot/bot.py:2671
 #, python-format
 msgid "  Downloaded songs will be %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2676
+#: musicbot/bot.py:2675
 #, python-format
 msgid "    Delete if unused for %d days"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2687
+#: musicbot/bot.py:2686
 #, python-format
 msgid "  Status message: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2699
+#: musicbot/bot.py:2698
 #, python-format
 msgid "  Spotify integration: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2712
+#: musicbot/bot.py:2711
 #, python-format
 msgid "    Timeout: %s seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2724
+#: musicbot/bot.py:2723
 #, python-format
 msgid "    Timeout: %d seconds"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2725
+#: musicbot/bot.py:2724
 #, python-format
 msgid "  Self Deafen: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2727
+#: musicbot/bot.py:2726
 #, python-format
 msgid "  Per-server command prefix: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2733
+#: musicbot/bot.py:2732
 #, python-format
 msgid "  Round Robin Queue: %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2799
+#: musicbot/bot.py:2798
 msgid ""
 "Attempted to handle Voice Channel inactivity, but Bot is not in voice..."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2806
+#: musicbot/bot.py:2805
 #, python-format
 msgid "Channel activity already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2816
+#: musicbot/bot.py:2815
 #, python-format
 msgid ""
 "Channel activity waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2831
+#: musicbot/bot.py:2830
 #, python-format
 msgid "Channel activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2837
+#: musicbot/bot.py:2836
 #, python-format
 msgid "Channel activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2865
+#: musicbot/bot.py:2864
 #, python-format
 msgid "Ignoring player inactivity in auto-joined channel:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2872
+#: musicbot/bot.py:2871
 #, python-format
 msgid "Player activity timer already waiting in guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2880
+#: musicbot/bot.py:2879
 #, python-format
 msgid ""
 "Player activity timer waiting %(time)d seconds to leave channel: %(channel)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2892
+#: musicbot/bot.py:2891
 #, python-format
 msgid "Player activity timer for %s has expired. Disconnecting."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2898 musicbot/bot.py:2903
+#: musicbot/bot.py:2897 musicbot/bot.py:2902
 #, python-format
 msgid "Player activity timer canceled for: %(channel)s in %(guild)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:2920
+#: musicbot/bot.py:2919
 msgid "Player activity timer is being reset."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3132
+#: musicbot/bot.py:3131
 #, python-format
 msgid "Not adding user to block list, already blocked:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -1382,24 +1364,24 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3699
+#: musicbot/bot.py:3698
 msgid "Ignoring auto-pause due to network outage."
 msgstr ""
 
 #. Used by: voicedebug
-#: musicbot/bot.py:3704
+#: musicbot/bot.py:3703
 msgid ""
 "MusicPlayer has no VoiceClient or has no channel data, cannot process auto-"
 "pause."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3715
+#: musicbot/bot.py:3714
 msgid "Already processing auto-pause, ignoring this event."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:3723
+#: musicbot/bot.py:3722
 #, python-format
 msgid ""
 "%sVoiceClient not connected, waiting %s seconds to handle auto-pause in "
@@ -1407,55 +1389,55 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:3731
+#: musicbot/bot.py:3730
 msgid "Auto-pause waiting was cancelled."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3738
+#: musicbot/bot.py:3737
 msgid "A new MusicPlayer is being connected, ignoring old auto-pause event."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3754
+#: musicbot/bot.py:3753
 #, python-format
 msgid "Playing in an empty voice channel, running auto pause for guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3761
+#: musicbot/bot.py:3760
 #, python-format
 msgid "Previously auto paused player is unpausing for guild: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -1463,59 +1445,59 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4252
+#: musicbot/bot.py:4251
 msgid ""
 "Could not prompt for playlist playback, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3549 musicbot/bot.py:4416
+#: musicbot/bot.py:3548 musicbot/bot.py:4415
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1523,7 +1505,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -1623,56 +1605,56 @@ msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1680,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1718,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1747,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1772,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6167
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6138
+#: musicbot/bot.py:6202
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6297
+#: musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1870,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6347
+#: musicbot/bot.py:6412
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6390
+#: musicbot/bot.py:6474
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6394
+#: musicbot/bot.py:6478
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1910,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1949,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7111
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -2004,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -2017,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2042,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7304
+#: musicbot/bot.py:7388
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7534
+#: musicbot/bot.py:7618
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7650
+#: musicbot/bot.py:7734
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7660
+#: musicbot/bot.py:7744
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7663
+#: musicbot/bot.py:7747
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2108,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7844
+#: musicbot/bot.py:7928
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7873
+#: musicbot/bot.py:7957
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7887
+#: musicbot/bot.py:7971
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7948
+#: musicbot/bot.py:8032
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2163,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8110
+#: musicbot/bot.py:8194
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8226
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8170
+#: musicbot/bot.py:8254
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8178
+#: musicbot/bot.py:8262
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8186
+#: musicbot/bot.py:8270
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8281
+#: musicbot/bot.py:8365
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8288
+#: musicbot/bot.py:8372
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8447
+#: musicbot/bot.py:8531
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8485
+#: musicbot/bot.py:8569
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8508
+#: musicbot/bot.py:8592
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8539
+#: musicbot/bot.py:8623
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8543
+#: musicbot/bot.py:8627
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8660
+#: musicbot/bot.py:8744
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8669
+#: musicbot/bot.py:8753
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8673
+#: musicbot/bot.py:8757
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8678
+#: musicbot/bot.py:8762
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8694
+#: musicbot/bot.py:8778
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8707
+#: musicbot/bot.py:8791
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8716
+#: musicbot/bot.py:8800
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8727
+#: musicbot/bot.py:8811
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8740
+#: musicbot/bot.py:8824
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8749
+#: musicbot/bot.py:8833
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8798
+#: musicbot/bot.py:8882
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8820
+#: musicbot/bot.py:8904
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8840
+#: musicbot/bot.py:8924
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8867
+#: musicbot/bot.py:8951
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2347,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8889
+#: musicbot/bot.py:8973
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8896
+#: musicbot/bot.py:8980
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8902
+#: musicbot/bot.py:8986
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8915
+#: musicbot/bot.py:8999
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8931
+#: musicbot/bot.py:9015
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8943
+#: musicbot/bot.py:9027
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8957
+#: musicbot/bot.py:9041
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8965
+#: musicbot/bot.py:9049
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8966
+#: musicbot/bot.py:9050
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8981
+#: musicbot/bot.py:9065
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8987
+#: musicbot/bot.py:9071
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9004
+#: musicbot/bot.py:9088
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9010
+#: musicbot/bot.py:9094
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9026
+#: musicbot/bot.py:9110
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9083
+#: musicbot/bot.py:9167
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2448,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1171
+#: musicbot/config.py:1198
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2456,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1179
+#: musicbot/config.py:1206
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2475,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1207
+#: musicbot/config.py:1234
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2494,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1223
+#: musicbot/config.py:1250
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2513,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1255
+#: musicbot/config.py:1282
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1264
+#: musicbot/config.py:1291
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2528,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1281
+#: musicbot/config.py:1309
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1303
+#: musicbot/config.py:1331
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1333
+#: musicbot/config.py:1361
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1346
+#: musicbot/config.py:1374
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2551,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1354
+#: musicbot/config.py:1382
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1368
+#: musicbot/config.py:1396
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2576,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2591,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1414
+#: musicbot/config.py:1442
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1419
+#: musicbot/config.py:1447
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1439
+#: musicbot/config.py:1467
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1454
+#: musicbot/config.py:1482
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1459
+#: musicbot/config.py:1487
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1472
+#: musicbot/config.py:1500
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1987
+#: musicbot/config.py:2017
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2165 musicbot/permissions.py:909
+#: musicbot/config.py:2199 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2651,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2664,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2677,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2357
+#: musicbot/config.py:2391
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2685,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2378
+#: musicbot/config.py:2412
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2693,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2427
+#: musicbot/config.py:2461
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2701,120 +2683,120 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2552
+#: musicbot/config.py:2586
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2623
+#: musicbot/config.py:2657
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2657
+#: musicbot/config.py:2691
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2719
+#: musicbot/config.py:2753
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2828
+#: musicbot/config.py:2862
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:220
+#: musicbot/constructs.py:255
 msgid ""
 "Cannot load data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:229
+#: musicbot/constructs.py:264
 #, python-format
 msgid "No file for guild %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/constructs.py:238
+#: musicbot/constructs.py:273
 #, python-format
 msgid "Loading guild data for guild with ID:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:245
+#: musicbot/constructs.py:280
 #, python-format
 msgid "An OS error prevented reading guild data file:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/constructs.py:256
+#: musicbot/constructs.py:293
 #, python-format
 msgid "Guild %(id)s/%(name)s has custom command prefix: %(prefix)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/constructs.py:276
+#: musicbot/constructs.py:313
 msgid ""
 "Cannot save data for guild with ID 0. This is likely a bug in the code!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:300
+#: musicbot/constructs.py:338
 msgid "Could not save guild specific data due to OS Error."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/constructs.py:303
+#: musicbot/constructs.py:341
 msgid "Failed to serialize guild specific data due to invalid data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:130
+#: musicbot/downloader.py:139
 #, python-format
 msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:153
+#: musicbot/downloader.py:174
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:159
+#: musicbot/downloader.py:180
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:260
+#: musicbot/downloader.py:281
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:263
+#: musicbot/downloader.py:284
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:264
+#: musicbot/downloader.py:285
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:332
+#: musicbot/downloader.py:353
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2822,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:334
+#: musicbot/downloader.py:355
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:466
+#: musicbot/downloader.py:487
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:515
+#: musicbot/downloader.py:536
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:520
+#: musicbot/downloader.py:541
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:539
+#: musicbot/downloader.py:560
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:583
+#: musicbot/downloader.py:603
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:744
+#: musicbot/downloader.py:764
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:749
+#: musicbot/downloader.py:769
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:978
+#: musicbot/downloader.py:998
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -2934,12 +2916,12 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:364 musicbot/entry.py:874 musicbot/entry.py:1084
+#: musicbot/entry.py:364 musicbot/entry.py:879 musicbot/entry.py:1089
 msgid "Entry data is missing version number, cannot deserialize."
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:367 musicbot/entry.py:877 musicbot/entry.py:1087
+#: musicbot/entry.py:367 musicbot/entry.py:882 musicbot/entry.py:1092
 msgid "Entry data has the wrong version number, cannot deserialize."
 msgstr ""
 
@@ -2956,13 +2938,13 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:437 musicbot/entry.py:943 musicbot/entry.py:1157
+#: musicbot/entry.py:437 musicbot/entry.py:948 musicbot/entry.py:1162
 #, python-format
 msgid "Could not load %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:486 musicbot/entry.py:948 musicbot/entry.py:1190
+#: musicbot/entry.py:486 musicbot/entry.py:953 musicbot/entry.py:1195
 #, python-format
 msgid "Getting ready for entry:  %r"
 msgstr ""
@@ -2984,7 +2966,7 @@ msgid "Download already cached at:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:536 musicbot/entry.py:1206
+#: musicbot/entry.py:536 musicbot/entry.py:1211
 #, python-format
 msgid ""
 "MusicBot could not get duration data for this entry.\n"
@@ -2999,50 +2981,50 @@ msgid "Got duration of %(time)s seconds for file:  %(file)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:566 musicbot/entry.py:1237
+#: musicbot/entry.py:566 musicbot/entry.py:1242
 msgid "Exception while checking entry data."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:577 musicbot/entry.py:1248
+#: musicbot/entry.py:577 musicbot/entry.py:1253
 #, python-format
 msgid "Trying to get duration via pymediainfo for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:583 musicbot/entry.py:1254
+#: musicbot/entry.py:583 musicbot/entry.py:1259
 msgid "Failed to get duration via pymediainfo."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:590 musicbot/entry.py:1261
+#: musicbot/entry.py:590 musicbot/entry.py:1266
 #, python-format
 msgid "Trying to get duration via ffprobe for:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:593 musicbot/entry.py:1264
+#: musicbot/entry.py:593 musicbot/entry.py:1269
 msgid "Could not locate ffprobe in your path!"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:614 musicbot/entry.py:1285
+#: musicbot/entry.py:614 musicbot/entry.py:1290
 msgid "ffprobe returned something that could not be used."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/entry.py:617 musicbot/entry.py:1288
+#: musicbot/entry.py:617 musicbot/entry.py:1293
 msgid "ffprobe could not be executed for some reason."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:627 musicbot/entry.py:1298
+#: musicbot/entry.py:627 musicbot/entry.py:1303
 #, python-format
 msgid "Calculating mean volume of:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:630 musicbot/entry.py:1301
+#: musicbot/entry.py:630 musicbot/entry.py:1306
 msgid "Could not locate ffmpeg on your path!"
 msgstr ""
 
@@ -3084,60 +3066,60 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:747
+#: musicbot/entry.py:752
 msgid "Extraction encountered an unhandled exception."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:756
+#: musicbot/entry.py:761
 #, python-format
 msgid "Download failed:  %r"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
 #. Used by: info
-#: musicbot/entry.py:759
+#: musicbot/entry.py:764
 #, python-format
 msgid "Download complete:  %r"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:906
+#: musicbot/entry.py:911
 #, python-format
 msgid "Deserialized StreamPlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:934
+#: musicbot/entry.py:939
 msgid ""
 "Deserialized StreamPlaylistEntry has an author ID but no channel for lookup!"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1119
+#: musicbot/entry.py:1124
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry has the wrong channel type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1147
+#: musicbot/entry.py:1152
 msgid ""
 "Deserialized LocalFilePlaylistEntry has an author ID but no channel for "
 "lookup!"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:1213
+#: musicbot/entry.py:1218
 #, python-format
 msgid "Got duration of %(seconds)s seconds for file:  %(file)s"
 msgstr ""
@@ -3206,7 +3188,7 @@ msgid "Cache level requires cleanup. %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:290
+#: musicbot/i18n.py:303
 #, python-format
 msgid "Failed to load log translations for any of:  [%s]  in:  %s"
 msgstr ""
@@ -3482,104 +3464,104 @@ msgid "Decoded data from ffmpeg: %s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:121
+#: musicbot/playlist.py:135
 #, python-format
 msgid "Adding stream entry for URL:  %(url)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:177
+#: musicbot/playlist.py:191
 msgid "Entry info appears to be a stream, adding stream entry..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:203
+#: musicbot/playlist.py:217
 msgid "Got text/html for content-type, this might be a stream."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:210
+#: musicbot/playlist.py:224
 #, python-format
 msgid "Questionable content-type \"%(type)s\" for url:  %(url)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:215
+#: musicbot/playlist.py:229
 #, python-format
 msgid "Adding URLPlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/playlist.py:235
+#: musicbot/playlist.py:249
 #, python-format
 msgid "Adding LocalFilePlaylistEntry for: %(subject)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:280
+#: musicbot/playlist.py:294
 #, python-format
 msgid "Ignored video from compound playlist link with ID:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:292
+#: musicbot/playlist.py:306
 #, python-format
 msgid ""
 "Not allowing entry that is in song block list:  %(title)s  URL: %(url)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:305
+#: musicbot/playlist.py:319
 #, python-format
 msgid ""
 "Ignoring song in entries by '%s', duration longer than permitted maximum."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:342
+#: musicbot/playlist.py:356
 msgid "Could not add item"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/playlist.py:343
+#: musicbot/playlist.py:357
 #, python-format
 msgid "Item: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/playlist.py:346
+#: musicbot/playlist.py:360
 #, python-format
 msgid "Skipped %s bad entries"
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:387
+#: musicbot/playlist.py:401
 msgid "Reorder looping over entries."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/playlist.py:469
+#: musicbot/playlist.py:483
 #, python-format
 msgid "Pre-downloading next track:  %r"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -4088,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:844
+#: run.py:851
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:919
+#: run.py:926
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:990
+#: run.py:1054
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:991
+#: run.py:1055
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:992
+#: run.py:1056
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1001
+#: run.py:1065
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1005
+#: run.py:1069
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4131,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1010
+#: run.py:1074
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1075
+#: run.py:1144
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1077
+#: run.py:1146
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1093
+#: run.py:1162
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1099
+#: run.py:1168
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1108
+#: run.py:1177
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1111
+#: run.py:1180
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1123
+#: run.py:1192
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4187,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1156
+#: run.py:1225
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1165
+#: run.py:1234
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4213,55 +4195,55 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1186
+#: run.py:1255
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
 #. Used by: error
-#: run.py:1198
+#: run.py:1267
 msgid ""
 "MusicBot got an ImportError after trying to install packages. MusicBot must "
 "exit..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1200
+#: run.py:1269
 msgid "The exception which caused the above error: "
 msgstr ""
 
 #. Used by: info
-#: run.py:1219
+#: run.py:1288
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1223
+#: run.py:1292
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1229
+#: run.py:1298
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1234
+#: run.py:1303
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1239
+#: run.py:1308
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1243
+#: run.py:1312
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1272
+#: run.py:1341
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4279,117 +4261,111 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:849 musicbot/bot.py:8776
+#: musicbot/bot.py:832 musicbot/bot.py:8860
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:978
+#: musicbot/bot.py:961
 msgid ""
 "[BUG] MusicPlayer is missing a VoiceClient somehow.  You should probably "
 "restart the bot."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1186 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5046
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1459 musicbot/downloader.py:694
+#: musicbot/bot.py:1458 musicbot/downloader.py:714
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1820
+#: musicbot/bot.py:1819
 #, python-format
 msgid "Cannot send non-response object:  %r"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2166
+#: musicbot/bot.py:2165
 msgid "MusicBot is now doing start up steps..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2173
+#: musicbot/bot.py:2172
 msgid "Start up failed at login."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2405
+#: musicbot/bot.py:2404
 #, python-format
 msgid "Cannot bind to non Messageable channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2454
+#: musicbot/bot.py:2453
 #, python-format
 msgid "Got None for auto join channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2460
+#: musicbot/bot.py:2459
 #, python-format
 msgid "Cannot auto join a Private/Non-Guild channel with ID:  %d"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2468
+#: musicbot/bot.py:2467
 #, python-format
 msgid "Cannot auto join to non-connectable channel with ID:  %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2484
+#: musicbot/bot.py:2483
 msgid "Auto joining voice channels:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2492 musicbot/bot.py:2495
+#: musicbot/bot.py:2491 musicbot/bot.py:2494
 msgid "Not auto joining any voice channels"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2665
+#: musicbot/bot.py:2664
 #, python-format
 msgid "    Delete Now Playing: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:3141
+#: musicbot/bot.py:3140
 #, python-format
 msgid "Not removing user from block list, not listed:  %(id)s/%(name)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: noise
@@ -4417,19 +4393,19 @@ msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4437,34 +4413,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9032
+#: musicbot/bot.py:9116
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1097
+#: musicbot/config.py:1124
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4478,7 +4454,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4496,12 +4472,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1287
+#: musicbot/config.py:1315
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4514,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4526,7 +4502,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1361
+#: musicbot/config.py:1389
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4535,31 +4511,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2698
+#: musicbot/config.py:2732
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2757 musicbot/config.py:2790
+#: musicbot/config.py:2791 musicbot/config.py:2824
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2817
+#: musicbot/config.py:2851
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2874
+#: musicbot/config.py:2908
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:458
+#: musicbot/downloader.py:479
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4583,7 +4559,7 @@ msgid "Cannot download Spotify links, processing error with type: %(type)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/entry.py:554 musicbot/entry.py:1224
+#: musicbot/entry.py:554 musicbot/entry.py:1229
 msgid ""
 "There as a problem with working out EQ, likely caused by a strange "
 "installation of FFmpeg. This has not impacted the ability for the bot to "
@@ -4591,50 +4567,50 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:656 musicbot/entry.py:1327
+#: musicbot/entry.py:656 musicbot/entry.py:1332
 msgid "Could not parse 'I' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:664 musicbot/entry.py:1335
+#: musicbot/entry.py:664 musicbot/entry.py:1340
 msgid "Could not parse 'LRA' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:672 musicbot/entry.py:1343
+#: musicbot/entry.py:672 musicbot/entry.py:1348
 msgid "Could not parse 'TP' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:680 musicbot/entry.py:1351
+#: musicbot/entry.py:680 musicbot/entry.py:1356
 msgid "Could not parse 'thresh' in normalize json."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/entry.py:688 musicbot/entry.py:1359
+#: musicbot/entry.py:688 musicbot/entry.py:1364
 msgid "Could not parse 'offset' in normalize json."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:890
+#: musicbot/entry.py:895
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:928
+#: musicbot/entry.py:933
 #, python-format
 msgid "Deserialized StreamPlaylistEntry cannot find author with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1103
+#: musicbot/entry.py:1108
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find channel with ID:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/entry.py:1141
+#: musicbot/entry.py:1146
 #, python-format
 msgid "Deserialized LocalFilePlaylistEntry cannot find author with ID:  %s"
 msgstr ""
@@ -4680,13 +4656,13 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/i18n.py:229
+#: musicbot/i18n.py:242
 #, python-format
 msgid "Lang Argument Error:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/i18n.py:338
+#: musicbot/i18n.py:351
 #, python-format
 msgid ""
 "Failed to load discord translations for any of:  [%s]  guild:  %s  in:  %s"
@@ -4764,13 +4740,13 @@ msgid "Deserialize returned an object that is not a MusicPlayer:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/playlist.py:317
+#: musicbot/playlist.py:331
 #, python-format
 msgid "Not adding YouTube video because it is marked private or deleted:  %s"
 msgstr ""
@@ -4826,45 +4802,45 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2421
+#: musicbot/bot.py:2420
 msgid "Private Channel"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2423
+#: musicbot/bot.py:2422
 msgid "Unknown User DM"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2425
+#: musicbot/bot.py:2424
 #, python-format
 msgid "User DM: %(name)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2429
+#: musicbot/bot.py:2428
 msgid "Unknown Channel (Partial)"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2431
+#: musicbot/bot.py:2430
 #, python-format
 msgid "Unnamed Channel: %(id)s"
 msgstr ""
 
 #. Used by: _L
-#: musicbot/bot.py:2811
+#: musicbot/bot.py:2810
 msgid "Unknown Channel"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:712
+#: musicbot/bot.py:695
 #, python-format
 msgid "MusicBot may use up to %(rate).2f %(suffix)s of bandwidth."
 msgstr ""
@@ -4876,220 +4852,220 @@ msgid "Probed codec and bitrate: %(name)s at %(rate)s kbps"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2607
+#: musicbot/bot.py:2606
 #, python-format
 msgid "  Command by @mention: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2609
+#: musicbot/bot.py:2608
 #, python-format
 msgid "  Command aliases: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2618
+#: musicbot/bot.py:2617
 #, python-format
 msgid "    Legacy skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2620
+#: musicbot/bot.py:2619
 #, python-format
 msgid "    Author insta-skip: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2628
+#: musicbot/bot.py:2627
 #, python-format
 msgid "  Auto-join Owner's voice channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2640
+#: musicbot/bot.py:2639
 #, python-format
 msgid "    Save per-server queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2644
+#: musicbot/bot.py:2643
 #, python-format
 msgid "    Save global queue history: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2648
+#: musicbot/bot.py:2647
 #, python-format
 msgid "    Remove URLs on extraction error: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2651
+#: musicbot/bot.py:2650
 #, python-format
 msgid "    Skip playlist for user requests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2669
+#: musicbot/bot.py:2668
 #, python-format
 msgid "  Songs blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2670
+#: musicbot/bot.py:2669
 #, python-format
 msgid "  Users blocklist: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2679
+#: musicbot/bot.py:2678
 #, python-format
 msgid "    Delete if cache exceeds %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2682
+#: musicbot/bot.py:2681
 #, python-format
 msgid "  Pre-download next track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2689
+#: musicbot/bot.py:2688
 #, python-format
 msgid "  Write current song title to file: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2692
+#: musicbot/bot.py:2691
 #, python-format
 msgid "  Respond with Embeds: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2695
+#: musicbot/bot.py:2694
 msgid "    Footer Text Disabled"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2697
+#: musicbot/bot.py:2696
 #, python-format
 msgid "    Footer Text:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2703
+#: musicbot/bot.py:2702
 #, python-format
 msgid "  Leave servers where Owner is not a member: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2707
+#: musicbot/bot.py:2706
 #, python-format
 msgid "  Disconnect from inactive channel: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2716
+#: musicbot/bot.py:2715
 #, python-format
 msgid "  Disconnect at end of queue: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2720
+#: musicbot/bot.py:2719
 #, python-format
 msgid "  Disconnect when player idles: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2730
+#: musicbot/bot.py:2729
 #, python-format
 msgid "  Search using reactions: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2731
+#: musicbot/bot.py:2730
 #, python-format
 msgid "    Results per search: %d"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2736
+#: musicbot/bot.py:2735
 #, python-format
 msgid "  Local media files: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2739
+#: musicbot/bot.py:2738
 #, python-format
 msgid "  Network checking ping tests: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2749
+#: musicbot/bot.py:2748
 #, python-format
 msgid "  Audio processed with: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2752
+#: musicbot/bot.py:2751
 #, python-format
 msgid "  Equalize audio level per-track: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2757
+#: musicbot/bot.py:2756
 #, python-format
 msgid "  HTTP Proxy set to:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:2759
+#: musicbot/bot.py:2758
 #, python-format
 msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8255
+#: musicbot/bot.py:8339
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8346
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8265
+#: musicbot/bot.py:8349
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8268
+#: musicbot/bot.py:8352
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:462
+#: musicbot/testrig.py:477
 msgid "Starting Command Tests..."
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:510
+#: musicbot/testrig.py:525
 #, python-format
 msgid "Buffered command: %(cmd)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/testrig.py:527
+#: musicbot/testrig.py:542
 #, python-format
 msgid "- Processing CMD %(n)s of %(t)s: %(cmd)s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:2508
+#: musicbot/bot.py:2507
 #, python-format
 msgid ""
 "Detected missing config options!\n"
@@ -5108,30 +5084,30 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:376
+#: musicbot/downloader.py:397
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:566
+#: musicbot/downloader.py:587
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5139,18 +5115,18 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:685
+#: musicbot/downloader.py:705
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:699
+#: musicbot/downloader.py:719
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
 msgstr ""
@@ -5225,9 +5201,88 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1118
 msgid "Updating example config files..."
 msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:335
+msgid ""
+"Your config does not have Spotify app credentials. Spotify support will not "
+"be available."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: warning
+#: musicbot/bot.py:6440
+#, python-format
+msgid ""
+"You may have QueueLength set too high! The setting is %(option)d but we "
+"could only list %(count)d tracks."
+msgstr ""
+
+#. Used by: debug
+#: musicbot/downloader.py:98
+msgid "YTDLP thinks there may be a bug in processing."
+msgstr ""
+
+#. Used by: info
+#: run.py:1001
+msgid "Saved config docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1008
+msgid "Saved permissions docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1036
+msgid "Saved command docs."
+msgstr ""
+
+#. Used by: info
+#: run.py:1037
+msgid "Export complete."
+msgstr ""
+
+#. Used by: info
+#: run.py:1124
+msgid "Updating documentation files..."
+msgstr ""
+
+#~ msgid ""
+#~ "The config did not have Spotify app credentials, attempting to use guest "
+#~ "mode."
+#~ msgstr ""
+
+#~ msgid "Authenticated with Spotify successfully using guest mode."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Could not start Spotify client using guest mode. Details: %s."
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "Experimental Yt-dlp OAuth2 plugin is enabled. This might break at any point!"

--- a/i18n/zh_TW/LC_MESSAGES/musicbot_logs.po
+++ b/i18n/zh_TW/LC_MESSAGES/musicbot_logs.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -416,13 +416,13 @@ msgstr ""
 
 #. Used by: PermissionsError
 #. Used by: exception
-#: musicbot/bot.py:837 musicbot/bot.py:8866
+#: musicbot/bot.py:837 musicbot/bot.py:8868
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
 #. Used by: exception
-#: musicbot/bot.py:841 musicbot/bot.py:8868
+#: musicbot/bot.py:841 musicbot/bot.py:8870
 msgid "MusicBot could not request to speak."
 msgstr ""
 
@@ -615,13 +615,13 @@ msgid "Looping over player autoplaylist..."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1432 musicbot/downloader.py:686
+#: musicbot/bot.py:1432 musicbot/downloader.py:694
 #, python-format
 msgid "Error while processing song \"%(url)s\":  %(raw_error)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:1443 musicbot/downloader.py:693
+#: musicbot/bot.py:1443 musicbot/downloader.py:701
 #, python-format
 msgid "Error extracting song \"%(url)s\": %(raw_error)s"
 msgstr ""
@@ -975,7 +975,7 @@ msgstr ""
 
 #. Used by: info
 #. Used by: debug
-#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9052
+#: musicbot/bot.py:2348 musicbot/bot.py:2374 musicbot/bot.py:9054
 #, python-format
 msgid " - %s"
 msgstr ""
@@ -1455,7 +1455,7 @@ msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -1476,28 +1476,28 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:3548 musicbot/bot.py:4415
+#: musicbot/bot.py:3548 musicbot/bot.py:4417
 msgid "Issue with extract_info(): "
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -1505,12 +1505,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:4467
+#: musicbot/bot.py:4469
 #, python-format
 msgid ""
 "Processed %(number)d of %(total)d songs in %(time).3f seconds at "
@@ -1518,143 +1518,143 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:4524
+#: musicbot/bot.py:4526
 #, python-format
 msgid "Added song(s) at position %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:4561
+#: musicbot/bot.py:4563
 #, python-format
 msgid "Cannot estimate time until playing for position: %d"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:4622
+#: musicbot/bot.py:4624
 #, python-format
 msgid "Failed to get info from the stream request: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5074
+#: musicbot/bot.py:5076
 #, python-format
 msgid "Waiting for summon lock: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:5077
+#: musicbot/bot.py:5079
 #, python-format
 msgid "Summon lock acquired for: %s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:5106
+#: musicbot/bot.py:5108
 #, python-format
 msgid "Joining %(guild)s/%(channel)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1662,37 +1662,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1700,28 +1700,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1729,24 +1729,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1754,97 +1754,97 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6167
+#: musicbot/bot.py:6169
 #, python-format
 msgid "Doing set with on %(config)s == %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6202
+#: musicbot/bot.py:6204
 #, python-format
 msgid "Resetting %(config)s to default %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6361
+#: musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1852,39 +1852,39 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6412
+#: musicbot/bot.py:6414
 msgid "Skipped the current playlist entry."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:6474
+#: musicbot/bot.py:6476
 msgid "Not enough entries to paginate the queue."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6478
+#: musicbot/bot.py:6480
 msgid "Could not post queue message, no message to add reactions to."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1892,38 +1892,38 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1931,54 +1931,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7113
 #, python-format
 msgid "Doing set on %(option)s with value: %(value)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1986,12 +1986,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1999,24 +1999,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2024,62 +2024,62 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:7388
+#: musicbot/bot.py:7390
 #, python-format
 msgid "MusicBot found a %s with no guild!  This could be a problem."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:7618
+#: musicbot/bot.py:7620
 #, python-format
 msgid "Activating debug breakpoint ID: %(uuid)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7734
+#: musicbot/bot.py:7736
 msgid "Debug code ran with eval()."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7744
+#: musicbot/bot.py:7746
 msgid "Debug code ran with exec()."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7747
+#: musicbot/bot.py:7749
 msgid "Debug code failed to execute."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2090,54 +2090,54 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7928
+#: musicbot/bot.py:7930
 msgid "Failed while checking for updates via git command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:7957
+#: musicbot/bot.py:7959
 msgid "Package missing meta in pip report."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:7971
+#: musicbot/bot.py:7973
 msgid "Failed to get pip update status due to some error."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8032
+#: musicbot/bot.py:8034
 msgid "Got a strange voice client entry."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2145,183 +2145,183 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8194
+#: musicbot/bot.py:8196
 #, python-format
 msgid "Could not remove old, disabled cookies file:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8226
+#: musicbot/bot.py:8228
 #, python-format
 msgid "Got a message with no channel, somehow:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8254
+#: musicbot/bot.py:8256
 #, python-format
 msgid "Ignoring command from myself (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8262
+#: musicbot/bot.py:8264
 #, python-format
 msgid "Ignoring command from other bot (%s)"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8270
+#: musicbot/bot.py:8272
 #, python-format
 msgid "Ignoring command from channel of type:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8365
+#: musicbot/bot.py:8367
 #, python-format
 msgid "User in block list: %(id)s/%(name)s  tried command: %(command)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8372
+#: musicbot/bot.py:8374
 #, python-format
 msgid "Message from %(id)s/%(name)s: %(message)s"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8531
+#: musicbot/bot.py:8533
 #, python-format
 msgid "Invalid command usage, missing values for params: %(params)r"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8569
+#: musicbot/bot.py:8571
 #, python-format
 msgid "Error in %(command)s: %(err_name)s: %(err_text)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8592
+#: musicbot/bot.py:8594
 #, python-format
 msgid "Exception while handling command: %(command)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8623
+#: musicbot/bot.py:8625
 #, python-format
 msgid "Cannot generate help for missing command:  %s"
 msgstr ""
 
 #. Used by: critical
-#: musicbot/bot.py:8627
+#: musicbot/bot.py:8629
 #, python-format
 msgid "Missing help data for command:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8744
+#: musicbot/bot.py:8746
 #, python-format
 msgid "Leaving voice channel %s in %s due to inactivity."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8753
+#: musicbot/bot.py:8755
 msgid "MusicBot has become connected."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8757
+#: musicbot/bot.py:8759
 msgid "MusicBot has become disconnected."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:8762
+#: musicbot/bot.py:8764
 #, python-format
 msgid "Got a Socket Event:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8778
+#: musicbot/bot.py:8780
 msgid "VoiceState updated before on_ready finished"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8791
+#: musicbot/bot.py:8793
 #, python-format
 msgid "Ignoring %s in %s as it is a bound voice channel."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8800
+#: musicbot/bot.py:8802
 #, python-format
 msgid "%s has been detected as empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8811
+#: musicbot/bot.py:8813
 #, python-format
 msgid "A user joined %s, cancelling timer."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8824
+#: musicbot/bot.py:8826
 #, python-format
 msgid ""
 "The bot got moved and the voice channel %s is empty. Handling timeouts."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8833
+#: musicbot/bot.py:8835
 #, python-format
 msgid "The bot got moved and the voice channel %s is not empty."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8882
+#: musicbot/bot.py:8884
 #, python-format
 msgid "No longer following user %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8904
+#: musicbot/bot.py:8906
 #, python-format
 msgid "Following user `%(user)s` to channel:  %(channel)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8924
+#: musicbot/bot.py:8926
 msgid "VoiceState disconnect before.channel is None."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8951
+#: musicbot/bot.py:8953
 #, python-format
 msgid ""
 "Disconnected from voice by Discord API in: %(guild)s/%(channel)s (Code: "
@@ -2329,90 +2329,90 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8973
+#: musicbot/bot.py:8975
 #, python-format
 msgid "Cannot use auto-join channel with type: %(type)s  in guild:  %(guild)s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:8980
+#: musicbot/bot.py:8982
 #, python-format
 msgid "Cannot find the auto-joined channel, was it deleted?  Guild:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:8986
+#: musicbot/bot.py:8988
 #, python-format
 msgid "Reconnecting to auto-joined guild on channel:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:8999
+#: musicbot/bot.py:9001
 #, python-format
 msgid "Cannot auto join channel:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9015
+#: musicbot/bot.py:9017
 #, python-format
 msgid "Bot has been added to guild: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9027
+#: musicbot/bot.py:9029
 #, python-format
 msgid "Left guild '%s' due to bot owner not found."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9041
+#: musicbot/bot.py:9043
 #, python-format
 msgid "Creating data folder for guild %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9049
+#: musicbot/bot.py:9051
 #, python-format
 msgid "Bot has been removed from guild: %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9050
+#: musicbot/bot.py:9052
 msgid "Updated guild list:"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9065
+#: musicbot/bot.py:9067
 #, python-format
 msgid "Guild \"%s\" has become available."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9071
+#: musicbot/bot.py:9073
 #, python-format
 msgid "Resuming player in \"%s\" due to availability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9088
+#: musicbot/bot.py:9090
 #, python-format
 msgid "Guild \"%s\" has become unavailable."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:9094
+#: musicbot/bot.py:9096
 #, python-format
 msgid "Pausing player in \"%s\" due to unavailability."
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9110
+#: musicbot/bot.py:9112
 #, python-format
 msgid "Guild update for:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:9167
+#: musicbot/bot.py:9169
 #, python-format
 msgid "Channel update for:  %(channel)s  --  %(changes)s"
 msgstr ""
@@ -2430,7 +2430,7 @@ msgid "Loading config from:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1198
+#: musicbot/config.py:1199
 #, python-format
 msgid ""
 "Cannot store more than %s log files. Option LogsMaxKept will be limited "
@@ -2438,14 +2438,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1206
+#: musicbot/config.py:1207
 msgid ""
 "Config option LogsDateFormat is empty and this will break log file rotation."
 " Using default instead."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -2457,12 +2457,12 @@ msgid ""
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1234
+#: musicbot/config.py:1235
 msgid "An exception was thrown while validating AudioCachePath."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -2476,13 +2476,13 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1250
+#: musicbot/config.py:1251
 #, python-format
 msgid "Audio Cache will be stored in:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -2495,14 +2495,14 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1282
+#: musicbot/config.py:1283
 msgid ""
 "StatusMessage config option is too long, it will be limited to 128 "
 "characters."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1291
+#: musicbot/config.py:1292
 #, python-format
 msgid ""
 "The default playback speed must be between 0.5 and 100.0. The option value "
@@ -2510,22 +2510,22 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1309
+#: musicbot/config.py:1310
 msgid "Validating options with service data..."
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1331
+#: musicbot/config.py:1332
 msgid "MusicBot does not have a user instance, cannot proceed."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1361
+#: musicbot/config.py:1362
 msgid "Config options file not found. Checking for alternatives..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1374
+#: musicbot/config.py:1375
 #, python-format
 msgid ""
 "Renaming %(ini_file)s to %(option_file)s, you should probably turn file "
@@ -2533,18 +2533,18 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:1382
+#: musicbot/config.py:1383
 #, python-format
 msgid "Copying existing example options file:  %(example_file)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1396
+#: musicbot/config.py:1397
 msgid "Something went wrong while trying to find a config option file."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -2558,7 +2558,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -2573,54 +2573,54 @@ msgid ""
 msgstr ""
 
 #. Used by: critical
-#: musicbot/config.py:1442
+#: musicbot/config.py:1443
 msgid "Dev Bug! Config option has getter that is not available."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1447
+#: musicbot/config.py:1448
 msgid ""
 "Dev Bug! Config option has invalid type, getter and default must be the same"
 " type."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1467
+#: musicbot/config.py:1468
 msgid "Option was missing previously."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1482
+#: musicbot/config.py:1483
 #, python-format
 msgid "Config section not in parsed config! Missing: %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1487
+#: musicbot/config.py:1488
 #, python-format
 msgid "Saved config option: %(config)s  =  %(value)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:1500
+#: musicbot/config.py:1501
 #, python-format
 msgid "Failed to save config:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2017
+#: musicbot/config.py:2018
 msgid ""
 "Option names are not unique between INI sections!  Resolver is disabled."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2199 musicbot/permissions.py:909
+#: musicbot/config.py:2200 musicbot/permissions.py:909
 #, python-format
 msgid "Failed to save default INI file at:  %s"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2633,7 +2633,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2646,7 +2646,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -2659,7 +2659,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2391
+#: musicbot/config.py:2392
 #, python-format
 msgid ""
 "Invalid DebugLevel option \"%(value)s\" given, falling back to level: "
@@ -2667,7 +2667,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2412
+#: musicbot/config.py:2413
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has invalid config value '%(value)s' using"
@@ -2675,7 +2675,7 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2461
+#: musicbot/config.py:2462
 #, python-format
 msgid ""
 "Option [%(section)s] > %(option)s has a value greater than 100 %% "
@@ -2683,30 +2683,30 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2586
+#: musicbot/config.py:2587
 #, python-format
 msgid ""
 "Renaming INI file entry [%(old_s)s] > %(old_o)s  to  [%(new_s)s] > %(new_o)s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2657
+#: musicbot/config.py:2658
 msgid "Upgrading config file with renamed options..."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/config.py:2691
+#: musicbot/config.py:2692
 msgid "Failed to upgrade config.  You'll need to upgrade it manually."
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2753
+#: musicbot/config.py:2754
 #, python-format
 msgid "Could not load block list from file:  %s"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2862
+#: musicbot/config.py:2863
 #, python-format
 msgid "We found a legacy blacklist file, it will be renamed to:  %s"
 msgstr ""
@@ -2764,39 +2764,39 @@ msgid "Forcing YTDLP to use User Agent:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:174
+#: musicbot/downloader.py:182
 #, python-format
 msgid "MusicBot will use cookies for yt-dlp from:  %s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/downloader.py:180
+#: musicbot/downloader.py:188
 msgid "Yt-dlp will use your configured proxy server."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:281
+#: musicbot/downloader.py:289
 msgid "Checking media headers failed due to timeout."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:284
+#: musicbot/downloader.py:292
 #, python-format
 msgid "Failed HEAD request for:  %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:285
+#: musicbot/downloader.py:293
 msgid "HEAD Request exception: "
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:353
+#: musicbot/downloader.py:361
 #, python-format
 msgid ""
 "Sanitized YTDL Extraction Info (not JSON):\n"
@@ -2804,76 +2804,76 @@ msgid ""
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:355
+#: musicbot/downloader.py:363
 #, python-format
 msgid "Sanitized YTDL Extraction Info (not JSON):  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:487
+#: musicbot/downloader.py:495
 msgid "Cannot run extraction, loop is closed. (This is normal on shutdowns.)"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:536
+#: musicbot/downloader.py:544
 msgid "Download Error with stream URL"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:541
+#: musicbot/downloader.py:549
 msgid "Assuming content is a direct stream"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:560
+#: musicbot/downloader.py:568
 msgid ""
 "Caught NoSupportingHandlers, trying again after replacing colon with space."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:611
 #, python-format
 msgid "Called safe_extract_info with:  %(args)s, %(kws)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:764
+#: musicbot/downloader.py:772
 msgid "Missing __input_subject from YtdlpResponseDict"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/downloader.py:769
+#: musicbot/downloader.py:777
 msgid ""
 "Entries is not a list in YtdlpResponseDict, set process=True to avoid this."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:998
+#: musicbot/downloader.py:1006
 #, python-format
 msgid "Warning, duration error for: %(url)s"
 msgstr ""
@@ -3892,55 +3892,55 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: run.py:582
+#: run.py:618
 #, python-format
 msgid "Less than %sMB of free space remains on this device"
 msgstr ""
 
 #. Used by: info
-#: run.py:591
+#: run.py:627
 msgid ""
 "\n"
 "Checking for updates to MusicBot or dependencies..."
 msgstr ""
 
 #. Used by: info
-#: run.py:608
+#: run.py:644
 msgid "No MusicBot updates available via `git` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:611
+#: run.py:647
 msgid ""
 "Could not check for updates using `git` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: _L
-#: run.py:618
+#: run.py:654
 msgid "The following packages can be updated:\n"
 msgstr ""
 
 #. Used by: _L
-#: run.py:624
+#: run.py:660
 #, python-format
 msgid "  %s  to version:  %s\n"
 msgstr ""
 
 #. Used by: info
-#: run.py:635
+#: run.py:671
 msgid "No dependency updates available via `pip` command."
 msgstr ""
 
 #. Used by: warning
-#: run.py:638
+#: run.py:674
 msgid ""
 "Could not check for updates using `pip` commands.  You should check "
 "manually."
 msgstr ""
 
 #. Used by: info
-#: run.py:642
+#: run.py:678
 #, python-format
 msgid ""
 "You can run a guided update by using the command:\n"
@@ -3948,107 +3948,107 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:660
+#: run.py:696
 msgid "Value is above the maximum limit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:662
+#: run.py:698
 msgid "Value must not be negative."
 msgstr ""
 
 #. Used by: _L
-#: run.py:666
+#: run.py:702
 #, python-format
 msgid "Value for Max Logs Kept must be a number from 0 to %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:676
+#: run.py:712
 #, python-format
 msgid "Log level '%s' is not available."
 msgstr ""
 
 #. Used by: _L
-#: run.py:680
+#: run.py:716
 #, python-format
 msgid "Log Level must be one of:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:690
+#: run.py:726
 msgid ""
 "Launch a music playing discord bot built using discord.py, youtubeDL, and "
 "ffmpeg."
 msgstr ""
 
 #. Used by: _L
-#: run.py:693
+#: run.py:729
 msgid "Available via Github:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:697
+#: run.py:733
 msgid "For more help and support with this bot, join our discord:"
 msgstr ""
 
 #. Used by: _L
-#: run.py:699
+#: run.py:735
 msgid "This software is provided under the MIT License."
 msgstr ""
 
 #. Used by: _L
-#: run.py:701
+#: run.py:737
 msgid "See the `LICENSE` text file for complete details."
 msgstr ""
 
 #. Used by: _L
-#: run.py:714
+#: run.py:750
 msgid ""
 "Override the default / system detected language for all text in MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:724
+#: run.py:760
 msgid "Use this language for all server-side log messages from MusicBot."
 msgstr ""
 
 #. Used by: _L
-#: run.py:734
+#: run.py:770
 msgid ""
 "Use this language for all messages sent to discord from MusicBot.\n"
 "This does not prevent per-guild language selection."
 msgstr ""
 
 #. Used by: _L
-#: run.py:745
+#: run.py:781
 msgid "Print the MusicBot version information and exit."
 msgstr ""
 
 #. Used by: _L
-#: run.py:753
+#: run.py:789
 msgid "Skip all optional startup checks, including the update check."
 msgstr ""
 
 #. Used by: _L
-#: run.py:761
+#: run.py:797
 msgid "Skip only the disk space check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:769
+#: run.py:805
 msgid "Skip only the update check at startup."
 msgstr ""
 
 #. Used by: _L
-#: run.py:778
+#: run.py:814
 msgid ""
 "Disable MusicBot from trying to install dependencies when it cannot import "
 "them."
 msgstr ""
 
 #. Used by: _L
-#: run.py:790
+#: run.py:826
 #, python-format
 msgid ""
 "Specify how many log files to keep, between 0 and %s inclusive. (Default: "
@@ -4056,13 +4056,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:801
+#: run.py:837
 #, python-format
 msgid "Override the log level settings set in config. Must be one of: %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:813
+#: run.py:849
 #, python-format
 msgid ""
 "Override the default date format used when rotating log files. This should "
@@ -4070,42 +4070,42 @@ msgid ""
 msgstr ""
 
 #. Used by: _L
-#: run.py:851
+#: run.py:887
 #, python-format
 msgid "Version:  %s"
 msgstr ""
 
 #. Used by: _L
-#: run.py:926
+#: run.py:962
 msgid "Opened a new MusicBot instance. This terminal can be safely closed!"
 msgstr ""
 
 #. Used by: info
-#: run.py:1054
+#: run.py:1096
 #, python-format
 msgid "Loading MusicBot version:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1055
+#: run.py:1097
 #, python-format
 msgid "Log opened:  %s"
 msgstr ""
 
 #. Used by: info
-#: run.py:1056
+#: run.py:1098
 #, python-format
 msgid "Python version:  %s"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1065
+#: run.py:1107
 #, python-format
 msgid "Changing working directory to:  %s"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1069
+#: run.py:1111
 msgid ""
 "Cannot start the bot!  You started `run.py` in the wrong directory and we "
 "could not locate `musicbot` and `.git` folders to verify a new directory "
@@ -4113,50 +4113,50 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: run.py:1074
+#: run.py:1116
 msgid ""
 "For best results, start `run.py` from the same folder you cloned MusicBot into.\n"
 "If you did not use git to clone the repository, you are strongly urged to."
 msgstr ""
 
 #. Used by: critical
-#: run.py:1144
+#: run.py:1186
 msgid ""
 "Certificate error is not a verification error, not trying certifi and "
 "exiting."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1146
+#: run.py:1188
 msgid "Here is the exact error, it could be a bug."
 msgstr ""
 
 #. Used by: warning
-#: run.py:1162
+#: run.py:1204
 msgid ""
 "To easily add a certificate to Windows trust store, \n"
 "you can open the failing site in Microsoft Edge or IE...\n"
 msgstr ""
 
 #. Used by: warning
-#: run.py:1168
+#: run.py:1210
 msgid ""
 "Could not get Issuer Certificate from default trust store, trying certifi "
 "instead."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1177
+#: run.py:1219
 msgid "Syntax error (modification detected, did you edit the code?)"
 msgstr ""
 
 #. Used by: exception
-#: run.py:1180
+#: run.py:1222
 msgid "Syntax error (this is a bug, not your fault)"
 msgstr ""
 
 #. Used by: error
-#: run.py:1192
+#: run.py:1235
 msgid ""
 "Cannot start MusicBot due to an error!\n"
 "\n"
@@ -4169,12 +4169,12 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1225
+#: run.py:1268
 msgid "Attempting to install MusicBot dependency packages automatically...\n"
 msgstr ""
 
 #. Used by: critical
-#: run.py:1234
+#: run.py:1277
 #, python-format
 msgid ""
 "MusicBot dependencies may not be installed!\n"
@@ -4195,55 +4195,43 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: run.py:1255
+#: run.py:1298
 msgid "OK, lets hope installing dependencies worked!"
 msgstr ""
 
-#. Used by: error
-#: run.py:1267
-msgid ""
-"MusicBot got an ImportError after trying to install packages. MusicBot must "
-"exit..."
-msgstr ""
-
-#. Used by: exception
-#: run.py:1269
-msgid "The exception which caused the above error: "
-msgstr ""
-
 #. Used by: info
-#: run.py:1288
+#: run.py:1327
 msgid "MusicBot is doing a soft restart..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1292
+#: run.py:1331
 msgid "MusicBot is doing a full process restart..."
 msgstr ""
 
 #. Used by: exception
-#: run.py:1298
+#: run.py:1337
 msgid "Error starting bot"
 msgstr ""
 
 #. Used by: debug
-#: run.py:1303
+#: run.py:1342
 msgid "Closing event loop."
 msgstr ""
 
 #. Used by: info
-#: run.py:1308
+#: run.py:1347
 #, python-format
 msgid "Restarting in %s seconds..."
 msgstr ""
 
 #. Used by: info
-#: run.py:1312
+#: run.py:1351
 msgid "All done."
 msgstr ""
 
 #. Used by: _L
-#: run.py:1341
+#: run.py:1380
 msgid "OK, we're closing!"
 msgstr ""
 
@@ -4261,7 +4249,7 @@ msgid ""
 msgstr ""
 
 #. Used by: info
-#: musicbot/bot.py:832 musicbot/bot.py:8860
+#: musicbot/bot.py:832 musicbot/bot.py:8862
 #, python-format
 msgid "MusicBot is requesting to speak in channel: %s"
 msgstr ""
@@ -4274,13 +4262,13 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:1185 musicbot/bot.py:5046
+#: musicbot/bot.py:1185 musicbot/bot.py:5048
 #, python-format
 msgid "No thumbnail set for entry with URL: %s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:1458 musicbot/downloader.py:714
+#: musicbot/bot.py:1458 musicbot/downloader.py:722
 msgid "MusicBot needs to stop the auto playlist extraction and bail."
 msgstr ""
 
@@ -4364,48 +4352,48 @@ msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/bot.py:4494
+#: musicbot/bot.py:4496
 msgid "Extracted an entry with 'youtube:playlist' as extractor key"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: error
-#: musicbot/bot.py:5285
+#: musicbot/bot.py:5287
 #, python-format
 msgid ""
 "Missing permissions to delete queue file for %(guild)s(%(id)s) at: %(path)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/bot.py:5290
+#: musicbot/bot.py:5292
 #, python-format
 msgid "OS level error while trying to delete queue file: %(path)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -4413,34 +4401,34 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: everything
-#: musicbot/bot.py:9116
+#: musicbot/bot.py:9118
 #, python-format
 msgid "Guild attribute %(attr)s is now: %(new)s  -- Was: %(old)s"
 msgstr ""
 
 #. Used by: info
-#: musicbot/config.py:1124
+#: musicbot/config.py:1125
 msgid "Generating new config options files..."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -4454,7 +4442,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -4472,12 +4460,12 @@ msgid ""
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:1315
+#: musicbot/config.py:1316
 msgid "Acquired owner ID via API"
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -4490,7 +4478,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -4502,7 +4490,7 @@ msgid ""
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:1389
+#: musicbot/config.py:1390
 #, python-format
 msgid ""
 "Could not locate config options or example options files.\n"
@@ -4511,31 +4499,31 @@ msgid ""
 msgstr ""
 
 #. Used by: warning
-#: musicbot/config.py:2732
+#: musicbot/config.py:2733
 #, python-format
 msgid "Block list file not found:  %s"
 msgstr ""
 
 #. Used by: error
-#: musicbot/config.py:2791 musicbot/config.py:2824
+#: musicbot/config.py:2792 musicbot/config.py:2825
 #, python-format
 msgid "Could not update the block list file:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2851
+#: musicbot/config.py:2852
 #, python-format
 msgid "Loaded User Block list with %s entries."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/config.py:2908
+#: musicbot/config.py:2909
 #, python-format
 msgid "Loaded a Song Block list with %s entries."
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:479
+#: musicbot/downloader.py:487
 #, python-format
 msgid "Called extract_info with:  '%(subject)s', %(args)s, %(kws)s"
 msgstr ""
@@ -4794,7 +4782,7 @@ msgid "Failed to clean up write-test path."
 msgstr ""
 
 #. Used by: _L
-#: run.py:827
+#: run.py:863
 msgid ""
 "Supply a directory where MusicBot can store all mutable files.\n"
 "Essentially treats the install directory as read-only.\n"
@@ -5025,24 +5013,24 @@ msgid "  User Agent set to:  %s"
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8339
+#: musicbot/bot.py:8341
 msgid ""
 "MusicBot has bound channel config and caller channel is not in bound "
 "channels."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8346
+#: musicbot/bot.py:8348
 msgid "Caller server has a bound channel, caller channel ignored."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8349
+#: musicbot/bot.py:8351
 msgid "Caller server has no bound channel, caller allowed."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/bot.py:8352
+#: musicbot/bot.py:8354
 #, python-format
 msgid "Unbound channel (%s) in server:  %s"
 msgstr ""
@@ -5089,25 +5077,25 @@ msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: debug
-#: musicbot/downloader.py:397
+#: musicbot/downloader.py:405
 #, python-format
 msgid "AutoPlaylist requested:  %s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: noise
-#: musicbot/downloader.py:587
+#: musicbot/downloader.py:595
 #, python-format
 msgid ""
 "Extractor %(extractor)s returned single-entry result, replacing base info "
@@ -5115,66 +5103,20 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. Used by: error
-#: musicbot/downloader.py:705
+#: musicbot/downloader.py:713
 #, python-format
 msgid "Could not process track '%(track)s' due to: %(raw_error)s"
 msgstr ""
 
 #. Used by: exception
-#: musicbot/downloader.py:719
+#: musicbot/downloader.py:727
 msgid ""
 "MusicBot got an unhandled exception while adding auto playlist to the queue."
-msgstr ""
-
-#. Used by: info
-#: run.py:388
-msgid "Checking for Python 3.9+"
-msgstr ""
-
-#. Used by: warning
-#: run.py:392
-#, python-format
-msgid "Python 3.9+ is required. This version is %s"
-msgstr ""
-
-#. Used by: warning
-#: run.py:394
-msgid "Attempting to locate Python 3.9..."
-msgstr ""
-
-#. Used by: warning
-#: run.py:413
-msgid "Could not execute `py.exe -3.9` "
-msgstr ""
-
-#. Used by: info
-#: run.py:422
-msgid "Trying \"python3.9\""
-msgstr ""
-
-#. Used by: warning
-#: run.py:425
-msgid "Could not locate python3.9 on path."
-msgstr ""
-
-#. Used by: info
-#: run.py:439
-#, python-format
-msgid ""
-"\n"
-"Python 3.9 found.  Re-launching bot using: %s run.py\n"
-msgstr ""
-
-#. Used by: critical
-#: run.py:444
-msgid ""
-"Could not find Python 3.9 or higher.  Please run the bot using Python "
-"version 3.9 to 3.13"
 msgstr ""
 
 #. Used by: critical
@@ -5201,7 +5143,7 @@ msgid "musicbot module is not importable"
 msgstr ""
 
 #. Used by: info
-#: run.py:1118
+#: run.py:1160
 msgid "Updating example config files..."
 msgstr ""
 
@@ -5213,25 +5155,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: warning
-#: musicbot/bot.py:6440
+#: musicbot/bot.py:6442
 #, python-format
 msgid ""
 "You may have QueueLength set too high! The setting is %(option)d but we "
@@ -5244,29 +5186,143 @@ msgid "YTDLP thinks there may be a bug in processing."
 msgstr ""
 
 #. Used by: info
-#: run.py:1001
+#: run.py:1037
 msgid "Saved config docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1008
+#: run.py:1049
 msgid "Saved permissions docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1036
+#: run.py:1078
 msgid "Saved command docs."
 msgstr ""
 
 #. Used by: info
-#: run.py:1037
+#: run.py:1079
 msgid "Export complete."
 msgstr ""
 
 #. Used by: info
-#: run.py:1124
+#: run.py:1166
 msgid "Updating documentation files..."
 msgstr ""
+
+#. Used by: info
+#: run.py:388
+msgid "Checking for Python 3.10+"
+msgstr ""
+
+#. Used by: warning
+#: run.py:392
+#, python-format
+msgid "Python 3.10+ is required. This version is %s"
+msgstr ""
+
+#. Used by: warning
+#: run.py:394
+msgid "Attempting to locate Python 3.10..."
+msgstr ""
+
+#. Used by: warning
+#: run.py:413
+msgid "Could not execute `py.exe -3.10` "
+msgstr ""
+
+#. Used by: info
+#: run.py:422
+msgid "Trying \"python3.10\""
+msgstr ""
+
+#. Used by: warning
+#: run.py:425
+msgid "Could not locate python3.10 on path."
+msgstr ""
+
+#. Used by: info
+#: run.py:439
+#, python-format
+msgid ""
+"\n"
+"Python 3.10 found.  Re-launching bot using: %s run.py\n"
+msgstr ""
+
+#. Used by: critical
+#: run.py:444
+msgid ""
+"Could not find Python 3.10 or higher.  Please run the bot using Python "
+"version 3.10 to 3.13"
+msgstr ""
+
+#. Used by: warning
+#: run.py:579
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find the yt-dlp EJS package.\n"
+"Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+msgstr ""
+
+#. Used by: debug
+#: run.py:592
+#, python-format
+msgid "Adding environment PATH fallback for deno as: %s "
+msgstr ""
+
+#. Used by: warning
+#: run.py:603
+msgid ""
+"YouTube support may not work!\n"
+"MusicBot could not find deno or node executables in your environment.\n"
+"Install deno from:  https://github.com/denoland/deno/\n"
+" -OR-\n"
+"Install node (version 25 or newer) via your package manager.\n"
+msgstr ""
+
+#. Used by: warning
+#: run.py:1227
+#, python-format
+msgid "Processing Error Data:  %s"
+msgstr ""
+
+#~ msgid ""
+#~ "MusicBot got an ImportError after trying to install packages. MusicBot must "
+#~ "exit..."
+#~ msgstr ""
+
+#~ msgid "The exception which caused the above error: "
+#~ msgstr ""
+
+#~ msgid "Checking for Python 3.9+"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "Python 3.9+ is required. This version is %s"
+#~ msgstr ""
+
+#~ msgid "Attempting to locate Python 3.9..."
+#~ msgstr ""
+
+#~ msgid "Could not execute `py.exe -3.9` "
+#~ msgstr ""
+
+#~ msgid "Trying \"python3.9\""
+#~ msgstr ""
+
+#~ msgid "Could not locate python3.9 on path."
+#~ msgstr ""
+
+#, python-format
+#~ msgid ""
+#~ "\n"
+#~ "Python 3.9 found.  Re-launching bot using: %s run.py\n"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Could not find Python 3.9 or higher.  Please run the bot using Python "
+#~ "version 3.9 to 3.13"
+#~ msgstr ""
 
 #~ msgid ""
 #~ "The config did not have Spotify app credentials, attempting to use guest "

--- a/i18n/zh_TW/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/zh_TW/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: release-250723-178-gba5fdbf2\n"
+"Project-Id-Version: 235ee4c\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -19,95 +19,95 @@ msgstr ""
 "X-Crowdin-Project-ID: 734017\n"
 
 #. Used by: CommandError
-#: musicbot/bot.py:726
+#: musicbot/bot.py:709
 msgid "Member is not voice-enabled and cannot use this command."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:734
+#: musicbot/bot.py:717
 msgid "You cannot use this command when not in the voice channel."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:777
+#: musicbot/bot.py:760
 #, python-format
 msgid "MusicBot does not have permission to Connect in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:786
+#: musicbot/bot.py:769
 #, python-format
 msgid "MusicBot does not have permission to Speak in channel:  `%(name)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:819
+#: musicbot/bot.py:802
 msgid ""
 "MusicBot could not connect to the channel.\n"
 "Try again later, or restart the bot if this continues."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:843
+#: musicbot/bot.py:826
 msgid ""
 "MusicBot connection to voice was cancelled. This is odd. Maybe restart?"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:854
+#: musicbot/bot.py:837
 msgid "MusicBot does not have permission to speak."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:858
+#: musicbot/bot.py:841
 msgid "MusicBot could not request to speak."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:1030
+#: musicbot/bot.py:1013
 msgid ""
 "The bot is not in a voice channel.\n"
 "Use the summon command to bring the bot to your voice channel."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1042
+#: musicbot/bot.py:1025
 msgid "Something is wrong, we didn't get the VoiceClient."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1098
+#: musicbot/bot.py:1081
 #, python-format
 msgid ""
 "Skipping next song `%(title)s` as requester `%(user)s` is not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1116
+#: musicbot/bot.py:1099
 #, python-format
 msgid "%(mention)s - your song `%(title)s` is now playing in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1125
+#: musicbot/bot.py:1108
 #, python-format
 msgid "Now playing in %(channel)s: `%(title)s` added by %(author)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1136
+#: musicbot/bot.py:1119
 #, python-format
 msgid "Now playing automatically added entry `%(title)s` in %(channel)s!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1351
+#: musicbot/bot.py:1350
 #, python-format
 msgid "Skipping songs added by %(user)s as they are not in voice!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:1573
+#: musicbot/bot.py:1572
 #, python-format
 msgid ""
 "Playback failed for song `%(song)s` due to an error:\n"
@@ -116,12 +116,12 @@ msgid ""
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/bot.py:1825
+#: musicbot/bot.py:1824
 msgid "[Dev Bug] Tried sending an invalid response object."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/bot.py:2176
+#: musicbot/bot.py:2175
 msgid ""
 "Failed Discord API Login!\n"
 "\n"
@@ -135,36 +135,36 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2924
+#: musicbot/bot.py:2923
 msgid ""
 "Reset the auto playlist queue by copying it back into player memory.\n"
 "This command will be removed in a future version, replaced by the autoplaylist command(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2939
+#: musicbot/bot.py:2938
 msgid "\\N{OK HAND SIGN}"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:2946
+#: musicbot/bot.py:2945
 msgid ""
 "Show usage and description of a command, or list all available commands.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2977
+#: musicbot/bot.py:2976
 msgid "**Aliases for this command:**\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:2980
+#: musicbot/bot.py:2979
 #, python-format
 msgid "`%(alias)s` alias of `%(command)s %(args)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3013
+#: musicbot/bot.py:3012
 #, python-format
 msgid ""
 "**Alias of command:**\n"
@@ -173,7 +173,7 @@ msgstr ""
 
 #. TRANSLATORS: template string for command-specific help output.
 #. Used by: _D
-#: musicbot/bot.py:3020
+#: musicbot/bot.py:3019
 #, python-format
 msgid ""
 "%(is_alias)s\n"
@@ -182,12 +182,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3029
+#: musicbot/bot.py:3028
 msgid "No such command"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3048
+#: musicbot/bot.py:3047
 #, python-format
 msgid ""
 "The list above shows only commands permitted for your use.\n"
@@ -195,7 +195,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3054
+#: musicbot/bot.py:3053
 #, python-format
 msgid ""
 "**Commands by name:** *(without prefix)*\n"
@@ -209,64 +209,64 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3073
+#: musicbot/bot.py:3072
 msgid "    Block a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3076
+#: musicbot/bot.py:3075
 msgid "    Unblock a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3079
+#: musicbot/bot.py:3078
 msgid "    Show the block status of a mentioned user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3083
+#: musicbot/bot.py:3082
 msgid ""
 "Manage the users in the user block list.\n"
 "Blocked users are forbidden from using all bot commands.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3105
+#: musicbot/bot.py:3104
 msgid "You must mention a user or provide their ID number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3110
+#: musicbot/bot.py:3109
 msgid "Invalid sub-command given. Use `help blockuser` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3121
+#: musicbot/bot.py:3120
 msgid "MusicBot could not find the user(s) you specified."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3128
+#: musicbot/bot.py:3127
 msgid "The owner cannot be added to the block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3148
+#: musicbot/bot.py:3147
 msgid "User block list is currently enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3150
+#: musicbot/bot.py:3149
 msgid "User block list is currently disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3158
+#: musicbot/bot.py:3157
 msgid "Cannot add the users you listed, they are already added."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3167
+#: musicbot/bot.py:3166
 #, python-format
 msgid ""
 "%(number)s user(s) have been added to the block list.\n"
@@ -274,24 +274,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3178
+#: musicbot/bot.py:3177
 msgid "None of those users are in the blacklist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3183
+#: musicbot/bot.py:3182
 #, python-format
 msgid "User: `%(user)s` is not blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3185
+#: musicbot/bot.py:3184
 #, python-format
 msgid "User: `%(user)s` is blocked.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3188
+#: musicbot/bot.py:3187
 #, python-format
 msgid ""
 "**Block list status:**\n"
@@ -300,7 +300,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3198
+#: musicbot/bot.py:3197
 #, python-format
 msgid ""
 "%(number)s user(s) have been removed from the block list.\n"
@@ -308,7 +308,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3207
+#: musicbot/bot.py:3206
 msgid ""
 "Manage a block list applied to song requests and extracted song data.\n"
 "A subject may be a song URL or a word or phrase found in the track title.\n"
@@ -319,18 +319,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3235
+#: musicbot/bot.py:3234
 msgid "You must provide a song subject if no song is currently playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3253
+#: musicbot/bot.py:3252
 #, python-format
 msgid "Subject `%(subject)s` is already in the song block list."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3276
+#: musicbot/bot.py:3275
 #, python-format
 msgid ""
 "Added subject `%(subject)s` to the song block list.\n"
@@ -338,12 +338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3285
+#: musicbot/bot.py:3284
 msgid "The subject is not in the song block list and cannot be removed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3293
+#: musicbot/bot.py:3292
 #, python-format
 msgid ""
 "Subject `%(subject)s` has been removed from the block list.\n"
@@ -351,104 +351,104 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3303
+#: musicbot/bot.py:3302
 msgid ""
 "    Adds or removes the specified song or currently playing song to/from the"
 " current playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3306
+#: musicbot/bot.py:3305
 msgid "    Adds the entire queue to the guilds playlist.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3329
+#: musicbot/bot.py:3328
 msgid ""
 "    Set a playlist as default for this guild and reloads the guild auto "
 "playlist.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3373
+#: musicbot/bot.py:3372
 msgid "Invalid sub-command given. Use `help autoplaylist` for usage examples."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3380
+#: musicbot/bot.py:3379
 msgid "The supplied song link is invalid"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3386
+#: musicbot/bot.py:3385
 msgid "The queue is empty. Add some songs with a play command!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3397
+#: musicbot/bot.py:3396
 msgid "All songs in the queue are already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3401
+#: musicbot/bot.py:3400
 #, python-format
 msgid "Added %(number)d songs to the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3411
+#: musicbot/bot.py:3410
 #, python-format
 msgid "Added `%(url)s` to the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3414
+#: musicbot/bot.py:3413
 msgid "This song is already in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3428
+#: musicbot/bot.py:3427
 #, python-format
 msgid "Removed `%(url)s` from the autoplaylist."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3431
+#: musicbot/bot.py:3430
 msgid "This song is not yet in the autoplaylist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3440
+#: musicbot/bot.py:3439
 #, python-format
 msgid "Loaded a fresh copy of the playlist: `%(file)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3465
+#: musicbot/bot.py:3464
 msgid "You must provide a playlist filename."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3485
+#: musicbot/bot.py:3484
 msgid ""
 "\n"
 "This playlist is new, you must add songs to save it to disk!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3490
+#: musicbot/bot.py:3489
 #, python-format
 msgid "The playlist for this server has been updated to: `%(name)s`%(note)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3601
+#: musicbot/bot.py:3600
 msgid ""
 "Generate an invite link that can be used to add this bot to another server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3613
+#: musicbot/bot.py:3612
 #, python-format
 msgid ""
 "Click here to add me to a discord server:\n"
@@ -456,35 +456,35 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3619
+#: musicbot/bot.py:3618
 msgid ""
 "Toggle karaoke mode on or off. While enabled, only karaoke members may queue songs.\n"
 "Groups with BypassKaraokeMode permission control which members are Karaoke members.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3631
+#: musicbot/bot.py:3630
 msgid "\\N{OK HAND SIGN} Karaoke mode is now enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3633
+#: musicbot/bot.py:3632
 msgid "\\N{OK HAND SIGN} Karaoke mode is now disabled."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3656
+#: musicbot/bot.py:3655
 msgid "You are not allowed to request playlists"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3664
+#: musicbot/bot.py:3663
 #, python-format
 msgid "Playlist has too many entries (%(songs)s but max is %(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:3675
+#: musicbot/bot.py:3674
 #, python-format
 msgid ""
 "The playlist entries will exceed your queue limit.\n"
@@ -493,39 +493,39 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3808
+#: musicbot/bot.py:3807
 msgid "Bot was previously paused, resuming playback now."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3856
+#: musicbot/bot.py:3855
 msgid ""
 "Play command that shuffles playlist entries before adding them to the "
 "queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3893
+#: musicbot/bot.py:3892
 #, python-format
 msgid "Shuffled playlist items into the queue from `%(request)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3900
+#: musicbot/bot.py:3899
 msgid ""
 "A play command that adds the song as the next to play rather than last.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3935
+#: musicbot/bot.py:3934
 msgid ""
 "A play command which skips any current song and plays immediately.\n"
 "Read help for the play command for information on supported inputs.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3972
+#: musicbot/bot.py:3971
 msgid ""
 "Restarts the current song at the given time.\n"
 "If time starts with + or - seek will be relative to current playback time.\n"
@@ -534,33 +534,33 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3992
+#: musicbot/bot.py:3991
 msgid "Cannot use seek if there is nothing playing."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3997
+#: musicbot/bot.py:3996
 msgid "Cannot use seek on current track, it has an unknown duration."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4003
+#: musicbot/bot.py:4002
 msgid "Seeking is not supported for streams."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4013
+#: musicbot/bot.py:4012
 msgid "Cannot use seek without a time to position playback."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4031
+#: musicbot/bot.py:4030
 #, python-format
 msgid "Could not convert `%(input)s` to a valid time in seconds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4044
+#: musicbot/bot.py:4043
 #, python-format
 msgid ""
 "Cannot seek to `%(input)s` (`%(seconds)s` seconds) in the current track with"
@@ -568,14 +568,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4068
+#: musicbot/bot.py:4067
 #, python-format
 msgid ""
 "Seeking to time `%(input)s` (`%(seconds).2f` seconds) in the current song."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4080
+#: musicbot/bot.py:4079
 msgid ""
 "Toggles playlist or song looping.\n"
 "If no option is provided the current song will be repeated.\n"
@@ -583,84 +583,84 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4098
+#: musicbot/bot.py:4097
 msgid "No songs are currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4105
+#: musicbot/bot.py:4104
 msgid "Invalid sub-command. Use the command `help repeat` for usage examples."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4111 musicbot/bot.py:4148
+#: musicbot/bot.py:4110 musicbot/bot.py:4147
 msgid "Playlist is now repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4114 musicbot/bot.py:4141 musicbot/bot.py:4152
+#: musicbot/bot.py:4113 musicbot/bot.py:4140 musicbot/bot.py:4151
 msgid "Playlist is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4120 musicbot/bot.py:4129
+#: musicbot/bot.py:4119 musicbot/bot.py:4128
 msgid "Player will now loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4122 musicbot/bot.py:4136
+#: musicbot/bot.py:4121 musicbot/bot.py:4135
 msgid "Player will no longer loop the current song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4126
+#: musicbot/bot.py:4125
 msgid "Player is already looping a song!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4143
+#: musicbot/bot.py:4142
 msgid "The player is not currently looping."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4154
+#: musicbot/bot.py:4153
 msgid "Song is no longer repeating."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4158
+#: musicbot/bot.py:4157
 msgid "Song is now repeating."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4166
+#: musicbot/bot.py:4165
 msgid "    Move song at position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4170
+#: musicbot/bot.py:4169
 msgid ""
 "Swap existing songs in the queue using their position numbers.\n"
 "Use the queue command to find track position numbers.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4189
+#: musicbot/bot.py:4188
 msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4199
+#: musicbot/bot.py:4198 musicbot/bot.py:5344
 msgid "Song positions must be integers!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4204
+#: musicbot/bot.py:4203
 msgid "You gave a position outside the playlist size!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4299
+#: musicbot/bot.py:4298
 #, python-format
 msgid ""
 "This link contains a Playlist ID:\n"
@@ -670,28 +670,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4341
+#: musicbot/bot.py:4340
 msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4384
+#: musicbot/bot.py:4383
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4398 musicbot/bot.py:4603
+#: musicbot/bot.py:4397 musicbot/bot.py:4603
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4404 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3553 musicbot/bot.py:4420 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,7 +699,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4426
+#: musicbot/bot.py:4425
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
@@ -860,7 +860,7 @@ msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6318 musicbot/bot.py:6350
+#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
 msgid "[autoplaylist]"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6297
+#: musicbot/bot.py:5055 musicbot/bot.py:6361
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
@@ -1002,58 +1002,49 @@ msgstr ""
 msgid "Cleared all songs from the queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:5301
-msgid ""
-"Remove a song from the queue, optionally at the given queue position.\n"
-"If the position is omitted, the song at the end of the queue is removed.\n"
-"Use the queue command to find position number of your track.\n"
-"However, positions of all songs are changed when a new song starts playing.\n"
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:5321
+#: musicbot/bot.py:5335
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5336
+#: musicbot/bot.py:5398
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5342
+#: musicbot/bot.py:5404
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5347 musicbot/bot.py:5383
+#: musicbot/bot.py:5409 musicbot/bot.py:5447
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5358 musicbot/bot.py:5363
+#: musicbot/bot.py:5422 musicbot/bot.py:5427
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5373
+#: musicbot/bot.py:5437
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5442
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5390
+#: musicbot/bot.py:5454
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1061,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5414
+#: musicbot/bot.py:5478
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5422
+#: musicbot/bot.py:5486
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5430
+#: musicbot/bot.py:5494
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5435
+#: musicbot/bot.py:5499
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5506
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5466
+#: musicbot/bot.py:5530
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5480
+#: musicbot/bot.py:5544
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5550
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5523 musicbot/bot.py:5556
+#: musicbot/bot.py:5587 musicbot/bot.py:5620
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5539
+#: musicbot/bot.py:5603
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1120,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5546
+#: musicbot/bot.py:5610
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5563
+#: musicbot/bot.py:5627
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1133,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5576
+#: musicbot/bot.py:5640
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1141,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5593
+#: musicbot/bot.py:5657
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5606
+#: musicbot/bot.py:5670
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5641
+#: musicbot/bot.py:5705
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5647
+#: musicbot/bot.py:5711
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1167,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5721
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5664
+#: musicbot/bot.py:5728
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1182,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5681
+#: musicbot/bot.py:5745
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5689
+#: musicbot/bot.py:5753
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5694
+#: musicbot/bot.py:5758
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5722
+#: musicbot/bot.py:5786
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5731
+#: musicbot/bot.py:5795
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5741
+#: musicbot/bot.py:5805
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5762 musicbot/bot.py:5878 musicbot/bot.py:6810
+#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5768
+#: musicbot/bot.py:5832
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5773
+#: musicbot/bot.py:5837
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5776
+#: musicbot/bot.py:5840
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1241,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5783
+#: musicbot/bot.py:5847
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5789
+#: musicbot/bot.py:5853
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5862
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5803
+#: musicbot/bot.py:5867
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5809
+#: musicbot/bot.py:5873
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5819
+#: musicbot/bot.py:5883
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5822
+#: musicbot/bot.py:5886
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5825
+#: musicbot/bot.py:5889
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5828
+#: musicbot/bot.py:5892
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5831
+#: musicbot/bot.py:5895
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5834
+#: musicbot/bot.py:5898
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5904
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5846
+#: musicbot/bot.py:5910
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5861
+#: musicbot/bot.py:5925
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5890
+#: musicbot/bot.py:5954
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5911
+#: musicbot/bot.py:5975
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5913
+#: musicbot/bot.py:5977
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1336,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5933
+#: musicbot/bot.py:5997
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1347,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5955
+#: musicbot/bot.py:6019
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:6023
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1360,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:6041
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5981
+#: musicbot/bot.py:6045
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5987
+#: musicbot/bot.py:6051
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6003
+#: musicbot/bot.py:6067
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1385,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6011
+#: musicbot/bot.py:6075
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6083
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6087
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6028
+#: musicbot/bot.py:6092
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1412,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6039
+#: musicbot/bot.py:6103
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6048
+#: musicbot/bot.py:6112
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6053
+#: musicbot/bot.py:6117
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6063
+#: musicbot/bot.py:6127
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6077
+#: musicbot/bot.py:6141
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1445,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6093
+#: musicbot/bot.py:6157
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6099 musicbot/bot.py:7023
+#: musicbot/bot.py:6163 musicbot/bot.py:7107
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6110
+#: musicbot/bot.py:6174
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6115
+#: musicbot/bot.py:6179
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1470,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6126
+#: musicbot/bot.py:6190
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6145
+#: musicbot/bot.py:6209
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6150
+#: musicbot/bot.py:6214
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1490,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6165
+#: musicbot/bot.py:6229
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6178
+#: musicbot/bot.py:6242
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6185
+#: musicbot/bot.py:6249
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6198
+#: musicbot/bot.py:6262
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6273
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6212
+#: musicbot/bot.py:6276
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6218 musicbot/bot.py:6221
+#: musicbot/bot.py:6282 musicbot/bot.py:6285
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6226
+#: musicbot/bot.py:6290
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1544,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6313
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6255
+#: musicbot/bot.py:6319
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6258
+#: musicbot/bot.py:6322
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6266
+#: musicbot/bot.py:6330
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6354
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6304
+#: musicbot/bot.py:6368
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1579,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6316
+#: musicbot/bot.py:6380
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6325
+#: musicbot/bot.py:6389
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1593,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6363
+#: musicbot/bot.py:6447
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1603,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6376
+#: musicbot/bot.py:6460
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6396
+#: musicbot/bot.py:6480
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6531
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1623,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6471
+#: musicbot/bot.py:6555
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6506
+#: musicbot/bot.py:6590
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6513
+#: musicbot/bot.py:6597
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6517
+#: musicbot/bot.py:6601
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6538
+#: musicbot/bot.py:6622
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6548
+#: musicbot/bot.py:6632
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1657,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6553
+#: musicbot/bot.py:6637
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6573
+#: musicbot/bot.py:6657
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6583
+#: musicbot/bot.py:6667
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6598
+#: musicbot/bot.py:6682
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6603
+#: musicbot/bot.py:6687
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6610
+#: musicbot/bot.py:6694
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1695,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6716
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6679
+#: musicbot/bot.py:6763
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6723
+#: musicbot/bot.py:6807
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6730
+#: musicbot/bot.py:6814
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1721,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6739
+#: musicbot/bot.py:6823
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1731,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6755
+#: musicbot/bot.py:6839
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6758
+#: musicbot/bot.py:6842
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6761
+#: musicbot/bot.py:6845
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6764
+#: musicbot/bot.py:6848
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6767
+#: musicbot/bot.py:6851
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6854
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6773
+#: musicbot/bot.py:6857
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6776
+#: musicbot/bot.py:6860
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6779
+#: musicbot/bot.py:6863
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6794
+#: musicbot/bot.py:6878
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6825
+#: musicbot/bot.py:6909
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6849
+#: musicbot/bot.py:6933
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1796,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6866
+#: musicbot/bot.py:6950
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6870
+#: musicbot/bot.py:6954
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6884
+#: musicbot/bot.py:6968
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6896
+#: musicbot/bot.py:6980
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1820,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6907
+#: musicbot/bot.py:6991
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6915
+#: musicbot/bot.py:6999
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6924
+#: musicbot/bot.py:7008
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6929
+#: musicbot/bot.py:7013
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1847,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6943
+#: musicbot/bot.py:7027
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6961
+#: musicbot/bot.py:7045
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:7052
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1866,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6979 musicbot/bot.py:7018
+#: musicbot/bot.py:7063 musicbot/bot.py:7102
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6987
+#: musicbot/bot.py:7071
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:7075
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7002
+#: musicbot/bot.py:7086
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1892,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7034
+#: musicbot/bot.py:7118
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7039
+#: musicbot/bot.py:7123
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1906,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7159
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7081
+#: musicbot/bot.py:7165
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1921,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7170
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7089
+#: musicbot/bot.py:7173
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7103
+#: musicbot/bot.py:7187
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7111
+#: musicbot/bot.py:7195
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1945,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7116
+#: musicbot/bot.py:7200
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7207
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7125
+#: musicbot/bot.py:7209
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7129
+#: musicbot/bot.py:7213
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7151
+#: musicbot/bot.py:7235
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7157
+#: musicbot/bot.py:7241
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7162
+#: musicbot/bot.py:7246
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7168
+#: musicbot/bot.py:7252
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7249
+#: musicbot/bot.py:7333
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7353
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7279
+#: musicbot/bot.py:7363
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2011,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7283
+#: musicbot/bot.py:7367
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7286
+#: musicbot/bot.py:7370
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7297
+#: musicbot/bot.py:7381
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7312
+#: musicbot/bot.py:7396
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7316
+#: musicbot/bot.py:7400
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7324
+#: musicbot/bot.py:7408
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7326
+#: musicbot/bot.py:7410
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7328
+#: musicbot/bot.py:7412
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7330
+#: musicbot/bot.py:7414
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7332
+#: musicbot/bot.py:7416
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7336
+#: musicbot/bot.py:7420
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2075,110 +2066,110 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7357
+#: musicbot/bot.py:7441
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7447
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7368
+#: musicbot/bot.py:7452
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7373
+#: musicbot/bot.py:7457
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7378
+#: musicbot/bot.py:7462
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7383
+#: musicbot/bot.py:7467
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7417
+#: musicbot/bot.py:7501
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7443
+#: musicbot/bot.py:7527
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7531
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7466
+#: musicbot/bot.py:7550
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7477
+#: musicbot/bot.py:7561
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
 
 #. TRANSLATORS: Placeholder for empty track title.
 #. Used by: _X
-#: musicbot/entry.py:299 musicbot/entry.py:821 musicbot/entry.py:1020
+#: musicbot/entry.py:299 musicbot/entry.py:826 musicbot/entry.py:1025
 msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7492
+#: musicbot/bot.py:7576
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7535
+#: musicbot/bot.py:7619
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7542
+#: musicbot/bot.py:7626
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7545
+#: musicbot/bot.py:7629
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7548
+#: musicbot/bot.py:7632
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7551
+#: musicbot/bot.py:7635
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7558
+#: musicbot/bot.py:7642
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2186,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7574
+#: musicbot/bot.py:7658
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7612
+#: musicbot/bot.py:7696
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2206,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7665
+#: musicbot/bot.py:7749
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2217,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7700 musicbot/bot.py:7761
+#: musicbot/bot.py:7784 musicbot/bot.py:7845
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7750
+#: musicbot/bot.py:7834
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7771
+#: musicbot/bot.py:7855
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7776
+#: musicbot/bot.py:7860
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7800
+#: musicbot/bot.py:7884
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7918
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7839
+#: musicbot/bot.py:7923
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7845 musicbot/bot.py:7888
+#: musicbot/bot.py:7929 musicbot/bot.py:7972
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7879
+#: musicbot/bot.py:7963
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7885
+#: musicbot/bot.py:7969
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7891
+#: musicbot/bot.py:7975
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7893
+#: musicbot/bot.py:7977
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7897
+#: musicbot/bot.py:7981
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2296,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7911
+#: musicbot/bot.py:7995
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7926
+#: musicbot/bot.py:8010
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7933
+#: musicbot/bot.py:8017
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:8047
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:8065
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:7998
+#: musicbot/bot.py:8082
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8005
+#: musicbot/bot.py:8089
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8094
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8018
+#: musicbot/bot.py:8102
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2349,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8030
+#: musicbot/bot.py:8114
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8033
+#: musicbot/bot.py:8117
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8037
+#: musicbot/bot.py:8121
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2374,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8058
+#: musicbot/bot.py:8142
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8149
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8078
+#: musicbot/bot.py:8162
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8081
+#: musicbot/bot.py:8165
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8092
+#: musicbot/bot.py:8176
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2403,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8096
+#: musicbot/bot.py:8180
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8101
+#: musicbot/bot.py:8185
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8119
+#: musicbot/bot.py:8203
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8124
+#: musicbot/bot.py:8208
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8132
+#: musicbot/bot.py:8216
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8242
+#: musicbot/bot.py:8326
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8323
+#: musicbot/bot.py:8407
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8358
+#: musicbot/bot.py:8442
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8462
+#: musicbot/bot.py:8546
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8516
+#: musicbot/bot.py:8600
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8560
+#: musicbot/bot.py:8644
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2466,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8564
+#: musicbot/bot.py:8648
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8567
+#: musicbot/bot.py:8651
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8601
+#: musicbot/bot.py:8685
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2486,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8654
+#: musicbot/bot.py:8738
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8950
+#: musicbot/bot.py:9034
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2941,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:979
+#: musicbot/config.py:1006
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1003
+#: musicbot/config.py:1030
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:989
+#: musicbot/config.py:1016
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1015
+#: musicbot/config.py:1042
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1028
+#: musicbot/config.py:1055
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1041
+#: musicbot/config.py:1068
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2981,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1061
+#: musicbot/config.py:1088
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1073
+#: musicbot/config.py:1100
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2997,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1086
+#: musicbot/config.py:1113
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -3006,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1190
+#: musicbot/config.py:1217
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3018,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1211
+#: musicbot/config.py:1238
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3032,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1234
+#: musicbot/config.py:1261
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3045,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1372
+#: musicbot/config.py:1400
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3059,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1390
+#: musicbot/config.py:1418
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3074,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2255
+#: musicbot/config.py:2289
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3087,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2291
+#: musicbot/config.py:2325
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3100,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2321
+#: musicbot/config.py:2355
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3113,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:249
+#: musicbot/downloader.py:270
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:402
+#: musicbot/downloader.py:423
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:468
+#: musicbot/downloader.py:489
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:477
+#: musicbot/downloader.py:498
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:528
+#: musicbot/downloader.py:549
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:603
+#: musicbot/downloader.py:623
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3155,13 +3146,13 @@ msgid "Download failed due to a yt-dlp error: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/entry.py:751
+#: musicbot/entry.py:756
 #, python-format
 msgid "Download failed due to an unhandled exception: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/entry.py:757
+#: musicbot/entry.py:762
 msgid "Failed to extract data for the requested media."
 msgstr ""
 
@@ -3287,22 +3278,22 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:159
+#: musicbot/playlist.py:173
 msgid "Could not extract information"
 msgstr ""
 
 #. Used by: WrongEntryTypeError
-#: musicbot/playlist.py:163
+#: musicbot/playlist.py:177
 msgid "This is a playlist."
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:495
+#: musicbot/playlist.py:509
 msgid "no duration data"
 msgstr ""
 
 #. Used by: InvalidDataError
-#: musicbot/playlist.py:504
+#: musicbot/playlist.py:518
 msgid "no duration data in current entry"
 msgstr ""
 
@@ -3385,32 +3376,32 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:2788
+#: musicbot/bot.py:2787
 #, python-format
 msgid "The requested song `%(subject)s` is blocked by the song block list."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3241
+#: musicbot/bot.py:3240
 msgid "Invalid sub-command given. Use `help blocksong` for usage examples."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3321
+#: musicbot/bot.py:3320
 msgid ""
 "    Show the currently selected playlist and a list of existing playlist "
 "files.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3325
+#: musicbot/bot.py:3324
 msgid ""
 "    Reload the auto playlist queue, restarting at the first track unless "
 "randomized.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3454
+#: musicbot/bot.py:3453
 #, python-format
 msgid ""
 "**Current Playlist:** `%(playlist)s`**Available Playlists:**\n"
@@ -3418,19 +3409,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3505 musicbot/bot.py:3528 musicbot/bot.py:3590
+#: musicbot/bot.py:3504 musicbot/bot.py:3527 musicbot/bot.py:3589
 #, python-format
 msgid "No playlist file exists with the name: `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3511
+#: musicbot/bot.py:3510
 #, python-format
 msgid "The playlist `%(playlist)s` has been cleared."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3817
+#: musicbot/bot.py:3816
 msgid ""
 "Add a song to be played in the queue. If no song is playing or paused, playback will be started.\n"
 "\n"
@@ -3441,21 +3432,15 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4211
+#: musicbot/bot.py:4210
 #, python-format
 msgid ""
 "Successfully moved song from position %(from)s in queue to position %(to)s!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4388
+#: musicbot/bot.py:4387
 msgid "Detected a Spotify URL, but Spotify is not enabled."
-msgstr ""
-
-#. Used by: CommandError
-#: musicbot/bot.py:4437
-#, python-format
-msgid "YouTube search returned no results for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
@@ -3472,50 +3457,50 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5703
+#: musicbot/bot.py:5767
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5734
+#: musicbot/bot.py:5798
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5737
+#: musicbot/bot.py:5801
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5901
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5843
+#: musicbot/bot.py:5907
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6522
+#: musicbot/bot.py:6606
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6686
+#: musicbot/bot.py:6770
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6800
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6829
+#: musicbot/bot.py:6913
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3523,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6951
+#: musicbot/bot.py:7035
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3532,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7056
+#: musicbot/bot.py:7140
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7176
+#: musicbot/bot.py:7260
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7179
+#: musicbot/bot.py:7263
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7182
+#: musicbot/bot.py:7266
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7185
+#: musicbot/bot.py:7269
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7198
+#: musicbot/bot.py:7282
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7203
+#: musicbot/bot.py:7287
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7214
+#: musicbot/bot.py:7298
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3579,42 +3564,42 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7224
+#: musicbot/bot.py:7308
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7229
+#: musicbot/bot.py:7313
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7237
+#: musicbot/bot.py:7321
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7585
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7524
+#: musicbot/bot.py:7608
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7554
+#: musicbot/bot.py:7638
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7683
+#: musicbot/bot.py:7767
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
@@ -3657,7 +3642,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1107
+#: musicbot/config.py:1134
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3671,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1141
+#: musicbot/config.py:1168
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3689,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1291
+#: musicbot/config.py:1319
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3702,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1309
+#: musicbot/config.py:1337
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3749,7 +3734,7 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/playlist.py:195
+#: musicbot/playlist.py:209
 #, python-format
 msgid "Invalid content type `%(type)s` for URL: %(url)s"
 msgstr ""
@@ -3762,61 +3747,61 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7485
+#: musicbot/bot.py:7569
 msgid "Unknown Owner"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed title.
 #. Used by: _D
-#: musicbot/constructs.py:420
+#: musicbot/constructs.py:458
 #, python-format
 msgid "## %(title)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed description.
 #. Used by: _D
-#: musicbot/constructs.py:423
+#: musicbot/constructs.py:461
 #, python-format
 msgid "%(content)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed url.
 #. Used by: _D
-#: musicbot/constructs.py:426
+#: musicbot/constructs.py:464
 #, python-format
 msgid "%(url)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field name and value.
 #. Used by: _D
-#: musicbot/constructs.py:432
+#: musicbot/constructs.py:470
 #, python-format
 msgid "**%(name)s** %(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed field without a name.
 #. Used by: _D
-#: musicbot/constructs.py:438
+#: musicbot/constructs.py:476
 #, python-format
 msgid "%(value)s\n"
 msgstr ""
 
 #. TRANSLATORS: text-only format for embed image or thumbnail.
 #. Used by: _D
-#: musicbot/constructs.py:443 musicbot/constructs.py:445
+#: musicbot/constructs.py:481 musicbot/constructs.py:483
 #, python-format
 msgid "%(url)s"
 msgstr ""
 
 #. TRANSLATORS: text-only format template for embeds converted to markdown.
 #. Used by: _D
-#: musicbot/constructs.py:449
+#: musicbot/constructs.py:487
 #, python-format
 msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7958
+#: musicbot/bot.py:8042
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3824,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7972
+#: musicbot/bot.py:8056
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3834,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8000
+#: musicbot/bot.py:8084
 #, python-format
 msgid ""
 "\n"
@@ -3858,40 +3843,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3310
+#: musicbot/bot.py:3309
 msgid ""
 "    Add all tracks in the given auto playlist to the normal playback queue.\n"
 "    If playlist name is omitted, the currently loaded playlist is used.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3316
+#: musicbot/bot.py:3315
 msgid ""
 "    Clear all songs from the named playlist file.\n"
 "    If playlist name is omitted, the currently loaded playlist is emptied.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:3333
+#: musicbot/bot.py:3332
 msgid ""
 "    Reload the given playlist from disk into memory, but does not update the"
 " current auto playlist queue."
 msgstr ""
 
-#. Used by: _Dd
-#: musicbot/bot.py:3338
-msgid ""
-"Manage auto playlist files and per-guild settings.\n"
-"Auto playlists use a their own queue, only playing when the main queue is empty."
-msgstr ""
-
 #. Used by: CommandError
-#: musicbot/bot.py:3518
+#: musicbot/bot.py:3517
 msgid "You must be in a voice channel to use this command."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3533
+#: musicbot/bot.py:3532
 #, python-format
 msgid ""
 "The tracks in playlist `%(playlist)s` will be added to the queue.\n"
@@ -3899,13 +3877,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3575
+#: musicbot/bot.py:3574
 #, python-format
 msgid "Added %(number)d track(s) to the queue from playlist `%(playlist)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:3594
+#: musicbot/bot.py:3593
 msgid "The playlist has been reloaded from disk."
 msgstr ""
 
@@ -3924,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5959
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3933,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6355
+#: musicbot/bot.py:6425
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3964,28 +3942,119 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:511
+#: musicbot/downloader.py:532
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:553
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:624
+#: musicbot/downloader.py:644
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1192 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5042
 msgid "URL:"
 msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:3337
+msgid ""
+"Manage auto playlist files and per-guild settings.\n"
+"Auto playlists use their own queue, only playing when the main queue is empty."
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:4436
+#, python-format
+msgid "Search returned no results with %(extractor)s for:  %(url)s"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5301
+msgid "    Remove a song at the end of the queue or at [POSITION].\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5303
+msgid "    Remove songs from position FROM to position TO.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5304
+msgid "    Remove songs added by the mentioned user.\n"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/bot.py:5307
+msgid ""
+"Remove a song from the queue at POSITION specified.\n"
+"Remove multiple songs from the queue from position FROM to position TO specified.\n"
+"Remove all songs from the queue added by the mentioned user.\n"
+"If the user-mention, position or positions are omitted, the song at the end of the queue is removed.\n"
+"Use the queue command to find position number of your track.\n"
+"However, positions of all songs are changed when a new song starts playing.\n"
+msgstr ""
+
+#. Used by: CommandError
+#: musicbot/bot.py:5349
+msgid "Invalid positions. Use the queue command to find queue positions."
+msgstr ""
+
+#. Used by: PermissionsError
+#: musicbot/bot.py:5371
+msgid ""
+"You do not have the permission to remove all the songs in the given range "
+"from the queue.\n"
+msgstr ""
+
+#. Used by: _D
+#: musicbot/bot.py:5378
+#, python-format
+msgid "Successfully removed songs %(from)s through %(to)s!"
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:978
+msgid ""
+"The number of threads used to download a (one) track.\n"
+"Higher number is faster at the cost of CPU and network load.\n"
+"Effectively the same as ytdlp -N or --concurrent-fragments option.\n"
+"This option has no effect on streams."
+msgstr ""
+
+#. Used by: _Dd
+#: musicbot/config.py:992
+msgid ""
+"The number of threads MusicBot may use for yt-dlp calls.\n"
+"Most useful for multi-server bot's with high traffic.\n"
+"These threads are spawned as-needed, not immediately.\n"
+"NOTE: Each thread may spawn up to YtdlpConcurrentFrags child-threads."
+msgstr ""
+
+#~ msgid ""
+#~ "Remove a song from the queue, optionally at the given queue position.\n"
+#~ "If the position is omitted, the song at the end of the queue is removed.\n"
+#~ "Use the queue command to find position number of your track.\n"
+#~ "However, positions of all songs are changed when a new song starts playing.\n"
+#~ msgstr ""
+
+#, python-format
+#~ msgid "YouTube search returned no results for:  %(url)s"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Manage auto playlist files and per-guild settings.\n"
+#~ "Auto playlists use a their own queue, only playing when the main queue is empty."
+#~ msgstr ""
 
 #~ msgid "Manage auto playlist files and per-guild settings."
 #~ msgstr ""

--- a/i18n/zh_TW/LC_MESSAGES/musicbot_messages.po
+++ b/i18n/zh_TW/LC_MESSAGES/musicbot_messages.po
@@ -1,7 +1,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 235ee4c\n"
+"Project-Id-Version: 3184b27\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-04 08:15-0800\n"
 "PO-Revision-Date: 2024-11-06 14:31\n"
@@ -650,7 +650,7 @@ msgid "There are no songs queued. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4198 musicbot/bot.py:5344
+#: musicbot/bot.py:4198 musicbot/bot.py:5346
 msgid "Song positions must be integers!"
 msgstr ""
 
@@ -675,23 +675,23 @@ msgid "Local media playback is not enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4383
+#: musicbot/bot.py:4385
 msgid "Spotify URL is invalid or not currently supported."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4397 musicbot/bot.py:4603
+#: musicbot/bot.py:4399 musicbot/bot.py:4605
 #, python-format
 msgid "You have reached your enqueued song limit (%(max)s)"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4403 musicbot/bot.py:4609 musicbot/bot.py:4706
+#: musicbot/bot.py:4405 musicbot/bot.py:4611 musicbot/bot.py:4708
 msgid "Karaoke mode is enabled, please try again when its disabled!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:3552 musicbot/bot.py:4419 musicbot/bot.py:4625
+#: musicbot/bot.py:3552 musicbot/bot.py:4421 musicbot/bot.py:4627
 #, python-format
 msgid ""
 "Failed to extract info due to error:\n"
@@ -699,19 +699,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4425
+#: musicbot/bot.py:4427
 msgid "That video cannot be played. Try using the stream command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4478
+#: musicbot/bot.py:4480
 #, python-format
 msgid ""
 "No songs were added, all songs were over max duration (%(max)s seconds)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4483
+#: musicbot/bot.py:4485
 #, python-format
 msgid ""
 "Enqueued **%(number)s** songs to be played.\n"
@@ -719,13 +719,13 @@ msgid ""
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4506
+#: musicbot/bot.py:4508
 #, python-format
 msgid "Song duration exceeds limit (%(length)s > %(max)s)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4518
+#: musicbot/bot.py:4520
 #, python-format
 msgid ""
 "Enqueued `%(track)s` to be played.\n"
@@ -733,24 +733,24 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4526 musicbot/bot.py:4541
+#: musicbot/bot.py:4528 musicbot/bot.py:4543
 msgid "Playing next!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4549
+#: musicbot/bot.py:4551
 #, python-format
 msgid "%(position)s - estimated time until playing: `%(eta)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4557
+#: musicbot/bot.py:4559
 #, python-format
 msgid "%(position)s - cannot estimate time until playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4575
+#: musicbot/bot.py:4577
 msgid ""
 "Add a media URL to the queue as a Stream.\n"
 "The URL may be actual streaming media, like Twitch, Youtube, or a shoutcast like service.\n"
@@ -759,292 +759,292 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4631
+#: musicbot/bot.py:4633
 msgid "Streaming playlists is not yet supported."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4648
+#: musicbot/bot.py:4650
 #, python-format
 msgid "Now streaming track `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4657
+#: musicbot/bot.py:4659
 msgid "    Search with service for a number of results with the search query.\n"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:4700
+#: musicbot/bot.py:4702
 #, python-format
 msgid "You have reached your playlist item limit (%(max)s)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4712
+#: musicbot/bot.py:4714
 msgid ""
 "Please specify a search query.  Use `help search` for more information."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4748
+#: musicbot/bot.py:4750
 #, python-format
 msgid "You cannot search for more than %(max)s videos"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4771
+#: musicbot/bot.py:4773
 msgid "Searching for videos..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4793
+#: musicbot/bot.py:4795
 #, python-format
 msgid "Search failed due to an error: %(error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4805
+#: musicbot/bot.py:4807
 msgid "No videos found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4814
+#: musicbot/bot.py:4816
 msgid "To select a song, type the corresponding number."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4815
+#: musicbot/bot.py:4817
 #, python-format
 msgid "Search results from %(service)s:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4824
+#: musicbot/bot.py:4826
 #, python-format
 msgid "**%(index)s**. **%(track)s** | %(length)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4833
+#: musicbot/bot.py:4835
 msgid ""
 "\n"
 "**0**. Cancel"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4837
+#: musicbot/bot.py:4839
 msgid "Pick a song"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4888
+#: musicbot/bot.py:4890
 #, python-format
 msgid "Added song [%(track)s](%(url)s) to the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4902
+#: musicbot/bot.py:4904
 #, python-format
 msgid "Result %(number)s of %(total)s: %(url)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:4952
+#: musicbot/bot.py:4954
 msgid "Alright, coming right up!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4964
+#: musicbot/bot.py:4966
 msgid "Show information on what is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5016 musicbot/bot.py:6382 musicbot/bot.py:6415
+#: musicbot/bot.py:5018 musicbot/bot.py:6384 musicbot/bot.py:6417
 msgid "[autoplaylist]"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5020
+#: musicbot/bot.py:5022
 msgid "Now playing"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5023
+#: musicbot/bot.py:5025
 msgid "Currently streaming:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5025
+#: musicbot/bot.py:5027
 msgid "Currently playing:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5031
+#: musicbot/bot.py:5033
 msgid "Added By:"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5032
+#: musicbot/bot.py:5034
 #, python-format
 msgid "`%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5036
+#: musicbot/bot.py:5038
 msgid "Progress:"
 msgstr ""
 
 #. Used by: _D
 #. Used by: CommandError
-#: musicbot/bot.py:5055 musicbot/bot.py:6361
+#: musicbot/bot.py:5057 musicbot/bot.py:6363
 msgid "There are no songs queued! Queue something with a play command."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5058
+#: musicbot/bot.py:5060
 msgid "Tell MusicBot to join the channel you're in."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5081
+#: musicbot/bot.py:5083
 msgid "You are not connected to voice. Try joining a voice channel!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5116
+#: musicbot/bot.py:5118
 #, python-format
 msgid "Connected to `%(channel)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5122
+#: musicbot/bot.py:5124
 msgid "Makes MusicBot follow a user when they change channels in a server.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5145
+#: musicbot/bot.py:5147
 #, python-format
 msgid "No longer following user `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5155
+#: musicbot/bot.py:5157
 #, python-format
 msgid "Now following user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5168
+#: musicbot/bot.py:5170
 msgid "MusicBot cannot follow a user that is not a member of the server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5175
+#: musicbot/bot.py:5177
 #, python-format
 msgid "Will follow user `%(user)s` between voice channels."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5181
+#: musicbot/bot.py:5183
 msgid "Pause playback if a track is currently playing."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5192
+#: musicbot/bot.py:5194
 #, python-format
 msgid "Paused music in `%(channel)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5196
+#: musicbot/bot.py:5198
 msgid "Player is not playing."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5198
+#: musicbot/bot.py:5200
 msgid "Resumes playback if the player was previously paused."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5209
+#: musicbot/bot.py:5211
 #, python-format
 msgid "Resumed music in `%(channel)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5215
+#: musicbot/bot.py:5217
 msgid "Resumed music queue"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5217
+#: musicbot/bot.py:5219
 msgid "Player is not paused."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5219
+#: musicbot/bot.py:5221
 msgid "Shuffle all current tracks in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5254
+#: musicbot/bot.py:5256
 msgid "Shuffled all songs in the queue."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5256
+#: musicbot/bot.py:5258
 msgid "Removes all songs currently in the queue."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5296
+#: musicbot/bot.py:5298
 msgid "Cleared all songs from the queue."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5335
+#: musicbot/bot.py:5337
 msgid "Nothing in the queue to remove!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5398
+#: musicbot/bot.py:5400
 #, python-format
 msgid "Removed `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5404
+#: musicbot/bot.py:5406
 #, python-format
 msgid "Nothing found in the queue from user `%(user)s`"
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5409 musicbot/bot.py:5447
+#: musicbot/bot.py:5411 musicbot/bot.py:5449
 msgid ""
 "You do not have the permission to remove that entry from the queue.\n"
 "You must be the one who queued it or have instant skip permissions."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5422 musicbot/bot.py:5427
+#: musicbot/bot.py:5424 musicbot/bot.py:5429
 msgid "Invalid entry number. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5437
+#: musicbot/bot.py:5439
 #, python-format
 msgid "Removed entry `%(track)s` added by `%(user)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5442
+#: musicbot/bot.py:5444
 #, python-format
 msgid "Removed entry `%(track)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5454
+#: musicbot/bot.py:5456
 msgid ""
 "Skip or vote to skip the current playing song.\n"
 "Members with InstaSkip permission may use force parameter to bypass voting.\n"
@@ -1052,58 +1052,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5478
+#: musicbot/bot.py:5480
 msgid "Can't skip! The player is not playing!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5486
+#: musicbot/bot.py:5488
 #, python-format
 msgid "The next song `%(track)s` is downloading, please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5494
+#: musicbot/bot.py:5496
 msgid "The next song will be played shortly. Please wait."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5499
+#: musicbot/bot.py:5501
 msgid ""
 "Something odd is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5506
+#: musicbot/bot.py:5508
 msgid ""
 "Something strange is happening.\n"
 "You might want to restart the bot if it doesn't start working."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5530
+#: musicbot/bot.py:5532
 msgid "You do not have permission to force skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5544
+#: musicbot/bot.py:5546
 #, python-format
 msgid "Force skipped `%(track)s`."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5550
+#: musicbot/bot.py:5552
 msgid "You do not have permission to force skip."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5587 musicbot/bot.py:5620
+#: musicbot/bot.py:5589 musicbot/bot.py:5622
 msgid "You do not have permission to skip a looped song."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5603
+#: musicbot/bot.py:5605
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1111,12 +1111,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5610
+#: musicbot/bot.py:5612
 msgid " Next song coming up!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5627
+#: musicbot/bot.py:5629
 #, python-format
 msgid ""
 "Your skip for `%(track)s` was acknowledged.\n"
@@ -1124,7 +1124,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5640
+#: musicbot/bot.py:5642
 msgid ""
 "Set the output volume level of MusicBot from 1 to 100.\n"
 "Volume parameter allows a leading + or - for relative adjustments.\n"
@@ -1132,25 +1132,25 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5657
+#: musicbot/bot.py:5659
 #, python-format
 msgid "Current volume: `%(volume)s%%`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5670
+#: musicbot/bot.py:5672
 #, python-format
 msgid "`%(new_volume)s` is not a valid number"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5705
+#: musicbot/bot.py:5707
 #, python-format
 msgid "Updated volume from **%(old)d** to **%(new)d**"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5711
+#: musicbot/bot.py:5713
 #, python-format
 msgid ""
 "Unreasonable volume change provided: %(old_volume)s%(adjustment)s is %(new_volume)s.\n"
@@ -1158,14 +1158,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5721
+#: musicbot/bot.py:5723
 #, python-format
 msgid ""
 "Unreasonable volume provided: %(volume)s. Provide a value between 1 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5728
+#: musicbot/bot.py:5730
 msgid ""
 "Change the playback speed of the currently playing track only.\n"
 "The rate must be between 0.5 and 100.0 due to ffmpeg limits.\n"
@@ -1173,58 +1173,58 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5745
+#: musicbot/bot.py:5747
 msgid ""
 "No track is playing, cannot set speed.\n"
 "Use the config command to set a default playback speed."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5753
+#: musicbot/bot.py:5755
 msgid "Speed cannot be applied to streamed media."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5758
+#: musicbot/bot.py:5760
 msgid "You must provide a speed to set."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5786
+#: musicbot/bot.py:5788
 #, python-format
 msgid "Setting playback speed to `%(speed).3f` for current track."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5795
+#: musicbot/bot.py:5797
 msgid "    Add an new alias with optional arguments.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5805
+#: musicbot/bot.py:5807
 msgid ""
 "Allows management of aliases from discord. To see aliases use the help "
 "command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5826 musicbot/bot.py:5942 musicbot/bot.py:6894
+#: musicbot/bot.py:5828 musicbot/bot.py:5944 musicbot/bot.py:6896
 #, python-format
 msgid "Invalid option for command: `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5832
+#: musicbot/bot.py:5834
 msgid "Aliases reloaded from config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5837
+#: musicbot/bot.py:5839
 msgid "Aliases saved to config file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5840
+#: musicbot/bot.py:5842
 #, python-format
 msgid ""
 "Failed to save aliases due to error:\n"
@@ -1232,94 +1232,94 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5847
+#: musicbot/bot.py:5849
 msgid "You must supply an alias and a command to alias"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5853
+#: musicbot/bot.py:5855
 #, python-format
 msgid "New alias added. `%(alias)s` is now an alias of `%(command)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5862
+#: musicbot/bot.py:5864
 msgid "You must supply an alias name to remove."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5867
+#: musicbot/bot.py:5869
 #, python-format
 msgid "The alias `%(alias)s` does not exist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5873
+#: musicbot/bot.py:5875
 #, python-format
 msgid "Alias `%(alias)s` was removed."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5883
+#: musicbot/bot.py:5885
 msgid "    Shows help text about any missing config options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5886
+#: musicbot/bot.py:5888
 msgid ""
 "    Lists the names of options which have been changed since loading config "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5889
+#: musicbot/bot.py:5891
 msgid "    List the available config options and their sections.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5892
+#: musicbot/bot.py:5894
 msgid "    Reload the options.ini file from disk.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5895
+#: musicbot/bot.py:5897
 msgid "    Shows help text for a specific option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5898
+#: musicbot/bot.py:5900
 msgid "    Display the current value of the option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5904
+#: musicbot/bot.py:5906
 msgid ""
 "    Validates the option and sets the config for the session, but not to "
 "file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5910
+#: musicbot/bot.py:5912
 msgid "Manage options.ini configuration from within Discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5925
+#: musicbot/bot.py:5927
 msgid "Config cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5954
+#: musicbot/bot.py:5956
 msgid "*All config options are present and accounted for!*"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5975
+#: musicbot/bot.py:5977
 msgid "No config options appear to be changed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5977
+#: musicbot/bot.py:5979
 #, python-format
 msgid ""
 "**Changed Options:**\n"
@@ -1327,7 +1327,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5997
+#: musicbot/bot.py:5999
 #, python-format
 msgid ""
 "## Available Options:\n"
@@ -1338,12 +1338,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6019
+#: musicbot/bot.py:6021
 msgid "Config options reloaded from file successfully!"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6023
+#: musicbot/bot.py:6025
 #, python-format
 msgid ""
 "Unable to reload Config due to the following error:\n"
@@ -1351,24 +1351,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6041
+#: musicbot/bot.py:6043
 msgid ""
 "Could not resolve section name from option name. Please provide a valid "
 "section and option name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6045
+#: musicbot/bot.py:6047
 msgid "The option given is ambiguous, please provide a section name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6051
+#: musicbot/bot.py:6053
 msgid "You must provide a section name and option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6067
+#: musicbot/bot.py:6069
 #, python-format
 msgid ""
 "The section `%(section)s` is not available.\n"
@@ -1376,24 +1376,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6075
+#: musicbot/bot.py:6077
 #, python-format
 msgid "The option `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6083
+#: musicbot/bot.py:6085
 msgid "This option can only be set by editing the config file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6087
+#: musicbot/bot.py:6089
 #, python-format
 msgid "By default this option is set to: %(default)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6092
+#: musicbot/bot.py:6094
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1403,31 +1403,31 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6103
+#: musicbot/bot.py:6105
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot save to disk."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6112
+#: musicbot/bot.py:6114
 #, python-format
 msgid "Failed to save the option:  `%(option)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6117
+#: musicbot/bot.py:6119
 #, python-format
 msgid "Successfully saved the option:  `%(config)s`"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6127
+#: musicbot/bot.py:6129
 #, python-format
 msgid "Option `%(option)s` is not editable, value cannot be displayed."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6141
+#: musicbot/bot.py:6143
 #, python-format
 msgid ""
 "**Option:** `%(config)s`\n"
@@ -1436,24 +1436,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6157
+#: musicbot/bot.py:6159
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot update setting."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6163 musicbot/bot.py:7107
+#: musicbot/bot.py:6165 musicbot/bot.py:7109
 msgid "You must provide a section, option, and value for this sub command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6174
+#: musicbot/bot.py:6176
 #, python-format
 msgid "Option `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6179
+#: musicbot/bot.py:6181
 #, python-format
 msgid ""
 "Option `%(config)s` was updated for this session.\n"
@@ -1461,19 +1461,19 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6190
+#: musicbot/bot.py:6192
 #, python-format
 msgid "Option `%(option)s` is not editable. Cannot reset to default."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6209
+#: musicbot/bot.py:6211
 #, python-format
 msgid "Option `%(option)s` was not reset to default!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6214
+#: musicbot/bot.py:6216
 #, python-format
 msgid ""
 "Option `%(config)s` was reset to its default value `%(default)s`.\n"
@@ -1481,50 +1481,50 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6229
+#: musicbot/bot.py:6231
 msgid "Deprecated command, use the config command instead."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6242
+#: musicbot/bot.py:6244
 msgid "The option command is deprecated, use the config command instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6249
+#: musicbot/bot.py:6251
 msgid ""
 "Display information about cache storage or clear cache according to configured limits.\n"
 "Using update option will scan the cache for external changes before displaying details."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6262
+#: musicbot/bot.py:6264
 msgid "Invalid option specified, use: info, update, or clear"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Disabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6273
+#: musicbot/bot.py:6275
 msgid "Enabled"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6276
+#: musicbot/bot.py:6278
 #, python-format
 msgid "%(time)s days"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6282 musicbot/bot.py:6285
+#: musicbot/bot.py:6284 musicbot/bot.py:6287
 msgid "Unlimited"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6290
+#: musicbot/bot.py:6292
 #, python-format
 msgid ""
 "**Video Cache:** *%(state)s*\n"
@@ -1535,34 +1535,34 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6313
+#: musicbot/bot.py:6315
 msgid "Cache has been cleared."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6319
+#: musicbot/bot.py:6321
 msgid "**Failed** to delete cache, check logs for more info..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6322
+#: musicbot/bot.py:6324
 msgid "No cache found to clear."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6330
+#: musicbot/bot.py:6332
 msgid ""
 "Display information about the current player queue.\n"
 "Optional page number shows later entries in the queue.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6354
+#: musicbot/bot.py:6356
 msgid "Queue page argument must be a whole number."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6368
+#: musicbot/bot.py:6370
 #, python-format
 msgid ""
 "Requested page number is out of bounds.\n"
@@ -1570,12 +1570,12 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6380
+#: musicbot/bot.py:6382
 msgid "(unknown duration)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6389
+#: musicbot/bot.py:6391
 #, python-format
 msgid ""
 "Currently playing: `%(title)s`\n"
@@ -1584,7 +1584,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6447
+#: musicbot/bot.py:6449
 #, python-format
 msgid ""
 "%(progress)sThere are `%(total)s` entries in the queue.\n"
@@ -1594,19 +1594,19 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6460
+#: musicbot/bot.py:6462
 msgid "Songs in queue"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6480
+#: musicbot/bot.py:6482
 msgid ""
 "Try that again. MusicBot couldn't make or get a reference to the queue message.\n"
 "If the issue persists, file a bug report."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6531
+#: musicbot/bot.py:6533
 msgid ""
 "Search for and remove bot messages and commands from the calling text channel.\n"
 "Optionally supply a number of messages to search through, 50 by default 500 max.\n"
@@ -1614,33 +1614,33 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6555
+#: musicbot/bot.py:6557
 msgid "Invalid parameter. Please provide a number of messages to search."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6590
+#: musicbot/bot.py:6592
 msgid "Cannot use purge on private DM channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6597
+#: musicbot/bot.py:6599
 #, python-format
 msgid "Cleaned up %(number)s message(s)."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6601
+#: musicbot/bot.py:6603
 msgid "Bot does not have permission to manage messages."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6622
+#: musicbot/bot.py:6624
 msgid "The given URL was not a valid URL."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6632
+#: musicbot/bot.py:6634
 #, python-format
 msgid ""
 "Could not extract info from input url\n"
@@ -1648,37 +1648,37 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6637
+#: musicbot/bot.py:6639
 msgid "This does not seem to be a playlist."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6657
+#: musicbot/bot.py:6659
 #, python-format
 msgid "Here is the playlist dump for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6667
+#: musicbot/bot.py:6669
 msgid ""
 "Display your Discord User ID, or the ID of a mentioned user.\n"
 "This command is deprecated in favor of Developer Mode in Discord clients.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6682
+#: musicbot/bot.py:6684
 #, python-format
 msgid "Your user ID is `%(id)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6687
+#: musicbot/bot.py:6689
 #, python-format
 msgid "The user ID for `%(username)s` is `%(id)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6694
+#: musicbot/bot.py:6696
 msgid ""
 "List the Discord IDs for the selected category.\n"
 "Returns all ID data by default, but one or more categories may be selected.\n"
@@ -1686,23 +1686,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6716
+#: musicbot/bot.py:6718
 #, python-format
 msgid "Valid categories: %(cats)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6763
+#: musicbot/bot.py:6765
 msgid "Here are the IDs you requested:"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6807
+#: musicbot/bot.py:6809
 msgid "Could not determine the discord User.  Try again."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6814
+#: musicbot/bot.py:6816
 #, python-format
 msgid ""
 "Your command permissions in %(server)s are:\n"
@@ -1712,7 +1712,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6823
+#: musicbot/bot.py:6825
 #, python-format
 msgid ""
 "The command permissions for %(username)s in %(server)s are:\n"
@@ -1722,62 +1722,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6839
+#: musicbot/bot.py:6841
 msgid "    Show loaded groups and list permission options.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6842
+#: musicbot/bot.py:6844
 msgid "    Reloads permissions from the permissions.ini file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6845
+#: musicbot/bot.py:6847
 msgid "    Add new group with defaults.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6848
+#: musicbot/bot.py:6850
 msgid "    Remove existing group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6851
+#: musicbot/bot.py:6853
 msgid "    Show help text for the permission option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6854
+#: musicbot/bot.py:6856
 msgid "    Show permission value for given group and permission.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6857
+#: musicbot/bot.py:6859
 msgid "    Save permissions group to file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6860
+#: musicbot/bot.py:6862
 msgid "    Set permission value for the group.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6863
+#: musicbot/bot.py:6865
 msgid "Manage permissions.ini configuration from within discord."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6878
+#: musicbot/bot.py:6880
 msgid "Permissions cannot use channel and user mentions at the same time."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6909
+#: musicbot/bot.py:6911
 msgid "Permissions reloaded from file successfully!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6933
+#: musicbot/bot.py:6935
 #, python-format
 msgid ""
 "## Available Groups:\n"
@@ -1787,23 +1787,23 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6950
+#: musicbot/bot.py:6952
 msgid "You must provide a group or option name for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6954
+#: musicbot/bot.py:6956
 msgid "You must provide a group, option, and value to set for this command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6968
+#: musicbot/bot.py:6970
 #, python-format
 msgid "The %(option)s sub-command requires a group and permission name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6980
+#: musicbot/bot.py:6982
 #, python-format
 msgid ""
 "The group `%(group)s` is not available.\n"
@@ -1811,24 +1811,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6991
+#: musicbot/bot.py:6993
 #, python-format
 msgid "The permission `%(option)s` is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6999
+#: musicbot/bot.py:7001
 msgid "This permission can only be set by editing the permissions file."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7008
+#: musicbot/bot.py:7010
 #, python-format
 msgid "By default this permission is set to: `%(value)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7013
+#: musicbot/bot.py:7015
 #, python-format
 msgid ""
 "**Permission:** `%(option)s`\n"
@@ -1838,18 +1838,18 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7027
+#: musicbot/bot.py:7029
 #, python-format
 msgid "Cannot add group `%(group)s` it already exists."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7045
+#: musicbot/bot.py:7047
 msgid "Cannot remove built-in group."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7052
+#: musicbot/bot.py:7054
 #, python-format
 msgid ""
 "Successfully removed group:  `%(group)s`\n"
@@ -1857,24 +1857,24 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7063 musicbot/bot.py:7102
+#: musicbot/bot.py:7065 musicbot/bot.py:7104
 msgid "The owner group is not editable."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7071
+#: musicbot/bot.py:7073
 #, python-format
 msgid "Failed to save the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7075
+#: musicbot/bot.py:7077
 #, python-format
 msgid "Successfully saved the group:  `%(group)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7086
+#: musicbot/bot.py:7088
 #, python-format
 msgid ""
 "**Permission:** `%(permission)s`\n"
@@ -1883,13 +1883,13 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7118
+#: musicbot/bot.py:7120
 #, python-format
 msgid "Permission `%(option)s` was not updated!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7123
+#: musicbot/bot.py:7125
 #, python-format
 msgid ""
 "Permission `%(permission)s` was updated for this session.\n"
@@ -1897,14 +1897,14 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7159
+#: musicbot/bot.py:7161
 msgid ""
 "Failed to change username. Did you change names too many times?\n"
 "Remember name changes are limited to twice per hour.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7165
+#: musicbot/bot.py:7167
 #, python-format
 msgid ""
 "Failed to change username due to error:  \n"
@@ -1912,23 +1912,23 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7170
+#: musicbot/bot.py:7172
 #, python-format
 msgid "Set the bot's username to `%(name)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7173
+#: musicbot/bot.py:7175
 msgid "Change the MusicBot's nickname."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7187
+#: musicbot/bot.py:7189
 msgid "Unable to change nickname: no permission."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7195
+#: musicbot/bot.py:7197
 #, python-format
 msgid ""
 "Failed to set nickname due to error:  \n"
@@ -1936,65 +1936,65 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7200
+#: musicbot/bot.py:7202
 #, python-format
 msgid "Set the bot's nickname to `%(nick)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7207
+#: musicbot/bot.py:7209
 msgid "    Set a per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7209
+#: musicbot/bot.py:7211
 msgid "    Clear the per-server command prefix."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7213
+#: musicbot/bot.py:7215
 msgid ""
 "Override the default command prefix in the server.\n"
 "The option EnablePrefixPerGuild must be enabled first."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7235
+#: musicbot/bot.py:7237
 msgid "Custom emoji must be from this server to use as a prefix."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7241
+#: musicbot/bot.py:7243
 msgid "Server command prefix is cleared."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7246
+#: musicbot/bot.py:7248
 #, python-format
 msgid "Server command prefix is now:  %(prefix)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7252
+#: musicbot/bot.py:7254
 msgid ""
 "Prefix per server is not enabled!\n"
 "Use the config command to update the prefix instead."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7333
+#: musicbot/bot.py:7335
 msgid ""
 "Change MusicBot's avatar.\n"
 "Attaching a file and omitting the url parameter also works.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7353
+#: musicbot/bot.py:7355
 msgid "You must provide a URL or attach a file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7363
+#: musicbot/bot.py:7365
 #, python-format
 msgid ""
 "Unable to change avatar due to error:  \n"
@@ -2002,62 +2002,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7367
+#: musicbot/bot.py:7369
 msgid "Changed the bot's avatar."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7370
+#: musicbot/bot.py:7372
 msgid "Force MusicBot to disconnect from the discord server."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7381
+#: musicbot/bot.py:7383
 #, python-format
 msgid "Disconnected from server `%(guild)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7396
+#: musicbot/bot.py:7398
 msgid "Disconnected a playerless voice client? [BUG]"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7400
+#: musicbot/bot.py:7402
 #, python-format
 msgid "Not currently connected to server `%(guild)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7408
+#: musicbot/bot.py:7410
 msgid "    Attempt to reload without process restart. The default option.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7410
+#: musicbot/bot.py:7412
 msgid ""
 "    Attempt to restart the entire MusicBot process, reloading everything.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7412
+#: musicbot/bot.py:7414
 msgid "    Full restart, but attempt to update pip packages before restart.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7414
+#: musicbot/bot.py:7416
 msgid "    Full restart, but update MusicBot source code with git first.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7416
+#: musicbot/bot.py:7418
 msgid ""
 "    Attempt to update all dependency and source code before fully "
 "restarting.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7420
+#: musicbot/bot.py:7422
 msgid ""
 "Attempts to restart the MusicBot in a number of different ways.\n"
 "With no option supplied, a `soft` restart is implied.\n"
@@ -2066,66 +2066,66 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7441
+#: musicbot/bot.py:7443
 msgid ""
 "Invalid option given, use one of:  soft, full, upgrade, uppip, or upgit"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7447
+#: musicbot/bot.py:7449
 #, python-format
 msgid "%(emoji)s Restarting current instance..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7452
+#: musicbot/bot.py:7454
 #, python-format
 msgid "%(emoji)s Restarting bot process..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7457
+#: musicbot/bot.py:7459
 #, python-format
 msgid ""
 "%(emoji)s Will try to upgrade required pip packages and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7462
+#: musicbot/bot.py:7464
 #, python-format
 msgid "%(emoji)s Will try to update bot code with git and restart the bot..."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7467
+#: musicbot/bot.py:7469
 #, python-format
 msgid "%(emoji)s Will try to upgrade everything and restart the bot..."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7501
+#: musicbot/bot.py:7503
 msgid "Disconnect from all voice channels and close the MusicBot process."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7527
+#: musicbot/bot.py:7529
 msgid "   Leave the discord server given by name or server ID."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7531
+#: musicbot/bot.py:7533
 msgid ""
 "Force MusicBot to leave the given Discord server.\n"
 "Names are case-sensitive, so using an ID number is more reliable.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7550
+#: musicbot/bot.py:7552
 msgid "You must provide an ID or name."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7561
+#: musicbot/bot.py:7563
 #, python-format
 msgid "No guild was found with the ID or name `%(input)s`"
 msgstr ""
@@ -2137,39 +2137,39 @@ msgid "Unknown"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7576
+#: musicbot/bot.py:7578
 #, python-format
 msgid "Left the guild: `%(name)s` (Owner: `%(owner)s`, ID: `%(id)s`)"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7619
+#: musicbot/bot.py:7621
 #, python-format
 msgid "Logged breakpoint with ID:  %(uuid)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7626
+#: musicbot/bot.py:7628
 msgid "    View most common types reported by objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7629
+#: musicbot/bot.py:7631
 msgid "    View limited objgraph.show_growth() output.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7632
+#: musicbot/bot.py:7634
 msgid "    View most common types of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7635
+#: musicbot/bot.py:7637
 msgid "    View typestats of leaking objects.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7642
+#: musicbot/bot.py:7644
 msgid ""
 "Interact with objgraph, if it is installed, to gain insight into memory usage.\n"
 "You can pass an arbitrary method with arguments (but no spaces!) that is a member of objgraph.\n"
@@ -2177,12 +2177,12 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7658
+#: musicbot/bot.py:7660
 msgid "Could not import `objgraph`, is it installed?"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7696
+#: musicbot/bot.py:7698
 msgid ""
 "This command will execute arbitrary python code in the command scope.\n"
 "First eval() is attempted, if exceptions are thrown exec() is tried next.\n"
@@ -2197,7 +2197,7 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7749
+#: musicbot/bot.py:7751
 #, python-format
 msgid ""
 "Failed to execute debug code:\n"
@@ -2208,73 +2208,73 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7784 musicbot/bot.py:7845
+#: musicbot/bot.py:7786 musicbot/bot.py:7847
 #, python-format
 msgid "Sub-command must be one of: %(options)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7834
+#: musicbot/bot.py:7836
 msgid "Makes default INI files."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7855
+#: musicbot/bot.py:7857
 msgid "Saved the requested INI file to disk. Go check it"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7860
+#: musicbot/bot.py:7862
 msgid ""
 "Display the current bot version and check for updates to MusicBot or "
 "dependencies.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7884
+#: musicbot/bot.py:7886
 msgid "Could not locate git executable."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7918
+#: musicbot/bot.py:7920
 #, python-format
 msgid "No updates in branch `%(branch)s` remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7923
+#: musicbot/bot.py:7925
 #, python-format
 msgid "New commits are available in `%(branch)s` branch remote."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7929 musicbot/bot.py:7972
+#: musicbot/bot.py:7931 musicbot/bot.py:7974
 msgid "Error while checking, see logs for details."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7963
+#: musicbot/bot.py:7965
 #, python-format
 msgid "Update for `%(name)s` to version: `%(version)s`\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7969
+#: musicbot/bot.py:7971
 msgid "No updates for dependencies found."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7975
+#: musicbot/bot.py:7977
 msgid "There are updates for MusicBot available for download."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7977
+#: musicbot/bot.py:7979
 msgid "MusicBot is totally up-to-date!"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7981
+#: musicbot/bot.py:7983
 #, python-format
 msgid ""
 "%(status)s\n"
@@ -2287,52 +2287,52 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7995
+#: musicbot/bot.py:7997
 msgid "Displays the MusicBot uptime, or time since last start / restart."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8010
+#: musicbot/bot.py:8012
 #, python-format
 msgid "%(name)s has been online for `%(time)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8017
+#: musicbot/bot.py:8019
 msgid ""
 "Display latency information for Discord API and all connected voice clients."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8047
+#: musicbot/bot.py:8049
 msgid "No voice clients connected.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8065
+#: musicbot/bot.py:8067
 msgid "Display API latency and Voice latency if MusicBot is connected."
 msgstr ""
 
 #. TRANSLATORS: short for automatic, displayed when voice region is not
 #. selected.
 #. Used by: _D
-#: musicbot/bot.py:8082
+#: musicbot/bot.py:8084
 msgid "auto"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8089
+#: musicbot/bot.py:8091
 #, python-format
 msgid "**API Latency:** `%(delay).0f ms`%(voice)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8094
+#: musicbot/bot.py:8096
 msgid "Display MusicBot version number in the chat."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8102
+#: musicbot/bot.py:8104
 #, python-format
 msgid ""
 "https://github.com/Just-Some-Bots/MusicBot\n"
@@ -2340,17 +2340,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8114
+#: musicbot/bot.py:8116
 msgid "    Update the cookies.txt file using a cookies.txt attachment."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8117
+#: musicbot/bot.py:8119
 msgid "    Enable or disable cookies.txt file without deleting it."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:8121
+#: musicbot/bot.py:8123
 msgid ""
 "Allows management of the cookies feature in yt-dlp.\n"
 "When updating cookies, you must upload a file named cookies.txt\n"
@@ -2365,28 +2365,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8142
+#: musicbot/bot.py:8144
 msgid "Cookies already enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8149
+#: musicbot/bot.py:8151
 msgid "Cookies must be uploaded to be enabled. (Missing cookies file.)"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8162
+#: musicbot/bot.py:8164
 #, python-format
 msgid "Could not enable cookies due to error:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8165
+#: musicbot/bot.py:8167
 msgid "Cookies have been enabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8176
+#: musicbot/bot.py:8178
 #, python-format
 msgid ""
 "Could not rename cookies file due to error:  %(raw_error)s\n"
@@ -2394,62 +2394,62 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8180
+#: musicbot/bot.py:8182
 msgid "Cookies have been disabled."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8185
+#: musicbot/bot.py:8187
 msgid ""
 "No attached uploads were found, try again while uploading a cookie file."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8203
+#: musicbot/bot.py:8205
 #, python-format
 msgid "Error downloading the cookies file from discord:  %(raw_error)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8208
+#: musicbot/bot.py:8210
 #, python-format
 msgid "Could not save cookies to disk:  %(raw_error)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8216
+#: musicbot/bot.py:8218
 msgid "Cookies uploaded and enabled."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8326
+#: musicbot/bot.py:8328
 msgid "You cannot use this bot in private messages."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:8407
+#: musicbot/bot.py:8409
 #, python-format
 msgid "This command is not allowed for your permissions group:  %(group)s"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:8442
+#: musicbot/bot.py:8444
 msgid "This command requires you to be in a Voice channel."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8546
+#: musicbot/bot.py:8548
 #, python-format
 msgid "**Command:** %(name)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8600
+#: musicbot/bot.py:8602
 msgid "Exception Error"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8644
+#: musicbot/bot.py:8646
 #, python-format
 msgid ""
 "**Example with prefix:**\n"
@@ -2457,17 +2457,17 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8648
+#: musicbot/bot.py:8650
 msgid "No description given.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8651
+#: musicbot/bot.py:8653
 msgid "No usage given."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8685
+#: musicbot/bot.py:8687
 #, python-format
 msgid ""
 "**Example usage:**\n"
@@ -2477,13 +2477,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8738
+#: musicbot/bot.py:8740
 #, python-format
 msgid "Leaving voice channel %(channel)s due to inactivity."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:9034
+#: musicbot/bot.py:9036
 #, python-format
 msgid "Left `%(guild)s` due to bot owner not being found in it."
 msgstr ""
@@ -2575,7 +2575,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:738
+#: musicbot/config.py:739
 msgid ""
 "A list of Voice Channel IDs that MusicBot should automatically join on start up.\n"
 "Use spaces to separate multiple IDs."
@@ -2637,13 +2637,13 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:749
+#: musicbot/config.py:750
 msgid "Allow MusicBot to keep downloaded media, or delete it right away."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos is not translated.
 #. Used by: _Dd
-#: musicbot/config.py:760
+#: musicbot/config.py:761
 msgid ""
 "If SaveVideos is enabled, set a limit on how much storage space should be "
 "used."
@@ -2651,14 +2651,14 @@ msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:771
+#: musicbot/config.py:772
 msgid ""
 "If SaveVideos is enabled, set a limit on how long files should be kept."
 msgstr ""
 
 #. TRANSLATORS: SaveVideos should not be translated.
 #. Used by: _Dd
-#: musicbot/config.py:782
+#: musicbot/config.py:783
 msgid ""
 "If SaveVideos is enabled, never purge auto playlist songs from the cache "
 "regardless of limits."
@@ -2670,26 +2670,26 @@ msgid "Mention the user who added the song when it is played."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:792
+#: musicbot/config.py:793
 msgid ""
 "Automatically join the owner if they are in an accessible voice channel when"
 " bot starts."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:656
+#: musicbot/config.py:657
 msgid ""
 "Enable MusicBot to automatically play music from the auto playlist when the "
 "queue is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:665
+#: musicbot/config.py:666
 msgid "Shuffles the auto playlist tracks before playing them."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:674
+#: musicbot/config.py:675
 msgid ""
 "Enable automatic skip of auto playlist songs when a user plays a new song.\n"
 "This only applies to the current playing song if it was added by the auto playlist."
@@ -2736,14 +2736,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:822
+#: musicbot/config.py:823
 msgid "If enabled, status messages will report info on paused players."
 msgstr ""
 
 #. TRANSLATORS: [Server ID] is a descriptive placeholder and may be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:833
+#: musicbot/config.py:834
 msgid ""
 "If enabled, MusicBot will save the track title to:  data/[Server "
 "ID]/current.txt"
@@ -2769,7 +2769,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:842
+#: musicbot/config.py:843
 msgid "Display MusicBot config settings in the logs at startup."
 msgstr ""
 
@@ -2782,7 +2782,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:851
+#: musicbot/config.py:852
 msgid ""
 "If enabled, MusicBot will leave servers if the owner is not in their member "
 "list."
@@ -2808,13 +2808,13 @@ msgid "Completely remove the footer from embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:861
+#: musicbot/config.py:862
 msgid ""
 "MusicBot will automatically deafen itself when entering a voice channel."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:872
+#: musicbot/config.py:873
 msgid ""
 "If enabled, MusicBot will leave a voice channel when no users are listening,\n"
 "after waiting for a period set in LeaveInactiveVCTimeOut option.\n"
@@ -2822,21 +2822,21 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:884
+#: musicbot/config.py:885
 msgid ""
 "Set a period of time to wait before leaving an inactive voice channel.\n"
 "You can set this to a number of seconds or phrase like:  4 hours"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:895
+#: musicbot/config.py:896
 msgid ""
 "If enabled, MusicBot will leave the channel immediately when the song queue "
 "is empty."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:905
+#: musicbot/config.py:906
 msgid ""
 "When paused or no longer playing, wait for this amount of time then leave voice.\n"
 "You can set this to a number of seconds of phrase like:  15 minutes\n"
@@ -2873,7 +2873,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:917
+#: musicbot/config.py:918
 msgid ""
 "Allow MusicBot to use timed pings to detect network outage and availability.\n"
 "This may be useful if you keep the bot joined to a channel or playing music 24/7.\n"
@@ -2882,7 +2882,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:697
+#: musicbot/config.py:698
 #, python-format
 msgid ""
 "Enable saving all songs played by MusicBot to a global playlist file:  %(filename)s\n"
@@ -2892,7 +2892,7 @@ msgstr ""
 #. TRANSLATORS:  [Server ID] is a descriptive placeholder, and can be
 #. translated.
 #. Used by: _Dd
-#: musicbot/config.py:710
+#: musicbot/config.py:711
 #, python-format
 msgid ""
 "Enable saving songs played per-server to a playlist file:  "
@@ -2913,7 +2913,7 @@ msgid "Allow MusicBot to automatically unpause when play commands are used."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:939
+#: musicbot/config.py:940
 msgid ""
 "Experimental, HTTP/HTTPS proxy settings to use with ytdlp media downloader.\n"
 "The value set here is passed to `ytdlp --proxy` and aiohttp header checking.\n"
@@ -2921,7 +2921,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:950
+#: musicbot/config.py:951
 msgid ""
 "Experimental option to set a static User-Agent header in yt-dlp.\n"
 "It is not typically recommended by yt-dlp to change the UA string.\n"
@@ -2932,37 +2932,37 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1006
+#: musicbot/config.py:1007
 msgid "Toggle the user block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1030
+#: musicbot/config.py:1031
 msgid ""
 "An optional file path to a text file listing Discord User IDs, one per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1016
+#: musicbot/config.py:1017
 msgid "Enable the song block list feature, without emptying the block list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1042
+#: musicbot/config.py:1043
 msgid ""
 "An optional file path to a text file that lists URLs, words, or phrases one per line.\n"
 "Any song title or URL that contains any line in the list will be blocked."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1055
+#: musicbot/config.py:1056
 msgid ""
 "An optional path to a directory containing auto playlist files.\n"
 "Each file should contain a list of playable URLs or terms, one track per line."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1068
+#: musicbot/config.py:1069
 #, python-format
 msgid ""
 "An optional directory path where playable media files can be stored.\n"
@@ -2972,14 +2972,14 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1088
+#: musicbot/config.py:1089
 msgid ""
 "An optional directory path where MusicBot will store long and short-term "
 "cache for playback."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1100
+#: musicbot/config.py:1101
 #, python-format
 msgid ""
 "Configure automatic log file rotation at restart, and limit the number of files kept.\n"
@@ -2988,7 +2988,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:1113
+#: musicbot/config.py:1114
 msgid ""
 "Configure the log file date format used when LogsMaxKept is enabled.\n"
 "If left blank, a warning is logged and the default will be used instead.\n"
@@ -2997,7 +2997,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1217
+#: musicbot/config.py:1218
 msgid ""
 "Error while validating config options.\n"
 "\n"
@@ -3009,7 +3009,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1238
+#: musicbot/config.py:1239
 #, python-format
 msgid ""
 "Error while validating config options.\n"
@@ -3023,7 +3023,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1261
+#: musicbot/config.py:1262
 #, python-format
 msgid ""
 "Error while reading config options.\n"
@@ -3036,7 +3036,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1400
+#: musicbot/config.py:1401
 #, python-format
 msgid ""
 "Error locating config.\n"
@@ -3050,7 +3050,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1418
+#: musicbot/config.py:1419
 #, python-format
 msgid ""
 "Error loading config.\n"
@@ -3065,7 +3065,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2289
+#: musicbot/config.py:2290
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3078,7 +3078,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2325
+#: musicbot/config.py:2326
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3091,7 +3091,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:2355
+#: musicbot/config.py:2356
 #, python-format
 msgid ""
 "Error loading config value.\n"
@@ -3104,32 +3104,32 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:270
+#: musicbot/downloader.py:278
 msgid "HEAD seems to have no headers..."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:423
+#: musicbot/downloader.py:431
 msgid "Song info extraction returned no data."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:489
+#: musicbot/downloader.py:497
 msgid "Cannot continue extraction, event loop is closed."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:498
+#: musicbot/downloader.py:506
 msgid "Spotify URL is invalid or not supported."
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:549
+#: musicbot/downloader.py:557
 msgid "Cannot stream an invalid URL."
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:623
+#: musicbot/downloader.py:631
 msgid "The local media file could not be found."
 msgstr ""
 
@@ -3439,68 +3439,68 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4387
+#: musicbot/bot.py:4389
 msgid "Detected a Spotify URL, but Spotify is not enabled."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4661
+#: musicbot/bot.py:4663
 msgid ""
 "    Search YouTube for query but get a custom number of results.\n"
 "    Note: the double-quotes are required in this case.\n"
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5271
+#: musicbot/bot.py:5273
 msgid ""
 "There is nothing currently playing. Play something with a play command."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5767
+#: musicbot/bot.py:5769
 msgid "The speed you provided is invalid. Use a number between 0.5 and 100."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5798
+#: musicbot/bot.py:5800
 msgid "    Remove an alias with the given name.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5801
+#: musicbot/bot.py:5803
 msgid "    Reload or save aliases from/to the config file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5901
+#: musicbot/bot.py:5903
 msgid "    Saves the current value to the options file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5907
+#: musicbot/bot.py:5909
 msgid "    Reset the option to its default value.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6606
+#: musicbot/bot.py:6608
 msgid "Dump the individual URLs of a playlist to a file."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:6770
+#: musicbot/bot.py:6772
 msgid ""
 "Get a list of your permissions, or the permissions of the mentioned user."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6800
+#: musicbot/bot.py:6802
 msgid ""
 "Invalid user ID or server nickname, please double-check the ID and try "
 "again."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:6913
+#: musicbot/bot.py:6915
 #, python-format
 msgid ""
 "Unable to reload Permissions due to an error:\n"
@@ -3508,7 +3508,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7035
+#: musicbot/bot.py:7037
 #, python-format
 msgid ""
 "Successfully added new group:  `%(group)s`\n"
@@ -3517,44 +3517,44 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7140
+#: musicbot/bot.py:7142
 msgid ""
 "Change the bot's username on discord.\n"
 "Note: The API may limit name changes to twice per hour."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7260
+#: musicbot/bot.py:7262
 msgid "    Show language codes available to use.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7263
+#: musicbot/bot.py:7265
 msgid "    Set the desired language for this server.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7266
+#: musicbot/bot.py:7268
 msgid "    Reset the server language to bot's default language.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7269
+#: musicbot/bot.py:7271
 msgid "Manage the language used for messages in the calling server."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7282
+#: musicbot/bot.py:7284
 msgid "This command can only be used in guilds."
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7287
+#: musicbot/bot.py:7289
 msgid "Invalid sub-command given. Use the help command for more information."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7298
+#: musicbot/bot.py:7300
 #, python-format
 msgid ""
 "**Current Language:** `%(locale)s`\n"
@@ -3564,56 +3564,56 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:7308
+#: musicbot/bot.py:7310
 #, python-format
 msgid "Cannot set language to `%(locale)s` it is not available."
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7313
+#: musicbot/bot.py:7315
 #, python-format
 msgid "Language for this server now set to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7321
+#: musicbot/bot.py:7323
 #, python-format
 msgid "Language for this server has been reset to: `%(locale)s`"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7585
+#: musicbot/bot.py:7587
 msgid "Command used to automate testing of commands."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7608
+#: musicbot/bot.py:7610
 msgid ""
 "This command issues a log at level CRITICAL, but does nothing else.\n"
 "Can be used to manually pinpoint events in the MusicBot log file.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7638
+#: musicbot/bot.py:7640
 msgid "    Evaluate the given function and arguments on objgraph.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:7767
+#: musicbot/bot.py:7769
 msgid ""
 "Create 'markdown' for options, permissions, or commands from the code.\n"
 "The output is used to update GitHub Pages and is thus unsuitable for normal reference use."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:685
+#: musicbot/config.py:686
 msgid ""
 "Remove songs from the auto playlist if they are found in the song block "
 "list."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:801
+#: musicbot/config.py:802
 msgid ""
 "Specify a custom message to use as the bot's status. If left empty, the bot\n"
 "will display dynamic info about music currently being played in its status instead.\n"
@@ -3635,14 +3635,14 @@ msgid "Allow MusicBot to format its messages as embeds."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:724
+#: musicbot/config.py:725
 msgid ""
 "Enable MusicBot to automatically remove unplayable entries from the auto "
 "playlist."
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1134
+#: musicbot/config.py:1135
 #, python-format
 msgid ""
 "Error creating default config options file.\n"
@@ -3656,7 +3656,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1168
+#: musicbot/config.py:1169
 #, python-format
 msgid ""
 "Error while reading config.\n"
@@ -3674,7 +3674,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1319
+#: musicbot/config.py:1320
 msgid ""
 "Error while fetching 'OwnerID' automatically.\n"
 "\n"
@@ -3687,7 +3687,7 @@ msgid ""
 msgstr ""
 
 #. Used by: HelpfulError
-#: musicbot/config.py:1337
+#: musicbot/config.py:1338
 msgid ""
 "Error validating config options.\n"
 "\n"
@@ -3747,7 +3747,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:7569
+#: musicbot/bot.py:7571
 msgid "Unknown Owner"
 msgstr ""
 
@@ -3801,7 +3801,7 @@ msgid "%(title)s%(content)s%(url)s%(fields)s%(image)s"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8042
+#: musicbot/bot.py:8044
 #, python-format
 msgid ""
 "- `%(delay).0f ms` (`%(avg).0f ms` Avg.) in region: `%(region)s` using "
@@ -3809,7 +3809,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8056
+#: musicbot/bot.py:8058
 #, python-format
 msgid ""
 "**API Latency:** `%(delay).0f ms`\n"
@@ -3819,7 +3819,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:8084
+#: musicbot/bot.py:8086
 #, python-format
 msgid ""
 "\n"
@@ -3888,7 +3888,7 @@ msgid "The playlist has been reloaded from disk."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:4667
+#: musicbot/bot.py:4669
 msgid ""
 "Search a supported service and select from results to add to queue.\n"
 "Service and number arguments can be omitted, default number is 3 results.\n"
@@ -3902,7 +3902,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5959
+#: musicbot/bot.py:5961
 #, python-format
 msgid ""
 "**Missing Options:**\n"
@@ -3911,7 +3911,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:6425
+#: musicbot/bot.py:6427
 #, python-format
 msgid ""
 "**Entry #%(index)s:**Title: `%(title)s`\n"
@@ -3925,7 +3925,7 @@ msgid "Command responses will also mention or notify the user."
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:640
+#: musicbot/config.py:641
 msgid ""
 "This option sets the default search service used by MusicBot through ytdlp.\n"
 "Read ytdlp's list of supported sites to find supported prefixes you can use here.\n"
@@ -3933,7 +3933,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:965
+#: musicbot/config.py:966
 msgid ""
 "Force yt-dlp to bind to a specific IP address or IP version on your system.\n"
 "To force any available IPv4, set this to:  0.0.0.0\n"
@@ -3942,26 +3942,26 @@ msgid ""
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:532
+#: musicbot/downloader.py:540
 #, python-format
 msgid "Error in yt-dlp while downloading media data: %(raw_error)s"
 msgstr ""
 
 #. Used by: ExtractionError
-#: musicbot/downloader.py:553
+#: musicbot/downloader.py:561
 #, python-format
 msgid "Error in yt-dlp while downloading stream data: %(raw_error)s"
 msgstr ""
 
 #. Used by: MusicbotException
-#: musicbot/downloader.py:644
+#: musicbot/downloader.py:652
 msgid "The playlist does not exist."
 msgstr ""
 
 #. TRANSLATORS:  URL field title for embeds.
 #. Used by: _D
 #. TRANSLATORS:  URL field title for embeds.
-#: musicbot/bot.py:1191 musicbot/bot.py:5042
+#: musicbot/bot.py:1191 musicbot/bot.py:5044
 msgid "URL:"
 msgstr ""
 
@@ -3973,28 +3973,28 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:4436
+#: musicbot/bot.py:4438
 #, python-format
 msgid "Search returned no results with %(extractor)s for:  %(url)s"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5301
+#: musicbot/bot.py:5303
 msgid "    Remove a song at the end of the queue or at [POSITION].\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5303
+#: musicbot/bot.py:5305
 msgid "    Remove songs from position FROM to position TO.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5304
+#: musicbot/bot.py:5306
 msgid "    Remove songs added by the mentioned user.\n"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/bot.py:5307
+#: musicbot/bot.py:5309
 msgid ""
 "Remove a song from the queue at POSITION specified.\n"
 "Remove multiple songs from the queue from position FROM to position TO specified.\n"
@@ -4005,25 +4005,25 @@ msgid ""
 msgstr ""
 
 #. Used by: CommandError
-#: musicbot/bot.py:5349
+#: musicbot/bot.py:5351
 msgid "Invalid positions. Use the queue command to find queue positions."
 msgstr ""
 
 #. Used by: PermissionsError
-#: musicbot/bot.py:5371
+#: musicbot/bot.py:5373
 msgid ""
 "You do not have the permission to remove all the songs in the given range "
 "from the queue.\n"
 msgstr ""
 
 #. Used by: _D
-#: musicbot/bot.py:5378
+#: musicbot/bot.py:5380
 #, python-format
 msgid "Successfully removed songs %(from)s through %(to)s!"
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:978
+#: musicbot/config.py:979
 msgid ""
 "The number of threads used to download a (one) track.\n"
 "Higher number is faster at the cost of CPU and network load.\n"
@@ -4032,7 +4032,7 @@ msgid ""
 msgstr ""
 
 #. Used by: _Dd
-#: musicbot/config.py:992
+#: musicbot/config.py:993
 msgid ""
 "The number of threads MusicBot may use for yt-dlp calls.\n"
 "Most useful for multi-server bot's with high traffic.\n"

--- a/install.ps1
+++ b/install.ps1
@@ -27,7 +27,7 @@ function AskInput {
     $prompt = $args[0]
     $defval = $args[1]
     if ($auto) {
-        Write-Output "${prompt}: $defval"
+        Write-Information "${prompt}: $defval"
         return $defval
     }
     $userInput = Read-Host "$prompt"
@@ -38,7 +38,7 @@ function ErrorExit {
     $message = if ($args.Count -ge 1) { $args[0] } else { "Error. Install halted." }
     $exitCode = if ($args.Count -ge 2) { $args[1] } else { 1 }
 
-    Write-Output $message
+    Write-Information $message
     exit $exitCode
 }
 
@@ -47,7 +47,7 @@ function wgInstall {
     if ($auto) {
         $command += " --silent"
     }
-    Write-Output "Running:  $command"
+    Write-Information "Running:  $command"
     Invoke-Expression $command
 }
 
@@ -125,7 +125,7 @@ if (-Not (Get-Command winget -ErrorAction SilentlyContinue) )
         Add-AppxPackage "DesktopAppInstaller_Dependencies\x64\Microsoft.WindowsAppRuntime*x64.appx"
         "Installing winget..."
         Add-AppxProvisionedPackage -Online -PackagePath "WinGet.msixbundle" -LicensePath "license.xml"
-        Get-AppPackage *Microsoft.DesktopAppInstaller*|select Name,PackageFullName
+        Get-AppPackage *Microsoft.DesktopAppInstaller*|Select-Object Name,PackageFullName
         Remove-Item -Path "WinGet.msixbundle", "DesktopAppInstaller_Dependencies.zip", "DesktopAppInstaller_Dependencies", "license.xml" -Recurse -Force
     }
 

--- a/install.ps1
+++ b/install.ps1
@@ -13,11 +13,44 @@
 # --------------------------------------------------CLI Parameters-----------------------------------------------------
 param (
     # -anybranch  Enables the use of any named branch, if it exists on repo.
-    [switch]$anybranch = $false
+    [switch]$anybranch = $false,
+    [switch]$auto = $false,
+    [string]$branch = ""
 )
 # Where to put MusicBot by default.  Updated by repo detection.
 # prolly should be param, but someone who cares about windows can code for it.
 $Install_Dir = (pwd).Path + '\MusicBot\'
+
+# --------------------------------------------------Functions----------------------------------------------------------
+
+function AskInput {
+    $prompt = $args[0]
+    $defval = $args[1]
+    if ($auto) {
+        Write-Host "${prompt}: $defval"
+        return $defval
+    }
+    $userInput = Read-Host "$prompt"
+    return $userInput
+}
+
+function ErrorExit {
+    $message = if ($args.Count -ge 1) { $args[0] } else { "Error. Install halted." }
+    $exitCodeRaw = if ($args.Count -ge 2) { $args[1] } else { 1 }
+
+    Write-Host $message
+    exit $exitCode
+}
+
+function wgInstall {
+    $command = "winget install $args"
+    if ($auto) {
+        $command += " --silent"
+    }
+    Write-Host "Running:  $command"
+    Invoke-Expression $command
+}
+
 
 # ---------------------------------------------Install notice and prompt-----------------------------------------------
 "MusicBot Installer"
@@ -38,12 +71,14 @@ $Install_Dir = (pwd).Path + '\MusicBot\'
 "    https://discord.gg/bots"
 ""
 
-$iagree = Read-Host "Would you like to continue with the install? [y/n]"
+$iagree = AskInput "Would you like to continue with the install? [Y/n]" "y"
 if($iagree -ne "Y" -and $iagree -ne "y")
 {
     # exit early if the user does not want to continue.
     Return
 }
+
+# ensure $auto implies any
 
 # First, unhide file extensions...
 $FERegPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced'
@@ -70,18 +105,33 @@ if (-Not (Get-Command winget -ErrorAction SilentlyContinue) )
     $ProgressPreference = 'SilentlyContinue'
     Invoke-WebRequest -Uri "https://aka.ms/getwinget" -OutFile "winget.msixbundle"
     $ProgressPreference = 'Continue'
-    Start-Process "winget.msixbundle"
-    
-    # wait for user to finish installing winget...
-    $ready = Read-Host "Is WinGet installed and ready to continue? [y/n]"
-    if ($ready -ne "Y" -and $ready -ne "y") {
-        # exit if not ready.
-        Return
+    Add-AppxPackage "winget.msixbundle"
+
+    # if the above fails, fall back to the more manual way...
+    if (-Not (Get-Command winget -ErrorAction SilentlyContinue) ) {
+        "... Trying a more manual install for winget..."
+        "Downloading winget & dependencies..."
+        Invoke-WebRequest -Uri "https://github.com/microsoft/winget-cli/releases/latest/download/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle" -OutFile "WinGet.msixbundle"
+        Invoke-WebRequest -Uri "https://github.com/microsoft/winget-cli/releases/latest/download/DesktopAppInstaller_Dependencies.zip" -OutFile "DesktopAppInstaller_Dependencies.zip"
+        Invoke-WebRequest -Uri "https://github.com/microsoft/winget-cli/releases/latest/download/e53e159d00e04f729cc2180cffd1c02e_License1.xml" -OutFile "license.xml"
+        "Unpacking dependencies..."
+        Expand-Archive -Path "DesktopAppInstaller_Dependencies.zip"
+        "Installing dependencies..."
+        " - Installing UI Xaml ..."
+        Add-AppxPackage "DesktopAppInstaller_Dependencies\x64\Microsoft.UI.Xaml*x64.appx"
+        " - Installing VC Libs ..."
+        Add-AppxPackage "DesktopAppInstaller_Dependencies\x64\Microsoft.VCLibs*x64.appx"
+        " - Installing Windows App Runtime ..."
+        Add-AppxPackage "DesktopAppInstaller_Dependencies\x64\Microsoft.WindowsAppRuntime*x64.appx"
+        "Installing winget..."
+        Add-AppxProvisionedPackage -Online -PackagePath "WinGet.msixbundle" -LicensePath "license.xml"
+        Get-AppPackage *Microsoft.DesktopAppInstaller*|select Name,PackageFullName
+        Remove-Item -Path "WinGet.msixbundle", "DesktopAppInstaller_Dependencies.zip", "DesktopAppInstaller_Dependencies", "license.xml" -Recurse -Force
     }
-    
+
     # check if winget is available post-install.
     if (-Not (Get-Command winget -ErrorAction SilentlyContinue) ) {
-        "WinGet is not available.  Installer cannot continue."
+        ErrorExit "WinGet is not available.  Installer cannot continue."
         Return
     }
 }
@@ -118,7 +168,7 @@ if (!($LastExitCode -eq 0))
 {
     # install git
     "Installing git..."
-    Invoke-Expression "winget install Git.Git"
+    wgInstall "Git.Git"
     $NeedsEnvReload = 1
     "Done."
 }
@@ -135,7 +185,7 @@ if (!($LastExitCode -eq 0))
 {
     # install python version 3.11 with the py.exe launcher.
     "Installing python..."
-    Invoke-Expression "winget install Python.Python.3.11 --custom \`"/passive Include_launcher=1\`""
+    wgInstall "Python.Python.3.11 --custom \`"/passive Include_launcher=1\`""
     $NeedsEnvReload = 1
     "Done."
 }
@@ -152,13 +202,30 @@ if (!($LastExitCode -eq 0))
 {
     # install FFmpeg
     "Installing FFmpeg..."
-    Invoke-Expression "winget install ffmpeg"
+    wgInstall "ffmpeg"
     $NeedsEnvReload = 1
     "Done."
 }
 else
 {
     "FFmpeg already installed."
+}
+""
+
+# Check if deno is installed
+"Checking if deno is already installed..."
+Invoke-Expression "winget list -q deno" | Out-Null
+if (!($LastExitCode -eq 0))
+{
+    # install deno js runtime
+    "Installing deno..."
+    wgInstall "--id=DenoLand.Deno"
+    $NeedsEnvReload = 1
+    "Done."
+}
+else
+{
+    "deno already installed."
 }
 ""
 
@@ -190,7 +257,7 @@ if((Test-Path $MB_Reqs_File) -and (Test-Path $MB_Module_Dir) -and (Test-Path $MB
     "   *     - WARNING: Any branch name is allowed, if it exists on github."
     }
     ""
-    $experimental = Read-Host "Enter the branch name you want to install"
+    $experimental = AskInput "Enter the branch name you want to install" "$branch"
     $experimental = $experimental.Trim()
     switch($experimental) {
         "dev" {
@@ -224,14 +291,14 @@ if((Test-Path $MB_Reqs_File) -and (Test-Path $MB_Module_Dir) -and (Test-Path $MB
 
 if (Get-Command "python" -errorAction SilentlyContinue)
 {
-    Invoke-Expression "python -c 'import sys; exit(0 if sys.version_info >= (3, 8) else 1)'" | Out-Null
+    Invoke-Expression "python -c 'import sys; exit(0 if sys.version_info >= (3, 10) else 1)'" | Out-Null
     if($LastExitCode -eq 0)
     {
         $PYTHON = "python"
     }
 }
 
-$versionArray = "3.9", "3.10", "3.11", "3.12", "3.13"
+$versionArray = "3.10", "3.11", "3.12", "3.13"
 
 foreach ($version in $versionArray)
 {
@@ -252,7 +319,7 @@ Invoke-Expression "$PYTHON -m pip install --upgrade -r requirements.txt"
 "This installer provides an automated, but minimal, guided configuration."
 "It will ask you to enter a bot token."
 ""
-$iagree = Read-Host "Would you like to continue with configuration? [y/n]"
+$iagree = AskInput "Would you like to continue with configuration? [y/N]" "n"
 if($iagree -ne "Y" -and $iagree -ne "y")
 {
     "All done!"

--- a/install.ps1
+++ b/install.ps1
@@ -19,7 +19,7 @@ param (
 )
 # Where to put MusicBot by default.  Updated by repo detection.
 # prolly should be param, but someone who cares about windows can code for it.
-$Install_Dir = (pwd).Path + '\MusicBot\'
+$Install_Dir = (Get-Location).Path + '\MusicBot\'
 
 # --------------------------------------------------Functions----------------------------------------------------------
 
@@ -27,7 +27,7 @@ function AskInput {
     $prompt = $args[0]
     $defval = $args[1]
     if ($auto) {
-        Write-Host "${prompt}: $defval"
+        Write-Output "${prompt}: $defval"
         return $defval
     }
     $userInput = Read-Host "$prompt"
@@ -36,9 +36,9 @@ function AskInput {
 
 function ErrorExit {
     $message = if ($args.Count -ge 1) { $args[0] } else { "Error. Install halted." }
-    $exitCodeRaw = if ($args.Count -ge 2) { $args[1] } else { 1 }
+    $exitCode = if ($args.Count -ge 2) { $args[1] } else { 1 }
 
-    Write-Host $message
+    Write-Output $message
     exit $exitCode
 }
 
@@ -47,7 +47,7 @@ function wgInstall {
     if ($auto) {
         $command += " --silent"
     }
-    Write-Host "Running:  $command"
+    Write-Output "Running:  $command"
     Invoke-Expression $command
 }
 
@@ -136,7 +136,7 @@ if (-Not (Get-Command winget -ErrorAction SilentlyContinue) )
     }
 }
 
-# 
+
 ""
 "Checking WinGet can be used..."
 "If prompted, you must agree to the MS terms to continue installing."
@@ -155,7 +155,6 @@ Remove-Item "cert.fetch"
 
 # -----------------------------------------------------CONSTANTS-------------------------------------------------------
 
-$DEFAULT_URL_BASE = "https://discordapp.com/api"
 $MB_RepoURL = "https://github.com/Just-Some-Bots/MusicBot.git"
 
 # ----------------------------------------------INSTALLING DEPENDENCIES------------------------------------------------
@@ -230,7 +229,7 @@ else
 ""
 
 # try to reload environment variables...
-if ($NeedsEnvReload -eq 1) 
+if ($NeedsEnvReload -eq 1)
 {
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
 }
@@ -238,15 +237,15 @@ if ($NeedsEnvReload -eq 1)
 # --------------------------------------------------PULLING THE BOT----------------------------------------------------
 
 # Test if we need to pull the bot or not by checking for some files.
-$MB_Reqs_File=(pwd).Path + '\requirements.txt'
-$MB_Module_Dir=(pwd).Path + '\musicbot'
-$MB_Git_Dir=(pwd).Path + '\.git'
+$MB_Reqs_File=(Get-Location).Path + '\requirements.txt'
+$MB_Module_Dir=(Get-Location).Path + '\musicbot'
+$MB_Git_Dir=(Get-Location).Path + '\.git'
 
 if((Test-Path $MB_Reqs_File) -and (Test-Path $MB_Module_Dir) -and (Test-Path $MB_Git_Dir) ) {
     ""
     "Installer detected an existing clone, and will continue installing with the current source."
     ""
-    $Install_Dir = (pwd).Path
+    $Install_Dir = (Get-Location).Path
 } else {
     ""
     "MusicBot currently has three branches available."
@@ -311,7 +310,7 @@ foreach ($version in $versionArray)
 
 "Using $PYTHON to install and run MusicBot..."
 ""
-Invoke-Expression "$PYTHON -m pip install --upgrade -r requirements.txt" 
+Invoke-Expression "$PYTHON -m pip install --upgrade -r requirements.txt"
 
 # -------------------------------------------------CONFIGURE THE BOT---------------------------------------------------
 ""

--- a/install.sh
+++ b/install.sh
@@ -23,13 +23,10 @@ VenvDir="MusicBotVenv"
 InstallDir=""
 ServiceName="musicbot"
 
-EnableUnlistedBranches=0
-DEBUG=0
-
 
 #----------------------------------------------Constants----------------------------------------------#
 # Suported versions of python using only major.minor format
-PySupported=("3.13" "3.12" "3.11" "3.10" "3.9")
+PySupported=("3.13" "3.12" "3.11" "3.10")
 PyBin="python3"
 # Path updated by find_python
 PyBinPath="$(command -v "$PyBin")"
@@ -108,7 +105,7 @@ function show_help() {
     echo "The user should have permission to install system packages using sudo."
     echo "Do NOT run this script with sudo, you will be prompted when it is needed!"
     echo "To bypass steps that use sudo, use --no-sudo or --no-sys as desired."
-    echo " Note: Your system admin must install the packages before hand, by using:"
+    echo " Note: Your system admin must install the system packages by using:"
     echo "   $0 --sys-only"
     echo ""
     echo "Available Options:"
@@ -116,14 +113,28 @@ function show_help() {
     echo "  --list      List potentially supported versions and exits."
     echo "  --help      Show this help text and exit."
     echo "  --sys-only  Install only system packages, no bot or pip libraries."
-    echo "  --service   Install only the system service for MusicBot."
+    echo "  --service   Install only the systemd service file for MusicBot."
     echo "  --no-sys    Bypass system packages, install bot and pip libraries."
     echo "  --no-sudo   Skip all steps that use sudo. This implies --no-sys."
-    echo "  --debug     Enter debug mode, with extra output. (for developers)"
-    echo "  --any-branch    Allow any existing branch to be given at the branch prompt. (for developers)"
+    echo "  --debug     Enter debug mode, with extra output."
+    echo "  --auto      Bypass all prompts using default values."
+    echo "  --any-branch    Allow any existing branch to be given at the branch prompt."
+    echo "  --branch [NAME] Bypass branch prompt and use the given branch name."
     echo "  --dir [PATH]    Directory into which MusicBot will be installed. Default is user Home directory."
     echo ""
     exit 0
+}
+
+function ask_input() {
+    # a prompt which can be bypassed by AUTO_INSTALL=1
+    local prompt="$1"
+    local varname="$2"
+    local defval="$3"
+    if [ "$AUTO_INSTALL" == "1" ] ; then
+        eval "$varname=\"$defval\""
+    else
+        read -rp "$prompt" "${varname?}"
+    fi
 }
 
 function exit_err() {
@@ -149,7 +160,7 @@ function build_python() {
         fi
     fi
 
-    # actually build python
+    # variables for what python source to actually build
     PyBuildVer="3.10.14"
     PySrcDir="Python-${PyBuildVer}"
     PySrcFile="${PySrcDir}.tgz"
@@ -160,7 +171,8 @@ function build_python() {
     echo "It will be installed using the altinstall target to avoid conflicts."
     echo "This process can take several minutes!"
     echo " Building Python ${PyBuildVer}  from: ${PySrcUrl}"
-    read -rp "Would you like to continue ? [N/y]" BuildPython
+    BuildPython="y"
+    ask_input "Would you like to continue ? [n/Y]" BuildPython "y"
     if [ "${BuildPython,,}" == "y" ] || [ "${BuildPython,,}" == "yes" ] ; then
         # Build python.
         curl -o "$PySrcFile" "$PySrcUrl"
@@ -232,8 +244,8 @@ function find_python() {
 
         # Major version must be 3+
         if [[ $PY_VER_MAJOR -ge 3 ]]; then
-            # if 3.9+ it should work.
-            if [[ $PY_VER_MINOR -ge 9 ]]; then
+            # if 3.10+ it should work.
+            if [[ $PY_VER_MINOR -ge 10 ]]; then
                 PyBinPath="$(which "$PyBinTest")"
                 PyBin="$PyBinTest"
                 debug "Selected: $PyBinTest  @  $PyBinPath"
@@ -265,8 +277,10 @@ function in_existing_repo() {
     ReqFile="${PWD}/requirements.txt"
     RunFile="${PWD}/run.py"
     if [ -d "$GitDir" ] && [ -d "$BotDir" ] && [ -f "$ReqFile" ] && [ -f "$RunFile" ]; then
+        debug "yes"
         return 0
     fi
+    debug "no"
     return 1
 }
 
@@ -274,18 +288,71 @@ function in_venv() {
     # Check if the current directory is inside a Venv, does not activate.
     # Assumes the current directory is a MusicBot clone.
     if [ -f "../bin/activate" ] ; then
+        debug "yes"
         return 0
     fi
+    debug "no"
     return 1
+}
+
+function clone_branch_selection() {
+    # If auto install but --branch wasn't given, we default to current branch name.
+    if [ "$AUTO_INSTALL" == "1" ] && [ "$USING_BRANCH" == "" ] ; then
+        if in_existing_repo ; then
+            USING_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+        else
+            # TODO: change this when merging to review or master.
+            USING_BRANCH="dev"
+        fi
+    fi
+
+    if [ "$USING_BRANCH" == "" ] ; then
+        echo ""
+        echo "MusicBot currently has three branches available."
+        echo "  master - An older MusicBot, for older discord.py. May not work without tweaks!"
+        echo "  review - Newer MusicBot, usually stable with less updates than the dev branch."
+        echo "  dev    - The newest MusicBot, latest features and changes which may need testing."
+        if [ "$UNLISTED_BRANCHES" == "1" ] ; then
+        echo "  *      - WARNING: Any branch name is allowed, if it exists on github."
+        fi
+        echo ""
+        read -rp "Enter the branch name you want to install:  " BRANCH
+    else
+        BRANCH="$USING_BRANCH"
+    fi
+    case ${BRANCH,,} in
+    "dev")
+        echo "Installing from 'dev' branch..."
+        git clone "${MusicBotGitURL}" "${CloneDir}" -b dev
+        ;;
+    "review")
+        echo "Installing from 'review' branch..."
+        git clone "${MusicBotGitURL}" "${CloneDir}" -b review
+        ;;
+    "master")
+        echo "Installing from 'master' branch..."
+        git clone "${MusicBotGitURL}" "${CloneDir}" -b master
+        ;;
+    *)
+        if [ "$UNLISTED_BRANCHES" == "1" ] ; then
+            echo "Installing from '${BRANCH}' branch..."
+            git clone "${MusicBotGitURL}" "${CloneDir}" -b "$BRANCH"
+        else
+            exit_err "Unknown branch name given, install cannot continue."
+        fi
+        ;;
+    esac
 }
 
 function pull_musicbot_git() {
     echo ""
+    debug "Starting in: '$InstallDir'"
     # Check if we're running inside a previously pulled repo.
     # ignore this if InstallDir is set.
     if in_existing_repo && [ "$InstallDir" == "" ]; then
         echo "Existing MusicBot repo detected."
-        read -rp "Would you like to install using the current repo? [Y/n]" UsePwd
+        UsePwd="y"
+        ask_input "Would you like to install using the current repo? [Y/n]" UsePwd "y"
         if [ "${UsePwd,,}" == "y" ] || [ "${UsePwd,,}" == "yes" ] ; then
             echo ""
             CloneDir="${PWD}"
@@ -317,44 +384,16 @@ function pull_musicbot_git() {
             exit_err "Delete the ${CloneDir} directory and try again, or complete the install manually."
         fi
     else
-        cd "$InstallDir" || exit_err "Fatal:  Could not change into install directory:  ${InstallDir}"
+        if [ "$InstallDir" != "" ] ; then
+            cd "$InstallDir" || exit_err "Fatal:  Could not change into install directory:  ${InstallDir}"  
+        fi
         if [ "$InstalledViaVenv" != "1" ] ; then
             CloneDir="${InstallDir}"
         fi
     fi
 
-    echo ""
-    echo "MusicBot currently has three branches available."
-    echo "  master - An older MusicBot, for older discord.py. May not work without tweaks!"
-    echo "  review - Newer MusicBot, usually stable with less updates than the dev branch."
-    echo "  dev    - The newest MusicBot, latest features and changes which may need testing."
-    if [ "$EnableUnlistedBranches" == "1" ] ; then
-    echo "  *      - WARNING: Any branch name is allowed, if it exists on github."
-    fi
-    echo ""
-    read -rp "Enter the branch name you want to install:  " BRANCH
-    case ${BRANCH,,} in
-    "dev")
-        echo "Installing from 'dev' branch..."
-        git clone "${MusicBotGitURL}" "${CloneDir}" -b dev
-        ;;
-    "review")
-        echo "Installing from 'review' branch..."
-        git clone "${MusicBotGitURL}" "${CloneDir}" -b review
-        ;;
-    "master")
-        echo "Installing from 'master' branch..."
-        git clone "${MusicBotGitURL}" "${CloneDir}" -b master
-        ;;
-    *)
-        if [ "$EnableUnlistedBranches" == "1" ] ; then
-            echo "Installing from '${BRANCH}' branch..."
-            git clone "${MusicBotGitURL}" "${CloneDir}" -b "$BRANCH"
-        else
-            exit_err "Unknown branch name given, install cannot continue."
-        fi
-        ;;
-    esac
+    clone_branch_selection
+
     cd "${CloneDir}" || exit_err "Fatal:  Could not change to MusicBot directory."
 
     # find python before using it
@@ -468,7 +507,8 @@ function ask_change_user_group() {
     User_Group="${Inst_User} / ${Inst_Group}"
     echo ""
     echo "The installer is currently running as:  ${User_Group}"
-    read -rp "Set a different User / Group to run the service? [N/y]: " MakeChange
+    MakeChange="n"
+    ask_input "Set a different User / Group to run the service? [N/y]: " MakeChange "n"
     case $MakeChange in
     [Yy]*)
         ask_for_user
@@ -480,7 +520,8 @@ function ask_change_user_group() {
 function ask_change_service_name() {
     echo ""
     echo "The service will be installed as:  $ServiceName"
-    read -rp "Would you like to change the name? [N/y]: " ChangeSrvName
+    ChangeSrvName="n"
+    ask_input "Would you like to change the name? [N/y]: " ChangeSrvName "n"
     case $ChangeSrvName in
     [Yy]*)
         while :; do
@@ -489,7 +530,8 @@ function ask_change_service_name() {
             echo ""
             echo "Service names may use only letters, numbers, and the listed special characters."
             echo "Spaces are not allowed. Special characters:  -_.:"
-            read -rp "Provide a name for the service:  " ServiceName
+            ServiceName="musicbot"
+            ask_input "Provide a name for the service:  " ServiceName "musicbot"
             # validate service name is allowed.
             if [[ "$ServiceName" =~ ^[a-zA-Z0-9:-_\.]+$ ]] ; then
                 # attempt to avoid conflicting service names...
@@ -582,7 +624,8 @@ function setup_as_service() {
     echo ""
     echo "The installer can also install MusicBot as a system service."
     echo "This starts the MusicBot at boot and restarts after failures."
-    read -rp "Install the musicbot system service? [N/y] " SERVICE
+    SERVICE="n"
+    ask_input "Install the musicbot system service? [N/y] " SERVICE "n"
     case $SERVICE in
     [Yy]*)
         ask_change_service_name
@@ -618,7 +661,8 @@ function setup_as_service() {
 
             echo ""
             echo "MusicBot will start automatically after the next reboot."
-            read -rp "Would you like to start MusicBot now? [N/y]" StartService
+            StartService="n"
+            ask_input "Would you like to start MusicBot now? [N/y]" StartService "n"
             case $StartService in
             [Yy]*)
                 echo "Running:  sudo systemctl start $ServiceName"
@@ -637,8 +681,10 @@ function setup_as_service() {
 
 function debug() {
     local msg=$1
-    if [[ $DEBUG == '1' ]]; then
-        echo -e "\e[1;36m[DEBUG]\e[0m $msg" 1>&2
+    if [ "$DEBUG" == "1" ]; then
+        FN="${FUNCNAME[1]:-install.sh}"
+        LN="${BASH_LINENO[0]:-?}"
+        echo -e "\e[1;36m[DEBUG]\e[0m[${FN} line:${LN}] $msg" 1>&2
     fi
 }
 
@@ -656,7 +702,8 @@ function configure_bot() {
     find_python
 
     echo "You can now configure MusicBot!"
-    read -rp "Would you like to launch the 'configure.py' tool? [N/y]" YesConfig
+    YesConfig="n"
+    ask_input "Would you like to launch the 'configure.py' tool? [N/y]" YesConfig "n"
     if [[ "${YesConfig,,}" != "y" && "${YesConfig,,}" != "yes" ]] ; then
         echo ""
         echo "Open the 'config' directory, then copy and rename the example files to get started."
@@ -671,11 +718,36 @@ function configure_bot() {
     fi
 }
 
+function install_deno() {
+    # look for deno before installing it.
+    if command -v deno >/dev/null; then
+        echo "deno is already installed and in PATH."
+        return
+    else
+        DenoPath="$HOME/.deno/bin/"
+        if [ -d "$DenoPath" ] && [ -x "${DenoPath}deno" ] ; then
+            echo "deno is already installed but may not be in path."
+            return
+        fi
+    fi
+    
+    echo "Downloading deno installer..."
+    curl -sL -o "install_deno.sh" "https://deno.land/install.sh"
+    chmod +x "install_deno.sh"
+    echo ""
+    echo "Running deno installer..."
+    ./install_deno.sh -y
+}
+
 #------------------------------------------CLI Arguments----------------------------------------------#
 INSTALL_SYS_PKGS="1"
 INSTALL_BOT_BITS="1"
 SERVICE_ONLY="0"
 SKIP_ALL_SUDO="0"
+USING_BRANCH=""
+AUTO_INSTALL="0"
+UNLISTED_BRANCHES="0"
+DEBUG="0"
 
 while [[ $# -gt 0 ]]; do
   case ${1,,} in
@@ -709,13 +781,13 @@ while [[ $# -gt 0 ]]; do
         shift
     ;;
 
-    --any-branch )
-        EnableUnlistedBranches=1
+    --any-branch | --anybranch )
+        UNLISTED_BRANCHES="1"
         shift
     ;;
 
     --debug )
-        DEBUG=1
+        DEBUG="1"
         shift
         echo "DEBUG MODE IS ENABLED!"
     ;;
@@ -724,6 +796,7 @@ while [[ $# -gt 0 ]]; do
         InstallDir="$2"
         shift
         shift
+        # Ensure path has trailing slash.
         if [ "${InstallDir:0-1}" != "/" ] ; then
             InstallDir="${InstallDir}/"
         fi
@@ -731,6 +804,21 @@ while [[ $# -gt 0 ]]; do
             exit_err "The install directory given does not exist:   '$InstallDir'"
         fi
         VenvDir="${InstallDir}${VenvDir}"
+    ;;
+    
+    "--branch" )
+        UNLISTED_BRANCHES="1"
+        USING_BRANCH="$2"
+        shift
+        shift
+        if [ "$USING_BRANCH" == "" ] ; then
+            exit_err "The option --branch requires a branch name."
+        fi
+    ;;
+    
+    "--auto" )
+        AUTO_INSTALL="1"
+        shift
     ;;
 
     * )
@@ -777,7 +865,8 @@ EOF
 
 echo "We detected your OS is:  $(distro_supported)"
 
-read -rp "Would you like to continue with the installer? [Y/n]:  " iagree
+iagree="y"
+ask_input "Would you like to continue with the installer? [Y/n]:  " iagree "y"
 if [[ "${iagree,,}" != "y" && "${iagree,,}" != "yes" ]] ; then
     exit 2
 fi
@@ -792,7 +881,8 @@ if [ "$(id -u)" -eq "0" ] && [ "$INSTALL_BOT_BITS" == "1" ] ;  then
     echo "        Meaning, little or no support and you have to fix stuff manually."
     echo "        Running MuiscBot as root is not recommended. You have been warned."
     echo ""
-    read -rp "Type 'I understand' (without quotes) to continue installing:" iunderstand
+    iunderstand="i understand"
+    ask_input "Type 'I understand' (without quotes) to continue installing:" iunderstand "i understand"
     if [[ "${iunderstand,,}" != "i understand" ]] ; then
         echo ""
         exit_err "Try again with --sys-only or change to a non-root user and use --no-sys and/or --no-sudo"
@@ -841,11 +931,12 @@ case $DISTRO_NAME in
     if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
         # NOTE: Arch now uses system managed python packages, so venv is required.
         $SUDO_BIN pacman -Syu
-        $SUDO_BIN pacman -S curl ffmpeg git jq python python-pip
+        $SUDO_BIN pacman -S curl ffmpeg git jq python python-pip unzip
     fi
 
     if [ "$INSTALL_BOT_BITS" == "1" ] ; then
         install_as_venv
+        install_deno
     fi
     ;;
 
@@ -864,6 +955,7 @@ case $DISTRO_NAME in
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             pull_musicbot_git
+            install_deno
         fi
         ;;
 
@@ -878,6 +970,7 @@ case $DISTRO_NAME in
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             install_as_venv
+            install_deno
         fi
         ;;
 
@@ -907,6 +1000,7 @@ case $DISTRO_NAME in
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             pull_musicbot_git
+            install_deno
         fi
         ;;
 
@@ -924,6 +1018,7 @@ case $DISTRO_NAME in
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             pull_musicbot_git
+            install_deno
         fi
         ;;
 
@@ -940,6 +1035,7 @@ case $DISTRO_NAME in
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             install_as_venv
+            install_deno
         fi
         ;;
 
@@ -955,7 +1051,10 @@ case $DISTRO_NAME in
 # NOTE: Raspberry Pi OS 11, i386 arch, returns Debian as distro name.
 *"Debian"* )
     case $DISTRO_NAME in
-    *"Debian GNU/Linux 10"*)
+    # Tested Working:
+    # R-Pi OS 11  @  2024/03/29
+    # Debian 11.3  @  2024/03/29
+    *"Debian GNU/Linux 10"*|*"Debian GNU/Linux 11"*)
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             $SUDO_BIN apt-get update -y
             $SUDO_BIN apt-get upgrade -y
@@ -971,21 +1070,7 @@ case $DISTRO_NAME in
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             pull_musicbot_git
-        fi
-        ;;
-    
-    # Tested working:
-    # R-Pi OS 11  @  2024/03/29
-    # Debian 11.3  @  2024/03/29
-    *"Debian GNU/Linux 11"*)
-        if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
-            $SUDO_BIN apt-get update -y
-            $SUDO_BIN apt-get upgrade -y
-            $SUDO_BIN apt-get install -y jq git curl ffmpeg python3 python3-pip
-        fi
-
-        if [ "$INSTALL_BOT_BITS" == "1" ] ; then
-            pull_musicbot_git
+            install_deno
         fi
         ;;
 
@@ -998,11 +1083,12 @@ case $DISTRO_NAME in
             $SUDO_BIN apt-get update -y
             $SUDO_BIN apt-get upgrade -y
             $SUDO_BIN apt-get install -y build-essential libopus-dev libffi-dev libsodium-dev \
-                python3-full python3-dev python3-venv python3-pip git ffmpeg curl
+                python3-full python3-dev python3-venv python3-pip git ffmpeg curl unzip
         fi
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             install_as_venv
+            install_deno
         fi
         ;;
 
@@ -1035,6 +1121,7 @@ case $DISTRO_NAME in
     fi
     if [ "$INSTALL_BOT_BITS" == "1" ] ; then
         pull_musicbot_git
+        install_deno
     fi
     ;;
 
@@ -1049,74 +1136,54 @@ case $DISTRO_NAME in
 
     case $DISTRO_NAME in
     # Handle the versions which are EOL.
-    *"CentOS "[2-6]* |*"CentOS 8."[0-5]* )
+    *"CentOS "[2-7]* |*"CentOS 8."[0-5]* |*"CentOS Stream "[0-8]* )
         echo "Unfortunately, this version of CentOS has reached End-of-Life, and will not be supported."
         echo "You should consider upgrading to the latest version to make installing MusicBot easier."
         exit 1
         ;;
 
-    # Supported versions.
-    *"CentOS 7"*)  # Tested 7.9 @ 2024/03/28
-        # TODO:  CentOS 7 reaches EOL June 2024.
-        if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
-            # Enable extra repos, as required for ffmpeg
-            # We DO NOT use the -y flag here.
-            $SUDO_BIN yum install epel-release
-            $SUDO_BIN yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
-
-            # Install available packages and libraries for building python 3.8+
-            $SUDO_BIN yum -y groupinstall "Development Tools"
-            $SUDO_BIN yum -y install opus-devel libffi-devel openssl-devel bzip2-devel \
-                git curl jq ffmpeg
-
-            # Ask if we should build python
-            echo "We need to build python from source for your system. It will be installed using altinstall target."
-            read -rp "Would you like to continue ? [N/y]" BuildPython
-            if [ "${BuildPython,,}" == "y" ] || [ "${BuildPython,,}" == "yes" ] ; then
-                # Build python.
-                PyBuildVer="3.10.14"
-                PySrcDir="Python-${PyBuildVer}"
-                PySrcFile="${PySrcDir}.tgz"
-
-                curl -o "$PySrcFile" "https://www.python.org/ftp/python/${PyBuildVer}/${PySrcFile}"
-                tar -xzf "$PySrcFile"
-                cd "${PySrcDir}" || exit_err "Fatal:  Could not change to python source directory."
-
-                ./configure --enable-optimizations
-                $SUDO_BIN make altinstall
-
-                # Ensure python bin is updated with altinstall name.
-                find_python
-                RetVal=$?
-                if [ "$RetVal" == "0" ] ; then
-                    # manually install pip package for the current user.
-                    $PyBin <(curl -s https://bootstrap.pypa.io/get-pip.py)
-                else
-                    echo "Error:  Could not find python on the PATH after installing it."
-                    exit 1
-                fi
-            fi
-        fi
-
-        if [ "$INSTALL_BOT_BITS" == "1" ] ; then
-            pull_musicbot_git
-        fi
-        ;;
-
-    *"CentOS Stream 8"*)  # Tested 2024/03/28
+    *"CentOS Stream 9"*)
+    # Added On:  2026/02/02
+    # Last Change;  never
+    # Last Test:  never
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             # Install extra repos, needed for ffmpeg.
             # Do not use -y flag here.
-            $SUDO_BIN dnf install epel-release
-            $SUDO_BIN dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
-            $SUDO_BIN dnf config-manager --enable powertools
+            $SUDO_BIN dnf config-manager --set-enabled crb
+            $SUDO_BIN dnf install --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel{,-next}-release-latest-9.noarch.rpm
+            $SUDO_BIN dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm
 
-            # Install available packages.
-            $SUDO_BIN yum -y install opus-devel libffi-devel git curl jq ffmpeg python39 python39-devel
+            # Install dependency packages.
+            $SUDO_BIN yum -y install opus-devel libffi-devel git curl jq ffmpeg unzip \
+                yum-utils make gcc openssl-devel bzip2-devel libffi-devel zlib-devel 
+
+            build_python
         fi
 
         if [ "$INSTALL_BOT_BITS" == "1" ] ; then
             pull_musicbot_git
+            install_deno
+        fi
+        ;;
+
+    *"CentOS Stream 10"*)
+    # Added On:  2026/02/02
+    # Last Change;  never
+    # Last Test:  2026/02/02
+        if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
+            # Install extra repos, needed for ffmpeg.
+            # Do not use -y flag here.
+            $SUDO_BIN dnf config-manager --set-enabled crb
+            $SUDO_BIN dnf install --nogpgcheck https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+            $SUDO_BIN dnf install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-10.noarch.rpm
+
+            # Install available packages.
+            $SUDO_BIN yum -y install opus-devel libffi-devel git curl jq ffmpeg python3 python3-pip python3-devel unzip
+        fi
+
+        if [ "$INSTALL_BOT_BITS" == "1" ] ; then
+            pull_musicbot_git
+            install_deno
         fi
         ;;
 
@@ -1142,6 +1209,7 @@ case $DISTRO_NAME in
         brew install libsodium
         brew install curl
         brew install jq
+        brew install deno
     fi
 
     if [ "$INSTALL_BOT_BITS" == "1" ] ; then

--- a/install.sh
+++ b/install.sh
@@ -927,7 +927,7 @@ fi
 echo ""
 
 case $DISTRO_NAME in
-*"Arch Linux"*)  # Tested working 2024.03.01  @  2024/03/31
+*"Arch Linux"*)  # Last Tested: 2026/02/04
     if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
         # NOTE: Arch now uses system managed python packages, so venv is required.
         $SUDO_BIN pacman -Syu
@@ -943,7 +943,7 @@ case $DISTRO_NAME in
 *"Pop!_OS"* )
     case $DISTRO_NAME in
 
-    # Tested working 22.04  @  2024/03/29
+    # Tested working 22.04  @  2026/02/04
     *"Pop!_OS 22.04"*)
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             $SUDO_BIN apt-get update -y
@@ -959,6 +959,7 @@ case $DISTRO_NAME in
         fi
         ;;
 
+    # Tested working 24.04  @ 2026/02/04
     *"Pop!_OS 24.04"*)
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             $SUDO_BIN apt-get update -y
@@ -1006,7 +1007,7 @@ case $DISTRO_NAME in
 
     # Tested working:
     # 20.04  @  2024/03/28
-    # 22.04  @  2024/03/30
+    # 22.04  @  2026/02/04
     *"Ubuntu 20"*|*"Ubuntu 22"*)
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             $SUDO_BIN apt-get update -y
@@ -1023,7 +1024,7 @@ case $DISTRO_NAME in
         ;;
 
     # Tested working:
-    # 24.04  @  2024/09/04
+    # 24.04  @  2026/02/04
     *"Ubuntu 24"*)
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             $SUDO_BIN apt-get update -y
@@ -1074,11 +1075,10 @@ case $DISTRO_NAME in
         fi
         ;;
 
-    # Tested working 12.5  @  2024/03/31
-    # Tested working 12.7  @  2024/09/05
-    # Tested working trixie  @  2024/09/05
-    *"Debian GNU/Linux 12"*|*"Debian GNU/Linux trixie"*|*"Debian GNU/Linux sid"*)
-        # Debian 12 uses system controlled python packages.
+    # Tested working 12.13  @  2026/02/04
+    # Tested working 13.3  @  2026/02/04
+    *"Debian GNU/Linux 12"*|*"Debian GNU/Linux 13"*|*"Debian GNU/Linux sid"*)
+        # Debian 12+ uses system controlled python packages.
         if [ "$INSTALL_SYS_PKGS" == "1" ] ; then
             $SUDO_BIN apt-get update -y
             $SUDO_BIN apt-get upgrade -y

--- a/musicbot/config.py
+++ b/musicbot/config.py
@@ -2091,12 +2091,14 @@ class ConfigOptionRegistry:
 
         return str(conf_value)
 
-    def export_markdown(self) -> str:
+    def export_markdown(self, only_section: str = "") -> str:
         """
         Transform registered config / permissions options into "markdown".
         This is intended to generate documentation from the code for publishing to pages.
         Currently will print options in order they are registered.
         But prints sections in the order ConfigParser loads them.
+
+        :param: only_section:   Only prints the given section, if it exists.
         """
         basedir = get_write_base()
         if not basedir:
@@ -2135,6 +2137,8 @@ class ConfigOptionRegistry:
         markdown = ""
         for sect in self._parser.sections():
             if sect not in md_sections:
+                continue
+            if only_section and only_section != sect:
                 continue
             opts = md_sections[sect]
             markdown += f"#### [{sect}]\n\n{''.join(opts)}\n\n"

--- a/musicbot/constants.py
+++ b/musicbot/constants.py
@@ -5,7 +5,7 @@ from typing import List
 # This fails if not cloned, or if git is not available for some reason.
 # VERSION should never be empty though.
 # Note this code is duplicated in update.py for stand-alone use.
-VERSION: str = ""
+VERSION: str = ""  # pylint: disable=invalid-name
 try:
     # Get the last release tag, number of commits since, and g{commit_id} as string.
     _VERSION_DESC = (
@@ -20,7 +20,7 @@ try:
         .strip()
     )
     # Check if any tracked files are modified for -modded version flag.
-    _VERSION_MOD = (
+    _VERSION_MOD = (  # pylint: disable=invalid-name
         subprocess.check_output(
             ["git", "-c", "core.fileMode=false", "status", "-suno", "--porcelain"]
         )
@@ -28,15 +28,15 @@ try:
         .strip()
     )
     if _VERSION_MOD:
-        _VERSION_MOD = "-modded"
+        _VERSION_MOD = "-modded"  # pylint: disable=invalid-name
     else:
-        _VERSION_MOD = ""
+        _VERSION_MOD = ""  # pylint: disable=invalid-name
 
-    VERSION = f"{_VERSION_DESC}-{_VERSION_BRANCH}{_VERSION_MOD}"
+    VERSION = f"{_VERSION_DESC}-{_VERSION_BRANCH}{_VERSION_MOD}"  # pylint: disable=invalid-name
 
 except (subprocess.SubprocessError, OSError, ValueError) as e:
     print(f"Failed setting version constant, reason:  {str(e)}")
-    VERSION = "version_unknown"
+    VERSION = "version_unknown"  # pylint: disable=invalid-name
 
 # constant string exempt from i18n
 DEFAULT_FOOTER_TEXT: str = f"Just-Some-Bots/MusicBot ({VERSION})"

--- a/musicbot/downloader.py
+++ b/musicbot/downloader.py
@@ -101,7 +101,6 @@ def _ytdlp_bug_msg(*_args: Any, **_kwargs: Any) -> str:
 
 youtube_dl.utils.bug_reports_message = _ytdlp_bug_msg
 
-
 """
     Alright, here's the problem.  To catch youtube-dl errors for their useful information, I have to
     catch the exceptions with `ignoreerrors` off.  To not break when ytdl hits a dumb video
@@ -144,6 +143,20 @@ class Downloader:
         # Copy immutable dict and use the mutable copy for everything else.
         ytdl_format_options = ytdl_format_options_immutable.copy()
         ytdl_format_options["http_headers"] = self.http_req_headers
+
+        # Since yt-dlp version 2025.11.12, EJS and a js runtime are needed.
+        # This should enable nodejs as a fallback to deno, if available.
+        # Value is a dict of: {'runtime': {'path': '/opt/path/config'}, ...}
+        ytdl_format_options["js_runtimes"] = {
+            "deno": {},
+            "node": {},
+        }
+
+        # add concurrent-fragments option if it is needed.
+        if bot.config.ytdlp_concurrent_frags > 1:
+            ytdl_format_options["concurrent_fragment_downloads"] = (
+                bot.config.ytdlp_concurrent_frags
+            )
 
         # apply source address settings.
         if bot.config.ytdlp_source_address != "*":

--- a/musicbot/entry.py
+++ b/musicbot/entry.py
@@ -41,10 +41,10 @@ log = logging.getLogger(__name__)
 
 # optionally using pymediainfo instead of ffprobe if presents
 try:
-    import pymediainfo  # type: ignore[import-untyped]
+    import pymediainfo  # type: ignore[import-untyped,unused-ignore]
 except ImportError:
     log.debug("module 'pymediainfo' not found, will fall back to ffprobe.")
-    pymediainfo = None
+    pymediainfo = None  # type: ignore[unused-ignore,no-redef,assignment]
 
 
 class BasePlaylistEntry(Serializable):

--- a/musicbot/testrig.py
+++ b/musicbot/testrig.py
@@ -213,8 +213,23 @@ TESTRIG_TEST_CASES: List[CmdTest] = [
     # Play adjustable media before testing speed
     CmdTest("playnow", ["https://www.youtube.com/watch?v=bm48ncbhU10"]),
     CmdTest("speed", ["", "1", "1.", "1.1", "six", "-0.3", "40"]),
+    # Play playlist for testing multi-entry command forms.
+    CmdTest("clear", [""]),
+    CmdTest("skip", [""]),
+    CmdTest(
+        "play", ["https://youtu.be/E3xbLcTj_bs?list=PLTxsp5i8fQO51pAymuKRfkmL4GnPRa6iC"]
+    ),
     CmdTest("move", ["", "2 4", "-1 -2", "x y"]),
-    CmdTest("remove", ["", "5", "a"]),
+    CmdTest(  # remove
+        "remove",
+        [
+            "",
+            "5",
+            "a",
+            "@TestUser",
+            "2 6",
+        ],
+    ),
     CmdTest("skip", [""]),
     CmdTest("pause", [""]),
     CmdTest("resume", [""]),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pynacl
 discord.py [voice] == 2.6.4
 #discord.py [voice] @ git+https://github.com/Rapptz/discord.py
 pip
-yt-dlp
+yt-dlp[default]
 colorlog
 colorama >= 0.4.6; sys_platform == 'win32'
 cffi --only-binary all; sys_platform == 'win32'

--- a/run.py
+++ b/run.py
@@ -353,7 +353,7 @@ def sanity_checks(args: argparse.Namespace) -> None:
     """
     log.info("Starting sanity checks")
     """Required Checks"""
-    # Make sure we're on Python 3.9+
+    # Make sure we're on Python 3.10+
     req_ensure_py3()
 
     # Make sure we're in a writable env
@@ -385,13 +385,13 @@ def req_ensure_py3() -> None:
     Verify the current running version of Python and attempt to find a
     suitable minimum version in the system if the running version is too old.
     """
-    log.info("Checking for Python 3.9+")
+    log.info("Checking for Python 3.10+")
 
-    if sys.version_info < (3, 9):
+    if sys.version_info < (3, 10):
         log.warning(
-            "Python 3.9+ is required. This version is %s", sys.version.split()[0]
+            "Python 3.10+ is required. This version is %s", sys.version.split()[0]
         )
-        log.warning("Attempting to locate Python 3.9...")
+        log.warning("Attempting to locate Python 3.10...")
         # Should we look for other versions than min-ver?
 
         pycom = None
@@ -402,15 +402,15 @@ def req_ensure_py3() -> None:
                 log.warning("Could not locate py.exe")
 
             try:
-                subprocess.check_output([pycom, "-3.9", '-c "exit()"'])
-                pycom = f"{pycom} -3.9"
+                subprocess.check_output([pycom, "-3.10", '-c "exit()"'])
+                pycom = f"{pycom} -3.10"
             except (
                 OSError,
                 PermissionError,
                 FileNotFoundError,
                 subprocess.CalledProcessError,
             ):
-                log.warning("Could not execute `py.exe -3.9` ")
+                log.warning("Could not execute `py.exe -3.10` ")
                 pycom = None
 
             if pycom:
@@ -419,29 +419,29 @@ def req_ensure_py3() -> None:
                 sys.exit(0)
 
         else:
-            log.info('Trying "python3.9"')
-            pycom = shutil.which("python3.9")
+            log.info('Trying "python3.10"')
+            pycom = shutil.which("python3.10")
             if not pycom:
-                log.warning("Could not locate python3.9 on path.")
-
-            try:
-                subprocess.check_output([pycom, '-c "exit()"'])
-            except (
-                OSError,
-                PermissionError,
-                FileNotFoundError,
-                subprocess.CalledProcessError,
-            ):
-                pycom = None
+                log.warning("Could not locate python3.10 on path.")
+            else:
+                try:
+                    subprocess.check_output([pycom, '-c "exit()"'])
+                except (
+                    OSError,
+                    PermissionError,
+                    FileNotFoundError,
+                    subprocess.CalledProcessError,
+                ):
+                    pycom = None
 
             if pycom:
                 log.info(
-                    "\nPython 3.9 found.  Re-launching bot using: %s run.py\n", pycom
+                    "\nPython 3.10 found.  Re-launching bot using: %s run.py\n", pycom
                 )
                 os.execlp(pycom, pycom, "run.py")
 
         log.critical(
-            "Could not find Python 3.9 or higher.  Please run the bot using Python version 3.9 to 3.13"
+            "Could not find Python 3.10 or higher.  Please run the bot using Python version 3.10 to 3.13"
         )
         bugger_off()
 
@@ -570,6 +570,42 @@ def req_ensure_env() -> None:
                 "Check for ffmpeg with your system package manager or build from sources."
             )
         bugger_off()
+
+    # Ensure we have the stuff needed to run js in yt-dlp.
+    # First we check for the yt-dlp-ejs package.
+    if not importlib.util.find_spec("yt_dlp_ejs"):
+        # Note: consider this check/warning as transitional code, could be removed later.
+        log.warning(
+            "YouTube support may not work!\n"
+            "MusicBot could not find the yt-dlp EJS package.\n"
+            "Update your pip packages, and make sure 'yt-dlp[default]' is in your requirements.txt"
+        )
+
+    # Next we look for node or deno, as one is needed for EJS to work.
+    # deno is supported and enabled by default, so we'll do checks for it first.
+    deno_bin = shutil.which("deno")
+    # Since deno may be installed in user-space, it may not be in common env paths.
+    # An issue for SystemD (maybe others) which don't load user config files.
+    # Fall back to looking in user space path if it isn't found right away.
+    if not deno_bin:
+        deno_common_path = pathlib.Path.home().joinpath(".deno").joinpath("bin")
+        log.debug("Adding environment PATH fallback for deno as: %s ", deno_common_path)
+        path_char = ":"  # used to separate paths in the environment PATH var.
+        if sys.platform.startswith("win"):
+            path_char = ";"
+        os.environ["PATH"] += path_char + os.path.abspath(deno_common_path)
+        # now try again to get deno bin.
+        deno_bin = shutil.which("deno")
+
+    node_bin = shutil.which("node")
+    if not deno_bin and not node_bin:
+        log.warning(
+            "YouTube support may not work!\n"
+            "MusicBot could not find deno or node executables in your environment.\n"
+            "Install deno from:  https://github.com/denoland/deno/\n"
+            " -OR-\n"
+            "Install node (version 25 or newer) via your package manager.\n"
+        )
 
 
 def opt_check_disk_space(warnlimit_mb: int = 200) -> None:
@@ -837,6 +873,13 @@ def parse_cli_args() -> argparse.Namespace:
         help="Update or create example config files and then exit. Useful if code is changed or examples are out-of-date for some reason.",
     )
 
+    ap.add_argument(
+        "--mk-docs",
+        dest="make_docs",
+        action="store_true",
+        help="Update documentation files used in the github pages. Useful if config or command help are changed / extended.",
+    )
+
     args = ap.parse_args()
 
     # Show version and exit.
@@ -973,6 +1016,69 @@ def set_console_title() -> None:
         pass
 
 
+async def mk_docs(m) -> None:  # type: ignore[no-untyped-def]
+    """
+    This function is used for automation of MusicBot documentation.
+    It creates github-flavored markdown documents which can update github pages.
+    """
+    file_config = "export_config.md"
+    file_perms = "export_perms.md"
+    file_cmd = "export_cmd.md"
+
+    # Show/Hide markup template.
+    show_hide_html = '<p><a class="expand-all-details">Show/Hide All</a></p>'
+
+    # Make config docs
+    config_md = m.config.register.export_markdown()
+    config_md += f"---\n\n{show_hide_html}\n\n"
+
+    with open(file_config, "w", encoding="utf8") as fh:
+        fh.write(config_md)
+        log.info("Saved config docs.")
+
+    # Make perms docs, using only default section.
+    perms_md = m.permissions.register.export_markdown(only_section="Default")
+    perms_md = perms_md.replace(
+        "#### [Default]",
+        f"### Available Permission Options  \n\n{show_hide_html}",
+    )
+    perms_md += f"---\n\n{show_hide_html}\n\n"
+
+    with open(file_perms, "w", encoding="utf8") as fh:
+        fh.write(perms_md)
+        log.info("Saved permissions docs.")
+
+    # Make commands docs.
+    cmd_md = f"### General Commands  \n\n{show_hide_html}\n\n"
+    admin_commands = []
+    dev_commands = []
+    for att in dir(m):
+        if att.startswith("cmd_"):
+            cmd = getattr(m, att, None)
+            doc = await m.gen_cmd_help(att.replace("cmd_", ""), None, for_md=True)
+            command_name = att.replace("cmd_", "").lower()
+            cmd_a = hasattr(cmd, "admin_only")
+            cmd_d = hasattr(cmd, "dev_cmd")
+            command_text = (
+                f"<details>\n  <summary>{command_name}</summary>\n{doc}\n</details>\n\n"
+            )
+            if cmd_d:
+                dev_commands.append(command_text)
+                continue
+            if cmd_a:
+                admin_commands.append(command_text)
+                continue
+            cmd_md += command_text
+    cmd_md += f"### Owner Commands  \n\n{''.join(admin_commands)}"
+    cmd_md += f"### Dev Commands  \n\n{''.join(dev_commands)}"
+    cmd_md += f"---\n\n{show_hide_html}\n\n"
+
+    with open(file_cmd, "w", encoding="utf8") as fh:
+        fh.write(cmd_md)
+        log.info("Saved command docs.")
+    log.info("Export complete.")
+
+
 def main() -> None:
     """
     All of the MusicBot starts here.
@@ -1056,6 +1162,11 @@ def main() -> None:
                 m.permissions.register.write_default_ini(write_path(EXAMPLE_PERMS_FILE))
                 raise TerminateSignal()
 
+            if cli_args.make_docs:
+                log.info("Updating documentation files...")
+                event_loop.run_until_complete(mk_docs(m))
+                raise TerminateSignal()
+
             # register system signal handlers with the event loop.
             if not getattr(event_loop, "_sig_handler_set", False):
                 setup_signal_handlers(event_loop, m.on_os_signal)
@@ -1113,6 +1224,7 @@ def main() -> None:
 
         except (AttributeError, ImportError, ModuleNotFoundError) as e:
             # In case a discord extension is installed but discord.py isn't.
+            log.warning("Processing Error Data:  %s", e)
             if isinstance(e, AttributeError):
                 if "module 'discord'" not in str(e):
                     raise
@@ -1194,10 +1306,6 @@ def main() -> None:
                 retries += 1
                 break
 
-            log.error(
-                "MusicBot got an ImportError after trying to install packages. MusicBot must exit..."
-            )
-            log.exception("The exception which caused the above error: ")
             retries = 0
             exit_signal = TerminateSignal(exit_code=1)
             break

--- a/run.sh
+++ b/run.sh
@@ -29,7 +29,7 @@ if [ -f "../bin/activate" ] ; then
 fi
 
 # Suported versions of python using only major.minor format
-PySupported=("3.13" "3.12" "3.11" "3.10" "3.9")
+PySupported=("3.13" "3.12" "3.11" "3.10")
 
 # compile a list of bin names to try for.
 PyBins=("python3")  # We hope that python3 maps to a good version.
@@ -63,8 +63,8 @@ for PyBin in "${PyBins[@]}" ; do
 
     # Major version must be 3+
     if [[ $PY_VER_MAJOR -ge 3 ]]; then
-        # if 3.9+ it should work.
-        if [[ $PY_VER_MINOR -ge 9 ]]; then
+        # if 3.10+ it should work.
+        if [[ $PY_VER_MINOR -ge 10 ]]; then
             VerGood=1
             Python_Bin="$PyBin"
             break
@@ -74,7 +74,7 @@ done
 
 # if we don't have a good version for python, bail.
 if [[ "$VerGood" == "0" ]]; then
-    echo "Python 3.9 or higher is required to run MusicBot."
+    echo "Python 3.10 or higher is required to run MusicBot."
     do_exit 1
 fi
 

--- a/update.py
+++ b/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import pathlib
 import shutil
@@ -10,14 +11,22 @@ import zipfile
 from typing import Any, List, Optional, Tuple
 from urllib.request import urlopen
 
+G_DO_DRY_RUN = False
 
-def yes_or_no_input(question: str) -> bool:
+
+def yes_or_no_input(question: str, answer: str = "") -> bool:
     """
     Prompt the user for a yes or no response to given `question`
     As many times as it takes to get yes or no.
+    If `answer` is given, the question is automatically answered.
+    The value of `answer` should be "yes" or "no" only.
     """
     while True:
-        ri = input(f"{question} (y/n): ")
+        if not answer:
+            ri = input(f"{question} (y/n): ")
+        else:
+            print(f"{question} (y/n):  [{answer}]")
+            ri = answer
 
         if ri.lower() in ["yes", "y"]:
             return True
@@ -33,6 +42,11 @@ def run_or_raise_error(cmd: List[str], message: str, **kws: Any) -> None:
     :kwparam: ok_codes:  A list of non-zero exit codes to consider OK.
     :raises: RuntimeError  with given `message` as exception text.
     """
+    # global G_DO_DRY_RUN
+    if G_DO_DRY_RUN:
+        print(f"[DRY RUN]:  {' '.join(cmd)}")
+        return
+
     ok_codes = kws.pop("ok_codes", [])
     try:
         subprocess.check_call(cmd, **kws)
@@ -111,13 +125,46 @@ def get_bot_remote_url(git_bin: str) -> str:
 
 
 def check_bot_updates(git_bin: str, branch_name: str) -> Optional[Tuple[str, str]]:
-    """Attempt a dry-run with git fetch to detect updates on remote."""
+    """
+    Attempt a dry-run with git fetch to detect updates on remote.
+    Falls back to status -b to check if the current branch is behind.
+    Returns a tuple of commit IDs if an update is detected, or None otherwise.
+    """
     try:
         updates = (
-            subprocess.check_output([git_bin, "fetch", "--dry-run"])
+            subprocess.check_output(
+                [git_bin, "fetch", "--dry-run"], stderr=subprocess.STDOUT
+            )
             .decode("utf8")
             .split("\n")
         )
+
+        # in case 'git fetch' has already been run, but pull still hasn't been done.
+        if (len(updates) == 1 and not updates[0]) or not updates:
+            updates = (
+                subprocess.check_output([git_bin, "status", "-b", "--porcelain"])
+                .decode("utf8")
+                .split("\n")
+            )
+            is_behind = False
+            for line in updates:
+                if branch_name in line and "behind" in line:
+                    is_behind = True
+                    break
+            if is_behind:
+                commit_at = (
+                    subprocess.check_output([git_bin, "rev-parse", "@"])
+                    .decode("utf8")
+                    .strip()
+                )
+                commit_to = (
+                    subprocess.check_output([git_bin, "rev-parse", "@{u}"])
+                    .decode("utf8")
+                    .strip()
+                )
+                return (commit_at, commit_to)
+            return None
+
         for line in updates:
             parts = line.split()
             if branch_name in parts:
@@ -166,11 +213,92 @@ def check_for_process(proc_path: str) -> None:
         )
 
 
-def update_deps() -> None:
+def update_deno(cli_args: argparse.Namespace) -> None:
+    """
+    Looks for and tries to run 'deno upgrade' at user discretion, if it is
+    installed in user-space rather than globally.
+    If deno is not found, this will notify the user to install it, and continue.
+    If deno fails to upgrade, the user is informed but the script continues.
+    """
+    # look for deno, make temp adjustments to PATH if needed.
+    deno_bin = shutil.which("deno")
+    deno_common_path = pathlib.Path.home().joinpath(".deno").joinpath("bin")
+    if not deno_bin:
+        path_char = ":"  # separates paths in PATH var.
+        if sys.platform.startswith("win"):
+            path_char = ";"
+        os.environ["PATH"] += path_char + os.path.abspath(deno_common_path)
+        deno_bin = shutil.which("deno")
+
+    # look for node as well.
+    node_bin = shutil.which("node")
+    # if no JS runtime is installed, try to install deno.
+    if not deno_bin and not node_bin:
+        print("\n")
+        print(
+            "Since yt-dlp version 2025.11.12, a JS runtime is needed for YouTube.\n"
+            "The recommended JS runtime is 'deno' which is not currently installed.\n"
+            "  https://github.com/denoland/deno/\n\n"
+            "MusicBot will still function without deno, but may not be able to"
+            " play media from YouTube without it."
+        )
+        install_deno = yes_or_no_input(
+            "Would you like to install deno JS runtime?", cli_args.q_deno
+        )
+        if install_deno:
+            if sys.platform.startswith("win"):  # windows
+                run_or_raise_error(
+                    ["winget", "install", "--id=DenoLand.Deno"],
+                    "Failed to install deno using winget.",
+                )
+            elif sys.platform.startswith("darwin"):  # mac OS
+                run_or_raise_error(
+                    ["homebrew", "install", "deno"],
+                    "Failed to install deno using homebrew.",
+                )
+            else:  # some *nix/other os
+                bin_unzip = shutil.which("unzip")
+                bin_7z = shutil.which("7z")
+                if not bin_unzip and not bin_7z:
+                    print(
+                        "Error:  Cannot install deno without unzip or 7zip.\n"
+                        "Install unzip or 7z program first."
+                    )
+                    return
+
+                deno_install = pathlib.Path.cwd().joinpath("install_deno.sh")
+                # curl -fsSL https://deno.land/install.sh | sh
+                with urlopen("https://deno.land/install.sh") as denodl:
+                    with open(deno_install, "w", encoding="utf8") as tmp:
+                        tmp.write(denodl.read().decode("utf8"))
+                run_or_raise_error(
+                    ["sh", f"{deno_install}", "-y"],
+                    "Failed to install deno.",
+                )
+        return
+
+    if not deno_bin:
+        print("deno not installed, skipped.")
+        return
+
+    print("It is recommended to use the latest version of deno.")
+    do_deno = yes_or_no_input("Would you like to run deno upgrade?", cli_args.q_deno)
+    if do_deno:
+        run_or_raise_error([str(deno_bin), "upgrade"], "NoOp")
+    else:
+        print("Skipped deno upgrade.")
+
+
+def update_deps(cli_args: argparse.Namespace) -> None:
     """
     Tries to upgrade MusicBot dependencies using pip module.
     This will use the same exe/bin as is running this code without version checks.
     """
+    do_pip = yes_or_no_input("Do you want to update dependencies?", cli_args.q_pip)
+    if not do_pip:
+        print("Skipping update of pip dependencies.")
+        return
+
     print("Attempting to update dependencies...")
 
     # outside a venv these args are used for pip update
@@ -291,7 +419,7 @@ def check_ffmpeg_running() -> None:
         check_for_process(ffmpeg_bin)
 
 
-def update_ffmpeg() -> None:
+def update_ffmpeg(cli_args: argparse.Namespace) -> None:
     """
     Handles checking for new versions of ffmpeg and requesting update.
     """
@@ -336,7 +464,9 @@ def update_ffmpeg() -> None:
             print("You will need to manually update FFmpeg instead.")
             return
 
-        do_upgrade = yes_or_no_input("Should we upgrade FFmpeg using winget? [Y/n]")
+        do_upgrade = yes_or_no_input(
+            "Should we upgrade FFmpeg using winget? [Y/n]", cli_args.q_ffmpeg
+        )
         if do_upgrade:
             run_or_raise_error(
                 [
@@ -356,7 +486,8 @@ def update_ffmpeg() -> None:
 
     elif ffmpeg_bin.lower() == bundle_ffmpeg_bin.lower():
         do_dl = yes_or_no_input(
-            "Should we update the MusicBot bundled ffmpeg executables? [Y/n]"
+            "Should we update the MusicBot bundled ffmpeg executables? [Y/n]",
+            cli_args.q_ffmpeg,
         )
         if do_dl:
             dl_windows_ffmpeg()
@@ -387,6 +518,203 @@ def finalize() -> None:
     print("Done!")
 
 
+def parse_cli_args() -> argparse.Namespace:
+    """
+    Parse command line arguments and do reasonable checks and assignments.
+
+    :returns:  Command line arguments parsed via argparse.
+    """
+
+    ap = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Update script for MusicBot. Supports interactive and non-interactive modes.\n"
+            "Use the listed command line flags in any combination to control non-interactive update process.\n"
+            "Available via Github:"
+            "\n  https://github.com/Just-Some-Bots/MusicBot"
+        ),
+        epilog=(
+            "For help with this script or MusicBot, join our discord:"
+            "\n  https://discord.gg/bots\n\n"
+            "This software is provided under the MIT License.\n"
+            "See the `LICENSE` text file for complete details."
+        ),
+    )
+
+    # display version and exit.
+    ap.add_argument(
+        "-V",
+        "--version",
+        action="store_true",
+        dest="show_version",
+        help="Print the MusicBot version information and exit.",
+    )
+
+    # dry run, does not run commands.
+    ap.add_argument(
+        "--dry-run",
+        dest="is_dry",
+        action="store_true",
+        help="Do a dry run, only prints commands instead of running them.",
+    )
+
+    # skip all, no
+    ap.add_argument(
+        "-n",
+        "--all-no",
+        dest="all_no",
+        action="store_true",
+        help="Answer 'no' to all questions, and skip all prompts.",
+    )
+
+    # skip all, yes
+    ap.add_argument(
+        "-y",
+        "--all-yes",
+        dest="all_yes",
+        action="store_true",
+        help="Answer 'yes' to all questions, and skip all prompts.",
+    )
+
+    # ffmpeg no
+    ap.add_argument(
+        "--no-ffmpeg",
+        dest="q_ffmpeg",
+        action="store_const",
+        const="no",
+        default="",
+        help="Answer 'no' to update ffmpeg prompt. (windows only)",
+    )
+    # ffmpeg yes
+    ap.add_argument(
+        "-f",
+        "--ffmpeg",
+        dest="q_ffmpeg",
+        action="store_const",
+        const="yes",
+        default="",
+        help="Answer 'yes' to update ffmpeg prompt. (windows only)",
+    )
+
+    # deno no
+    ap.add_argument(
+        "--no-deno",
+        dest="q_deno",
+        action="store_const",
+        const="no",
+        default="",
+        help="Answer 'no' to update deno prompt.",
+    )
+    # deno yes
+    ap.add_argument(
+        "-d",
+        "--deno",
+        dest="q_deno",
+        action="store_const",
+        const="yes",
+        default="",
+        help="Answer 'yes' to update deno prompt.",
+    )
+
+    # bot code no
+    ap.add_argument(
+        "--no-bot",
+        dest="q_bot",
+        action="store_const",
+        const="no",
+        default="",
+        help="Answer 'no' to update bot code prompt.",
+    )
+    # bot code yes
+    ap.add_argument(
+        "-b",
+        "--bot",
+        dest="q_bot",
+        action="store_const",
+        const="yes",
+        default="",
+        help="Answer 'yes' to update bot code prompt.",
+    )
+    # bot code, git reset no
+    ap.add_argument(
+        "--no-reset",
+        dest="q_reset",
+        action="store_const",
+        const="no",
+        default="",
+        help="Answer 'no' to git hard reset prompt, if applicable.",
+    )
+    # bot code, git reset yes
+    ap.add_argument(
+        "-r",
+        "--reset",
+        dest="q_reset",
+        action="store_const",
+        const="yes",
+        default="",
+        help="Answer 'yes' to git hard reset prompt, if applicable.",
+    )
+
+    # pip no
+    ap.add_argument(
+        "--no-pip",
+        dest="q_pip",
+        action="store_const",
+        const="no",
+        default="",
+        help="Answer 'no' to update pip packages prompt.",
+    )
+    # pip yes
+    ap.add_argument(
+        "-p",
+        "--pip",
+        dest="q_pip",
+        action="store_const",
+        const="yes",
+        default="",
+        help="Answer 'yes' to update pip packages prompt.",
+    )
+
+    args = ap.parse_args()
+
+    # Show version and exit.
+    if args.show_version:
+        git_bin = shutil.which("git")
+        if not git_bin:
+            raise EnvironmentError(
+                "Could not determine MusicBot version.\n"
+                "Check that `git` is installed and available in your environment path."
+            )
+        print("Just-Some-Bots/MusicBot")
+        get_bot_version(git_bin)
+        print(f"Current Branch:  {get_bot_branch(git_bin)}\n")
+        sys.exit(0)
+
+    if args.is_dry:
+        global G_DO_DRY_RUN  # pylint: disable=global-statement
+        G_DO_DRY_RUN = True
+
+    if args.all_no and args.all_yes:
+        print("Error:  cannot use --all-no and --all-yes at the same time.")
+        sys.exit(1)
+
+    if args.all_no:
+        args.q_ffmpeg = "no" if not args.q_ffmpeg else args.q_ffmpeg
+        args.q_reset = "no" if not args.q_reset else args.q_reset
+        args.q_bot = "no" if not args.q_bot else args.q_bot
+        args.q_pip = "no" if not args.q_pip else args.q_pip
+        args.q_deno = "no" if not args.q_deno else args.q_deno
+
+    if args.all_yes:
+        args.q_ffmpeg = "yes" if not args.q_ffmpeg else args.q_ffmpeg
+        args.q_reset = "yes" if not args.q_reset else args.q_reset
+        args.q_bot = "yes" if not args.q_bot else args.q_bot
+        args.q_pip = "yes" if not args.q_pip else args.q_pip
+        args.q_deno = "yes" if not args.q_deno else args.q_deno
+
+    return args
+
+
 def main() -> None:
     """
     Runs several checks, starting with making sure there is a .git folder
@@ -394,6 +722,7 @@ def main() -> None:
     Attempt to detect a git executable and use it to run git pull.
     Later, we try to use pip module to upgrade dependency modules.
     """
+    cli_args = parse_cli_args()
     print("Starting update checks...")
 
     if sys.platform.startswith("win"):
@@ -448,7 +777,8 @@ def main() -> None:
         )
         hard_reset = yes_or_no_input(
             "WARNING:  All changed files listed above will be reset!\n"
-            "Would you like to reset the Source code, to allow MusicBot to update?"
+            "Would you like to reset the Source code, to allow MusicBot to update?",
+            cli_args.q_reset,
         )
         if hard_reset:
             check_ffmpeg_running()
@@ -458,13 +788,11 @@ def main() -> None:
                 "You will need to manually reset the local git repository, or make a new clone of MusicBot.",
             )
         else:
-            do_deps = yes_or_no_input(
-                "OK, skipping bot update. Do you still want to update dependencies?"
-            )
-            if do_deps:
-                update_deps()
+            print("OK, skipping bot update via git pull.")
 
-            update_ffmpeg()
+            update_deps(cli_args)
+            update_deno(cli_args)
+            update_ffmpeg(cli_args)
             finalize()
             return
 
@@ -476,14 +804,14 @@ def main() -> None:
     if repo_url:
         print(f"Current git repo URL:  {repo_url}")
 
-    # Check for updates.
+    # Check for bot git updates.
     print("Checking remote repo for bot updates...")
     updates = check_bot_updates(git_bin, branch_name)
     if not updates:
         print("No updates found for bot source code.")
     else:
         print(f"Updates are available, latest commit ID is:  {updates[1]}")
-        do_bot_upgrade = yes_or_no_input("Would you like to update?")
+        do_bot_upgrade = yes_or_no_input("Would you like to update?", cli_args.q_bot)
         if do_bot_upgrade:
             check_ffmpeg_running()
             run_or_raise_error(
@@ -491,8 +819,9 @@ def main() -> None:
                 "Could not update the bot. You will need to run 'git pull' manually.",
             )
 
-    update_deps()
-    update_ffmpeg()
+    update_deps(cli_args)
+    update_deno(cli_args)
+    update_ffmpeg(cli_args)
     finalize()
 
 


### PR DESCRIPTION
- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.10 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description

This PR contains changes mostly related to the EJS support needed for a well known site that often breaks itself. :)  

After this gets merged, most users can get working by running the update.py script twice. The first run should update your bot code (you can just do `git pull` if you like.)  The second run of update.py will then contain updated code which should install deno for you.   

Since EJS requires python 3.10, our minimum version is now 3.10 as well.  
The installer scripts have been adjusted to install deno.  
The update script has been adjusted to install and update deno.  
Some linting was done, some strings updated, and a docs helper also added.  

These changes have been tested on a handful of different supported OS versions, but not all.  

Documentation has not yet been updated to reflect any of these changes to the requirements, there will be a PR for that at some point...