### PR TITLE
Update discord.py version to 2.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pynacl
-discord.py [voice] == 2.6.4
+discord.py [voice] == 2.7.1
 #discord.py [voice] @ git+https://github.com/Rapptz/discord.py
 pip
 yt-dlp[default]


### PR DESCRIPTION
Fixes a connect-disconnect crash loop when the bot tries to join a voice channel.

After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
I encountered a crash-loop using the dev branch. This is fixed by bumping the `discord.py` version.

Validated using both venv python and Docker.


### Related issues (if applicable)

