### PR TITLE
Bump Docker base image to Python 3.12 to unblock current yt-dlp releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apk update && apk add --no-cache \
   opus-dev \
   libffi \
   libsodium \
-  gcc \
   git
 
 # Install pip dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.12-alpine
 
 # Add project source
 WORKDIR /musicbot
@@ -14,6 +14,7 @@ RUN apk update && apk add --no-cache --virtual .build-deps \
 # Install dependencies
 RUN apk update && apk add --no-cache \
   ca-certificates \
+  deno \
   ffmpeg \
   opus-dev \
   libffi \

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pynacl
 #discord.py [voice, speed] >= 2.4.0
 discord.py [voice, speed] @ git+https://github.com/Rapptz/discord.py
 pip
-yt-dlp
+yt-dlp[default]
 colorlog
 colorama >= 0.4.6; sys_platform == 'win32'
 cffi --only-binary all; sys_platform == 'win32'


### PR DESCRIPTION
## Problem

The official Dockerfile is pinned to `python:3.8-alpine`. Since Python 3.8
support was dropped upstream in yt-dlp, pip can only resolve yt-dlp releases
up to `2024.10.22` inside the container -- the last version compatible with
3.8. That's now well over a year behind, missing the extractor fixes needed
to keep up with YouTube's changes (e.g. many videos fail with "Sign in to
confirm you're not a bot" or return only storyboard formats because the
bundled yt-dlp predates JS-challenge-solving support).

Anyone running the bot via the official Docker image is stuck on this old
yt-dlp with no way to upgrade it, since `pip install --upgrade` inside the
container correctly reports it's already on the newest version *available
for Python 3.8*.

## Fix

- Bump the base image to `python:3.12-alpine`, which lets pip resolve
  current yt-dlp releases.
- Add `deno` (apk package) and switch to `yt-dlp[default]` in
  requirements.txt, which bundles the `yt-dlp-ejs` challenge-solver scripts.
  Recent yt-dlp versions need a JS runtime + these scripts to solve
  YouTube's signature/n-param challenges; without them, only storyboard
  (thumbnail) formats are returned and playback fails with "Requested
  format is not available."

Tested by building the image, confirming `yt-dlp -F` returns real
audio/video formats (not just storyboards) for a video that previously only
returned storyboards, and confirming the bot plays audio normally end to
end.

## Scope

This PR only touches the Docker build (Dockerfile + requirements.txt). No
application code changed.
