### PR TITLE
Fix: Force reload autoplaylist from disk on set command

### DIFF
--- a/musicbot/bot.py
+++ b/musicbot/bot.py
@@ -3470,7 +3470,7 @@ class MusicBot(discord.Client):
             pl = self.playlist_mgr.get_playlist(opt_url)
             self.server_data[guild.id].autoplaylist = pl
             await self.server_data[guild.id].save_guild_options_file()
-            await pl.load()
+            await pl.load(force=True)
 
             # Update the player copy if needed.
             if _player and self.config.auto_playlist:


### PR DESCRIPTION
This PR ensures that the autoplaylist is always reloaded from the disk when the set command is used. Currently, the bot skips reloading if the playlist is already marked as loaded, which prevents manual edits or external tool updates (like SFTP) from taking effect without a bot restart. Adding force=True to the load() call fixes this.

After creating your pull request, tick these boxes if they are applicable to you.

- [] I have tested my changes against the `dev` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description



### Related issues (if applicable)

